### PR TITLE
Ignore executable /usr/bin/javac for Linux jdk manager test

### DIFF
--- a/test/lisp/jde-jdk-manager-test.el
+++ b/test/lisp/jde-jdk-manager-test.el
@@ -103,7 +103,9 @@
                  '("/usr/lib/jvm/java-6-oracle"
                    "/usr/lib/jvm/java-8-oracle"
                    "/usr/lib/jvm/java-7-oracle"
-                   "/usr/lib/jvm/java-7-openjdk-amd64"))))
+                   "/usr/lib/jvm/java-7-openjdk-amd64")))
+              ((symbol-function 'file-executable-p)
+               (lambda (path) nil)))
       (should (equal '(("1.8" . "/usr/lib/jvm/java-8-oracle")
                        ("1.7" . "/usr/lib/jvm/java-7-oracle")
                        ("1.6" . "/usr/lib/jvm/java-6-oracle"))


### PR DESCRIPTION
If testing on Linux and /usr/bin/javac exists, in can be detected in
tests and cause failures. This change makes the `file-executable-p`
check return nil and thus it will be ignored so only JDKs existing in
the `/usr/lib/jvm` and `/usr/lib64/jvm` directories are used.

Fixes #13