### PR TITLE
Fix a couple of XXX-at-point functions

### DIFF
--- a/jdee-bug.el
+++ b/jdee-bug.el
@@ -1490,7 +1490,7 @@ field of an object or class of objects."
 	  :object-class (concat
 			 "*."
 			 (car (jdee-parse-get-innermost-class-at-point)))
-	  :field (thing-at-point 'symbol))))
+	  :field (thing-at-point 'symbol t))))
     (efc-dialog-show dialog)))
 
 (defun jdee-bug-watch-field-modification ()
@@ -1503,7 +1503,7 @@ field of an object or class of objects."
 		 :object-class (concat
 				"*."
 				(car (jdee-parse-get-innermost-class-at-point)))
-		 :field (thing-at-point 'symbol))))
+		 :field (thing-at-point 'symbol t))))
     (efc-dialog-show dialog)))
 
 
@@ -1673,7 +1673,7 @@ requests to cancel."
       (error "No target process or process is not suspended."))
   ;; Previously we used semantic. I recently have been having problems
   ;; with it, so I just replaced it with word-at-point
-  (let ((qualified-expr (thing-at-point 'word)))
+  (let ((qualified-expr (thing-at-point 'word t)))
     (jdee-bug-evaluate-expression qualified-expr)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/jdee-help.el
+++ b/jdee-help.el
@@ -647,7 +647,7 @@ documented."
 		   (jdee-jdhelper-show-class jdee-jdhelper-singleton class member))))))
     (condition-case err
 	(let* ((parse-result (jdee-help-parse-symbol-at-point))
-	       (unqualified-name (thing-at-point 'symbol))
+	       (unqualified-name (thing-at-point 'symbol t))
 	       (class-name (jdee-parse-get-qualified-name unqualified-name t))
 	       (pair (jdee-parse-java-variable-at-point)))
 	  (if (not class-name)

--- a/jdee-import.el
+++ b/jdee-import.el
@@ -768,7 +768,7 @@ version of the JDE with the semantic parser."
 		(when (car group)
 		  (forward-line -1)
 		  (if (not (string< (concat comment-start (car group))
-				    (thing-at-point 'line)))
+				    (thing-at-point 'line t)))
 		      (forward-line 1)))
 		(setq group nil))
 	      ;; 3- Kill current imports

--- a/jdee-jdb.el
+++ b/jdee-jdb.el
@@ -487,7 +487,7 @@ on the list."
 (defmethod jdee-db-cmd-init ((this jdee-jdb-cmd-print))
   "The debugger invokes this method before executing the
 command."
-  (oset this expr (read-from-minibuffer "expr: " (thing-at-point 'word)
+  (oset this expr (read-from-minibuffer "expr: " (thing-at-point 'word t)
 					nil nil 'jdee-jdb-cmd-print-history)))
 
 (defmethod jdee-db-cmd-make-command-line ((this jdee-jdb-cmd-print))
@@ -528,7 +528,7 @@ command."
 (defmethod jdee-db-cmd-init ((this jdee-jdb-cmd-set-var))
   "The debugger invokes this method before executing the
 command."
-  (oset this expr (read-from-minibuffer "variable: " (thing-at-point 'word)
+  (oset this expr (read-from-minibuffer "variable: " (thing-at-point 'word t)
 					nil nil 'jdee-jdb-cmd-print-history))
   (oset this value (read-from-minibuffer "value: " nil
 					nil nil '(null))))
@@ -1455,16 +1455,16 @@ the debuggee process at (e.g., jdbconn)."
 	     (oref debuggee-status stopped-p))
 	(let* ((cmd-set (oref debugger cmd-set))
 	       cmd)
-	  (if (string= "print" key)
-	      (setq cmd (oref cmd-set print))
-	    (if (string= "dump" key)
-		(setq cmd (oref cmd-set dump))
-	      (if (string= "eval" key)
-		  (setq cmd (oref cmd-set eval))
-		(if (string= "set" key)
-		    (setq cmd (oref cmd-set set-var))
-		  (if (string= "locals" key)
-		      (setq cmd (oref cmd-set locals)))))))
+	  (cond ((string= "print" key)
+                 (setq cmd (oref cmd-set print)))
+                ((string= "dump" key)
+                 (setq cmd (oref cmd-set dump)))
+                ((string= "eval" key)
+                 (setq cmd (oref cmd-set eval)))
+		((string= "set" key)
+                 (setq cmd (oref cmd-set set-var)))
+                ((string= "locals" key)
+                 (setq cmd (oref cmd-set locals))))
 	  (jdee-db-exec-cmd debugger cmd))
       (let ((class (oref debuggee main-class)))
 	(error "Application %s is not stopped" class)))))
@@ -1733,7 +1733,7 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 	   val)
 	  (set-default sym val)))
 
-(defun jdee-jdb-string-to-int(number)
+(defun jdee-jdb-string-to-int (number)
   "This method removes punctuation from a string, e.g, 1,200 (1.200 in Danish),
 and converts the result to an integer."
   (if (string-match "[^[:digit:]]" number)

--- a/jdee-jdb.el
+++ b/jdee-jdb.el
@@ -1692,7 +1692,7 @@ the debuggee process at (e.g., jdbconn)."
 	(cons "[?\C-c ?\C-a ?\C-u]" 'jdee-debug-up)
 	(cons "[?\C-c ?\C-a ?\C-d]" 'jdee-debug-down)
 	(cons "[?\C-c ?\C-a ?\C-p]" 'jdee-jdb-print)
-	(cons "[?\C-c ?\C-a ?\C-d]" 'jdee-jdb-dump)
+	(cons "[?\C-c ?\C-a ?\C-x]" 'jdee-jdb-dump)
 	(cons "[?\C-c ?\C-a ?\C-e]" 'jdee-jdb-eval)
 	(cons "[?\C-c ?\C-a ?\C-v]" 'jdee-jdb-set)
 	(cons "[?\C-c ?\C-a ?\C-l]" 'jdee-jdb-locals))

--- a/jdee-open-source.el
+++ b/jdee-open-source.el
@@ -79,21 +79,19 @@ If this fails point is on a method or an attribute of a class in the current
 buffer or in a superclass. In this cases we check first if the parsed-symbol
 is a possible member of the current class(\"this\") and if this fails it
 checks if it is a member of the base class(\"super\")."
- (if (and (stringp (car pair))
-	  (> (length (car pair)) 0))
-     ;; if we got a pair all should work fine.
-     (jdee-parse-eval-type-of (car pair))
-   (or (condition-case ()
-	   (jdee-parse-eval-type-of parsed-symbol)
-	 (error nil))
-       (if (jdee-parse-find-completion-for-pair
-	    `("this" ,parsed-symbol) nil jdee-complete-private)
-	   (jdee-parse-eval-type-of "this")
-	 nil)
-       (if (jdee-parse-find-completion-for-pair
-	    `("super" ,parsed-symbol) nil jdee-complete-private)
-	   (jdee-parse-eval-type-of "super")
-	 nil))))
+  (cond ((and (stringp (car pair))
+              (> (length (car pair)) 0))
+         ;; if we got a pair all should work fine.
+         (concat (car pair) "." (cadr pair)))
+        ((condition-case ()
+             (jdee-parse-eval-type-of parsed-symbol)
+           (error nil)) )
+        ((jdee-parse-find-completion-for-pair
+          `("this" ,parsed-symbol) nil jdee-complete-private)
+         (jdee-parse-eval-type-of "this"))
+        ((jdee-parse-find-completion-for-pair
+          `("super" ,parsed-symbol) nil jdee-complete-private)
+         (jdee-parse-eval-type-of "super"))))
 
 
 (defun jdee-open-functions-exist ()
@@ -184,7 +182,7 @@ $CLASSPATH, then in the current directory."
 			    (prog1
 				(point)
 			      (goto-char position))))
-	     (thing-of-interest (thing-at-point 'symbol))
+	     (thing-of-interest (thing-at-point 'symbol t))
 	     (pair (save-excursion
 		     (end-of-thing 'symbol)
 		     (jdee-parse-java-variable-at-point)))
@@ -241,7 +239,7 @@ not associated with any project."
   (condition-case err
       (let* ((unqualified-name
 	      (or unqual-class
-		  (read-from-minibuffer "Class: " (thing-at-point 'symbol))))
+		  (read-from-minibuffer "Class: " (thing-at-point 'symbol t))))
 	     (class-names
 	      ;;expand the names into full names, or a list of names
 	      (jdee-jeval-r
@@ -313,15 +311,11 @@ CLASS. If it finds the source file in a directory, it returns the
 file's path. If it finds the source file in an archive, it returns a
 buffer containing the contents of the file. If this function does not
 find the source for the class, it returns nil."
-  (let ((verified-name (jdee-parse-class-exists class))
-	outer-class file package)
-    (if (null verified-name)
-	(error "Class not found: %s" class))
-    (setq outer-class (car (split-string verified-name "[$]"))
-	  file (concat
+  (let* ((outer-class (car (split-string class "[$]")))
+         (file (concat
 		(jdee-parse-get-unqualified-name outer-class)
-		".java")
-	  package (jdee-parse-get-package-from-name outer-class))
+		".java"))
+         (package (jdee-parse-get-package-from-name outer-class)))
     (catch 'found
       (loop for path in (jdee-expand-wildcards-and-normalize jdee-sourcepath 'jdee-sourcepath) do
 	      (if (and (file-exists-p path)

--- a/jdee-parse-expr.el
+++ b/jdee-parse-expr.el
@@ -226,7 +226,7 @@ when called interactively.
 GETTERP, if non-nil, make it a getter, otherwise make it a setter.  If
 \\[universal-argument] is used while calling interactively, then make it a
 setter, otherwise, make a getter."
-  (interactive (list (thing-at-point 'word) (not current-prefix-arg)))
+  (interactive (list (thing-at-point 'word t) (not current-prefix-arg)))
   (let* ((toks (jdee-split-by-camel-notation member-name))
 	 (attr (apply 'concat
 		      (append (list (if getterp "get" "set")

--- a/jdee-parse.el
+++ b/jdee-parse.el
@@ -605,7 +605,7 @@ point is
 In this case, this function returns (cons \"error.msg\" \"length\").
 This function works only for qualified names that do not contain
 white space. It returns null if there is no qualified name at point."
-  (let ((symbol-at-point (thing-at-point 'symbol)))
+  (let ((symbol-at-point (thing-at-point 'symbol t)))
     (when symbol-at-point
        (thing-at-point-looking-at "[^ \n\t();,:+<]+") ;; add < to prevent like "Map<String"
       (let ((qualified-name
@@ -1042,7 +1042,7 @@ in a method; otherwise, nil."
 (defun jdee-parse-java-variable-at-point ()
   "Returns a list (VAR PARTIAL) where VAR.PARTIAL is the partially completed
 method or field name at point. For example, suppose obj.f1.ge were the name
-at point. This function would return the list (obj.f1 ge)."
+at point. This function would return the list (\"obj.f1\" \"ge\")."
   (save-excursion
     (let (start middle-point varname curcar dot (dot-offset 0) found
 		(original-point (point))
@@ -1736,9 +1736,9 @@ The first two elements of the list are `nil' if CLASSNAME isn't fully qualifed."
 	;; (i.e. [a-zA-Z.])  but this need to be refined to use the Sun Java
 	;; standards of class name parsing
 	(or (let ((thing-at-point-file-name-chars "-~/[:alnum:]_.${}#%:"))
-	      (parse-at-point (thing-at-point 'filename)))
-	    (parse-at-point (thing-at-point 'word))
-	    (parse-at-point (thing-at-point 'symbol)))
+	      (parse-at-point (thing-at-point 'filename t)))
+	    (parse-at-point (thing-at-point 'word t))
+	    (parse-at-point (thing-at-point 'symbol t)))
       (parse-at-point classname))))
 
 (provide 'jdee-parse)

--- a/jdee-wiz.el
+++ b/jdee-wiz.el
@@ -498,7 +498,7 @@ the cursor"
   (interactive)
   (let* ((class
 	 (or class-name
-	     (read-from-minibuffer "Class: " (thing-at-point 'symbol))))
+	     (read-from-minibuffer "Class: " (thing-at-point 'symbol t))))
 	 (fq-class-name
 	  (jdee-parse-select-qualified-class-name class)))
     (if fq-class-name

--- a/jdee.el
+++ b/jdee.el
@@ -2260,7 +2260,7 @@ This command has the  same requirements to work as the field/method-completion
 feature in JDEE (see `jdee-complete-at-point')."
   (interactive)
   (if (jdee-open-functions-exist)
-      (let* ((thing-of-interest (thing-at-point 'symbol))
+      (let* ((thing-of-interest (thing-at-point 'symbol t))
 	     (pair (save-excursion (end-of-thing 'symbol)
 				   (jdee-parse-java-variable-at-point)))
 	     (class-to-open (jdee-open-get-class-to-open


### PR DESCRIPTION
Change to jdee-open-get-class-to-open is, I believe, correct, but deserves some careful examination. Basically the pair arg is a list of the package name and the short class name, so if the package is supplied it is easy to get the full class name.

The change to jdee-find-class-source-file is clear: there is no reason to verify that the class file exists if the source file can be found.