### PR TITLE
Allow detection of JVM version 8 and 9

### DIFF
--- a/lisp/jde-jdk-manager.el
+++ b/lisp/jde-jdk-manager.el
@@ -61,15 +61,15 @@
    ((null dir) nil)
 
    ;; java-1.6.0-openjdk-amd64 or jdk1.7.0_21 etc.
-   ((string-match "\\(1\\.[4567]\\)\\.[0-9]" dir)
+   ((string-match "\\(1\\.[456789]\\)\\.[0-9]" dir)
     (match-string 1 dir))
 
    ;; j2sdk1.6-oracle etc
-   ((string-match "[^0-9]\\(1\\.[4567]\\)\\-" dir)
+   ((string-match "[^0-9]\\(1\\.[456789]\\)\\-" dir)
     (match-string 1 dir))
 
    ;; java-7-openjdk-amd64 etc
-   ((string-match "-\\([45678]\\)-" dir)
+   ((string-match "-\\([456789]\\)-" dir)
     (concat "1." (match-string 1 dir)))))
 
 (defun jde--jdk-find-darwin-jdk ()

--- a/test/lisp/jde-jdk-manager-test.el
+++ b/test/lisp/jde-jdk-manager-test.el
@@ -122,7 +122,17 @@
   (should (string= "1.6" (jde--jdk-get-version "/usr/lib64/jvm/java-1.6.0-openjdk-amd64")))
   (should (string= "1.7" (jde--jdk-get-version "/usr/lib64/jvm/jdk1.7.0_21")))
   (should (string= "1.7" (jde--jdk-get-version "/usr/lib/jvm/java-7-openjdk-amd64")))
-  (should (string= "1.8" (jde--jdk-get-version "/usr/lib/jvm/java-8-oracle"))))
+  (should (string= "1.8" (jde--jdk-get-version "/usr/lib/jvm/java-8-oracle")))
+  (should
+   (string=
+    "1.8"
+    (jde--jdk-get-version
+     "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.51-4.b16.fc22.x86_64")))
+    (should
+   (string=
+    "1.9"
+    (jde--jdk-get-version
+     "/usr/lib/jvm/java-1.9.0-openjdk-1.9.0.12-4.b16.fc22.x86_64"))))
 
 (provide 'jde-jdk-manager-test)
 ;;; jde-jdk-manager-test.el ends here


### PR DESCRIPTION
```
ELISP> dir
"/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.51-4.b16.fc22.x86_64"
```

Prior to this change:

````
ELISP> (jde--jdk-get-version dir)
nil
```

After this change:

```
ELISP> (jde--jdk-get-version dir)
"1.8"
```