### PR TITLE
Accept known-good values of `jdee-build-function` without querying the user

### DIFF
--- a/jdee-ant.el
+++ b/jdee-ant.el
@@ -208,6 +208,7 @@ current directory for the build definition file. Also note that, if non-nil,
 this will relax the requirement for an explicit jdee project file.  If
 `jdee-ant-read-buildfile' is enable that value is used as a default if valid."
    :group 'jdee-ant
+   :safe 'booleanp
    :type 'boolean)
 
 (defcustom jdee-ant-complete-target t

--- a/jdee.el
+++ b/jdee.el
@@ -501,6 +501,7 @@ specify a custom function to use. The custom function must
 be an interactive function that can be called by
 `call-interactively'."
   :group 'jdee-project
+  :safe (lambda (val) (member val '(jdee-make jdee-ant-build)))
   :type '(radio
 	  (const :tag "Make" jdee-make)
 	  (const :tag "Ant" jdee-ant-build)


### PR DESCRIPTION
It is useful to set `jdee-build-function` via file-local variables, or per project via `.dir-locals.el`.  Accept the standard `jdee-make` and `jdee-ant-build` symbols as values of `jdee-build-function` without querying the user.
