### PR TITLE
Fix byte compile warnings

### DIFF
--- a/efc.el
+++ b/efc.el
@@ -388,7 +388,7 @@ and a string describing how the process finished."))
                      (compilation-file-regexp-alist
                       ,file-regexp-alist)))
         (if (boundp (car elt))
-            (set (make-local-variable (car elt)) (second elt))))
+            (set (make-local-variable (car elt)) (cl-second elt))))
 
       (if (slot-boundp this 'comp-finish-fcn)
 	  (set (make-local-variable 'compilation-finish-functions)
@@ -572,8 +572,8 @@ is an object of efc-visitor class."
 (defmethod initialize-instance ((this efc-list-iterator) &rest fields)
   "Iterator constructor."
   (call-next-method)
-  (assert (oref this list-obj))
-  (assert (cl-typep (oref this list-obj) efc-list))
+  (cl-assert (oref this list-obj))
+  (cl-assert (cl-typep (oref this list-obj) efc-list))
   (oset this list (oref (oref this list-obj) items)))
 
 (defmethod efc-iter-has-next ((this efc-list-iterator))

--- a/jdee-bsh.el
+++ b/jdee-bsh.el
@@ -41,7 +41,8 @@
 
 ;; FIXME: there is no cl-lexical-let
 ;; Change file to lexical-binding t
-(require 'cl)
+(eval-when-compile
+  '(require 'cl))
 
 ;; FIXME: refactor to eliminate these
 (defvar jdee-devel-debug);; jde.el

--- a/jdee-parse-expr.el
+++ b/jdee-parse-expr.el
@@ -30,6 +30,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'thingatpt)
 
 ;; FIXME: (require 'cc-cmds) doesn't work
@@ -94,7 +95,7 @@ TO-PARSE is the string to parse."
 		 (prog1
 		     (apply 'string (cl-subseq to-parse last-cap pos))
 		   (setq last-cap pos))))
-	(do ((pos 0 (incf pos)))
+	(cl-do ((pos 0 (cl-incf pos)))
 	    ((> pos (1- (length to-parse))))
 	  (if (and (upperp pos)
 		   ;;(> (- pos last-cap) 2))

--- a/jdee-util.el
+++ b/jdee-util.el
@@ -238,7 +238,7 @@ See `jdee-htmlize-code-destinations'."
   (save-restriction
     (narrow-to-region start end)
     (let ((code-buf (current-buffer))
-	  (line-width (ceiling (log10 (count-lines (point-min) (point-max)))))
+	  (line-width (ceiling (log (count-lines (point-min) (point-max)) 10)))
 	  (ln 0))
       (with-temp-buffer
 	(insert-buffer-substring code-buf)

--- a/jdee-util.el
+++ b/jdee-util.el
@@ -41,6 +41,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'efc)
 
 ;; FIXME: refactor
@@ -246,7 +247,7 @@ See `jdee-htmlize-code-destinations'."
 	(if (not no-line-numbers-p)
 	    (while (not (eobp))
 	      (beginning-of-line)
-	      (insert (format (format "%%.%dd " line-width) (incf ln)))
+	      (insert (format (format "%%.%dd " line-width) (cl-incf ln)))
 	      (forward-line)))
 	(rename-buffer (concat (buffer-name code-buf) ".html"))
 	(let ((buf (when (fboundp 'htmlize-buffer)
@@ -258,7 +259,7 @@ See `jdee-htmlize-code-destinations'."
 		 (dolist (dir jdee-htmlize-code-destinations)
 		   (setq dir (expand-file-name dir))
 		   (if (file-exists-p dir)
-		       (return (expand-file-name bname dir)))))
+		       (cl-return (expand-file-name bname dir)))))
 		(save-buffer)
 		(if (featurep 'browse-url)
 		    (browse-url (buffer-file-name))))


### PR DESCRIPTION
- Fix loading cl.el at runtime
- Fix using obsolete function
- Use cl-lib functions/macros instead of cl.el