### PR TITLE
changes to plugin support

### DIFF
--- a/jdee-bsh.el
+++ b/jdee-bsh.el
@@ -36,7 +36,6 @@
 (require 'eieio)
 (require 'beanshell)
 (require 'jdee-parse-expr)
-(require 'jdee-plugins);; jdee-pi-get-bsh-classpath
 (require 'jdee-util)
 
 ;; FIXME: there is no cl-lexical-let
@@ -54,6 +53,9 @@
 (declare-function jdee-expand-classpath "jdee" (classpath &optional symbol))
 (declare-function jdee-get-global-classpath "jdee" ())
 (declare-function jdee-create-prj-values-str "jdee" ())
+
+;; Avoid recursive requires, where a plugin might require this file
+(autoload 'jdee-pi-get-bsh-classpath "jdee-plugins")
 
 (defcustom jdee-bsh-separate-buffer nil
   "*Whether or not to use a separate buffer for errors."

--- a/jdee-jdb.el
+++ b/jdee-jdb.el
@@ -1692,7 +1692,7 @@ the debuggee process at (e.g., jdbconn)."
 	(cons "[?\C-c ?\C-a ?\C-u]" 'jdee-debug-up)
 	(cons "[?\C-c ?\C-a ?\C-d]" 'jdee-debug-down)
 	(cons "[?\C-c ?\C-a ?\C-p]" 'jdee-jdb-print)
-	(cons "[?\C-c ?\C-a ?\C-d]" 'jdee-jdb-dump)
+	(cons "[?\C-c ?\C-a ?\C-x]" 'jdee-jdb-dump)
 	(cons "[?\C-c ?\C-a ?\C-e]" 'jdee-jdb-eval)
 	(cons "[?\C-c ?\C-a ?\C-v]" 'jdee-jdb-set)
 	(cons "[?\C-c ?\C-a ?\C-l]" 'jdee-jdb-locals))

--- a/jdee-plugins.el
+++ b/jdee-plugins.el
@@ -4,7 +4,7 @@
 ;; Maintainer: Paul Landes <landes <at> mailc dt net>
 ;; Keywords: java, tools
 
-;; Copyright (C) 2003, 2004, 2016 Paul Kinnucan.
+;; Copyright (C) 2003, 2004 Paul Kinnucan.
 ;; Copyright (C) 2009 by Paul Landes
 
 ;; GNU Emacs is free software; you can redistribute it and/or modify

--- a/jdee-plugins.el
+++ b/jdee-plugins.el
@@ -56,7 +56,10 @@ type `jdee-plugin'."
   (oset-default
    'jdee-plugin
    plugins
-   (cons plugin (oref-default 'jdee-plugin plugins))))
+   (cons plugin (cl-mapcan (lambda (p) (if (not (equal (eieio-object-name-string p)
+                                                       (eieio-object-name-string plugin)))
+                                           (list p)))
+                           (oref-default 'jdee-plugin plugins)))))
 
 
 (defun jdee-pi-get-plugin-dir (plugin)
@@ -87,25 +90,16 @@ a file named jdee-PLUGIN.el. This function loads jdee-PLUGIN.el."
 (defun jdee-pi-load-plugins ()
   "Loads the plugins in the JDEE's plugins directory."
   (interactive)
-  (if (file-exists-p jdee-plugins-directory)
-      (let ((plugins
-	     (delq
-	      nil
-	      (mapcar
-	       (lambda (file)
-		 (let ((file-name (file-name-nondirectory file)))
-		   (if (and
-			(file-directory-p file)
-			(not (string= file-name "."))
-			(not (string= file-name ".."))
-			(not (string= file-name "CVS"))
-			(not (string= file-name "RCS")))
-		       file-name)))
-	       (directory-files jdee-plugins-directory t)))))
-	(loop for plugin in plugins do
-	  (jdee-pi-load-plugin plugin)))))
-
-(jdee-pi-load-plugins)
+  (if (and jdee-plugins-directory (file-directory-p jdee-plugins-directory))
+      (mapc (lambda (f)
+              (if (and (not (member (file-name-nondirectory f) '("." ".." ".git" "CVS" "RCS")))
+                       (file-directory-p f))
+                  (jdee-pi-load-plugin (file-name-nondirectory f))))
+            (directory-files jdee-plugins-directory t)))
+  ;; Update the menu after the plugins have been loaded
+  (setq jdee-plugin-minor-mode-map (jdee-pi-mode-map))
+  (setcdr (assq 'jdee-plugin-minor-mode minor-mode-map-alist)
+          jdee-plugin-minor-mode-map))
 
 (defun jdee-pi-get-bsh-classpath ()
   "Get the plugin directories and jar files to include in the Beanshell classpath."
@@ -148,10 +142,10 @@ jar program is on the system path."
 	    (insert "\n\nInstallation complete"))))))
 
 
-(defun jdee-plugin-make-menu-spec ()
+(defun jdee-pi-make-menu-spec ()
   (if (oref-default 'jdee-plugin plugins)
       (append
-       (list "JDEpi")
+       (list "JDEEpi")
        (delq
 	nil
 	(cl-mapcan
@@ -159,22 +153,23 @@ jar program is on the system path."
 	   (oref plugin menu-spec))
 	 (oref-default 'jdee-plugin plugins))))))
 
-(defvar jdee-plugin-mode-map
+(defun jdee-pi-mode-map ()
+  "Keymap for JDEE plugin minor mode."
   (let ((km (make-sparse-keymap))
-	(menu-spec (jdee-plugin-make-menu-spec)))
+	(menu-spec (jdee-pi-make-menu-spec)))
     (if menu-spec
-	(easy-menu-define jdee-plugin-menu km "JDEE Plugin Minor Mode Menu"
+	(easy-menu-define jdee-pi-menu km "JDEE Plugin Minor Mode Menu"
 	  menu-spec))
-    km)
-  "Keymap for JDEE plugin minor mode.")
-
+    km))
 
 (define-minor-mode jdee-plugin-minor-mode nil
-                   :keymap jdee-plugin-mode-map)
+  :keymap (jdee-pi-mode-map))
 
 (semantic-add-minor-mode 'jdee-plugin-minor-mode " plugin")
 
-
 (provide 'jdee-plugins)
+
+;; Only load the plugins after the provide, to avoid potential recursive require issues.
+(jdee-pi-load-plugins)
 
 ;;; jdee-plugins.el ends here

--- a/jdee-plugins.el
+++ b/jdee-plugins.el
@@ -4,7 +4,7 @@
 ;; Maintainer: Paul Landes <landes <at> mailc dt net>
 ;; Keywords: java, tools
 
-;; Copyright (C) 2003, 2004 Paul Kinnucan.
+;; Copyright (C) 2003, 2004, 2016 Paul Kinnucan.
 ;; Copyright (C) 2009 by Paul Landes
 
 ;; GNU Emacs is free software; you can redistribute it and/or modify
@@ -38,9 +38,11 @@
 (defclass jdee-plugin ()
   ((bsh-cp    :initarg :bsh-cp
 	      :type list
+              :initform nil
 	      :documentation "Beanshell classpath for this plugin.")
    (menu-spec :initarg :menu-spec
 	      :type list
+              :initform nil
 	      :documentation "Specifies menu for this plugin.")
    (plugins   :type list
 	      :allocation :class

--- a/jdee.el
+++ b/jdee.el
@@ -7,7 +7,7 @@
 ;; Version: 2.4.2
 ;; Package-Requires: ((emacs "24.3"))
 
-;; Copyright (C) 1997-2008 Paul Kinnucan.
+;; Copyright (C) 1997-2008, 2016 Paul Kinnucan.
 ;; Copyright (C) 2009 by Paul Landes
 
 ;; GNU Emacs is free software; you can redistribute it and/or modify
@@ -763,9 +763,6 @@ idle moments.")
 (derived-mode-init-mode-variables 'jdee-mode)
 (put 'jdee-mode 'derived-mode-parent 'java-mode)
 
-;; Lazy load the plugins file, to avoid recursive requires
-(autoload 'jdee-plugin-minor-mode "jdee-plugins")
-
 ;;;###autoload
 (defun jdee-mode ()
   "Major mode for developing Java applications and applets.
@@ -774,6 +771,7 @@ idle moments.")
   (condition-case err
       (progn
 	(jdee-check-versions)
+        (require 'jdee-plugins)
 
 	(add-to-list 'semantic-new-buffer-setup-functions
 		     '(jdee-mode . jdee-parse-semantic-default-setup))
@@ -859,9 +857,6 @@ idle moments.")
 	(if (string= (car jdee-debugger) "JDEbug")
 	    (jdee-bug-minor-mode 1)
 	  (jdee-jdb-minor-mode 1))
-
-	;; Install plugin menu.
-	(jdee-plugin-minor-mode 1)
 
 	(when (boundp 'jdee-mode-map)
 	  (let ((key (car (read-from-string "[return]"))))

--- a/jdee.el
+++ b/jdee.el
@@ -59,7 +59,6 @@
 (require 'jdee-jdb)
 (require 'jdee-jdk-manager)
 (require 'jdee-open-source)
-(require 'jdee-plugins)
 (require 'jdee-project-file)
 (require 'jdee-run)
 (require 'jdee-util)
@@ -764,6 +763,9 @@ idle moments.")
 (derived-mode-init-mode-variables 'jdee-mode)
 (put 'jdee-mode 'derived-mode-parent 'java-mode)
 
+;; Lazy load the plugins file, to avoid recursive requires
+(autoload 'jdee-plugin-minor-mode "jdee-plugins")
+
 ;;;###autoload
 (defun jdee-mode ()
   "Major mode for developing Java applications and applets.
@@ -975,7 +977,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 (add-to-list 'auto-mode-alist '("\\.java\\'" . jdee-mode))
 
 (defcustom jdee-menu-definition
-  (list "JDE"
+  (list "JDEE"
 	["Compile"           jdee-compile t]
 	;; ["Run App"           jdee-run (not (jdee-run-application-running-p))]
 	["Run App"           jdee-run t]
@@ -1127,11 +1129,10 @@ Does nothing but return nil if `jdee-log-max' is nil."
   :set '(lambda (sym val)
 	  (set-default sym val)
           ;; Define JDEE menu for FSF Emacs.
-	  (if (featurep 'infodock)
-	      (easy-menu-define jdee-menu
-                jdee-mode-map
-                "Menu for JDE."
-                val))))
+	  (easy-menu-define jdee-menu
+            jdee-mode-map
+            "Menu for JDEE."
+            val)))
 
 (defcustom jdee-new-buffer-menu
   (list

--- a/jdee.el
+++ b/jdee.el
@@ -7,7 +7,7 @@
 ;; Version: 2.4.2
 ;; Package-Requires: ((emacs "24.3"))
 
-;; Copyright (C) 1997-2008, 2016 Paul Kinnucan.
+;; Copyright (C) 1997-2008 Paul Kinnucan.
 ;; Copyright (C) 2009 by Paul Landes
 
 ;; GNU Emacs is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Plugin support has some problems. Notably was a recursive-require problem. Plugins were loaded (indirectly) by jdee before the `(provide ...)`, so if the plugin required jdee you would end up with recursive requires. The fix is to delay loading the plugins until jdee is first used.

Secondly, I moved the plugin menu from the top-level to be a sub-menu of the main jdee menu.