### PR TITLE
Basic Maven Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist
 elpa
 build.properties
 build
+
+
+#EMACS
+*~

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -61,9 +61,13 @@ in a maven project.")
  :group 'jdee-maven
  :type 'string)
 
-(defcustom jdee-maven-artifacts-excluded-from-sources '("ojdbc16" "wlfullclient" "wlthint3client"
-                                                        "common-tools-ihc" "ihc-ldap-client" "audit3-ejb" "CDRClientEJB" "spring-context-support" "spring-js-resources")
-  "Artifact IDs to exclude from sources"
+(defcustom jdee-maven-artifacts-excluded-from-sources nil
+  "*Specifies a list of artifact IDs to exclude from sources.  Should be added
+to the prj.el with something like:
+
+(jdee-set-variables
+ '(jdee-maven-artifacts-excluded-from-sources '(\"ojdbc16\")))
+"
  :group 'jdee-maven
  :type '(repeat (string :tag "Artifact:")))
 

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -132,7 +132,7 @@ relative the maven project dir."
                              nil))))
           (erase-buffer)
           (pop-to-buffer (current-buffer))
-          (apply 'call-process "mvn" nil t t args))
+          (apply 'call-process "mvn" nil t t (remove-if-not 'identity args)))
         (goto-char (point-min))
         (when (search-forward "BUILD SUCCESS" nil t)
           (kill-buffer (current-buffer)))))))

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -49,6 +49,11 @@
  :group 'jdee-maven
  :type 'string)
 
+(defcustom jdee-maven-build-phase "package"
+  "*Specifies maven phase to specify when calling Build."
+ :group 'jdee-maven
+ :type 'string)
+
 (defcustom jdee-maven-artifacts-excluded-from-sources '("ojdbc16" "wlfullclient" "wlthint3client"
                                                         "common-tools-ihc" "ihc-ldap-client" "audit3-ejb" "CDRClientEJB" "spring-context-support" "spring-js-resources")
   "Artifact IDs to exclude from sources"
@@ -229,7 +234,7 @@ and this in src/main
   "Build using the maven command from PATH (default to `default-directory')"
   (interactive)
   (let ((default-directory (jdee-maven-get-default-directory path)))
-    (compilation-start (format "%s package" jdee-maven-program))))
+    (compilation-start (format "%s %s" jdee-maven-program jdee-maven-build-phase))))
 
 (provide 'jdee-maven)
 

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -34,13 +34,20 @@
   :prefix "jdee-")
 
 
+(defvar jdee-maven-mode-hook nil
+  "*Lists functions to run when a buffer is successfully initialized as being
+in a maven project.")
+
+(defvar jdee-maven-project-dir nil
+  "*When a buffer is in a maven project, the full path to the project directory, the one with the pom.xml.  It will be set buffer local by the `jdee-maven-hook'.")
+
 (defcustom jdee-maven-disabled-p nil
-  "When nil (default) add maven support to project startup."
+  "*When nil (default) add maven support to project startup."
   :group 'jdee-maven
   :type 'boolean)
 
 (defcustom jdee-maven-buildfile "pom.xml"
-  "Specify the name of the maven project file."
+  "*Specify the name of the maven project file."
   :group 'jdee-maven
   :type 'string)
 
@@ -254,9 +261,16 @@ and this in src/main
 
 ;;;###autoload
 (defun jdee-maven-hook ()
-  "Initialize the maven integration if available."
-  (unless jdee-maven-disabled-p 
-    (run-hook-with-args-until-success 'jdee-maven-init-hook (jdee-maven-get-default-directory))))
+  "Initialize the maven integration if available.  Runs all the
+functions in `jdee-maven-init-hook' until one returns non-nil.
+If all return nil, maven mode is not initialized.  If one of the
+functions returns non-nil, set `jdee-maven-project-dir' buffer
+local and then run the functions in `jdee-maven-mode-hook'."
+  (unless jdee-maven-disabled-p
+    (let ((jdee-maven-project-dir* (jdee-maven-get-default-directory)))
+      (when (run-hook-with-args-until-success 'jdee-maven-init-hook jdee-maven-project-dir*)
+        (setq-local jdee-maven-project-dir jdee-maven-project-dir*)
+        (run-hooks 'jdee-maven-mode-hook)))))
 
 (provide 'jdee-maven)
 

--- a/jdee-project-file.el
+++ b/jdee-project-file.el
@@ -27,13 +27,13 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'jdee-project-maven)
+(require 'jdee-maven)
 
 ;; FIXME: refactor
 (declare-function jdee-wiz-set-bsh-project "jdee-wiz" ())
 (declare-function jdee-root-dir-p "jdee" (dir))
 (declare-function jdee-log-msg "jdee" (msg &rest args))
-(declare-function jdee-project-maven-hook "jdee-project-maven" ())
+(declare-function jdee-maven-hook "jdee-maven" ())
 
 
 (defconst jdee-project-file-version "1.0"
@@ -522,9 +522,9 @@ defined by the current project's project file."
   (jdee-custom-adjust-groups)
   (jdee-load-project-file))
 
-(when  (or (not (boundp 'jdee-project-maven-disabled-p))
-           (not jdee-project-maven-disabled-p))
-  (add-hook 'jdee-mode-hook 'jdee-project-maven-hook))
+(when  (or (not (boundp 'jdee-maven-disabled-p))
+           (not jdee-maven-disabled-p))
+  (add-hook 'jdee-mode-hook 'jdee-maven-hook))
 
 (provide 'jdee-project-file)
 

--- a/jdee-project-file.el
+++ b/jdee-project-file.el
@@ -27,11 +27,14 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'jdee-project-maven)
 
 ;; FIXME: refactor
 (declare-function jdee-wiz-set-bsh-project "jdee-wiz" ())
 (declare-function jdee-root-dir-p "jdee" (dir))
 (declare-function jdee-log-msg "jdee" (msg &rest args))
+(declare-function jdee-project-maven-hook "jdee-project-maven" ())
+
 
 (defconst jdee-project-file-version "1.0"
   "*The current JDEE project file version number.")
@@ -519,6 +522,9 @@ defined by the current project's project file."
   (jdee-custom-adjust-groups)
   (jdee-load-project-file))
 
+(when  (or (not (boundp 'jdee-project-maven-disabled-p))
+           (not jdee-project-maven-disabled-p))
+  (add-hook 'jdee-mode-hook 'jdee-project-maven-hook))
 
 (provide 'jdee-project-file)
 

--- a/jdee-project-file.el
+++ b/jdee-project-file.el
@@ -89,17 +89,18 @@ being loaded.")
 (defvar jdee-current-project ""
   "Path of the project file for the current project.")
 
-(defun jdee-find-project-file (dir)
-  "Finds the next project file upwards in the directory tree
-from DIR. Returns nil if it cannot find a project file in DIR
-or an ascendant directory."
+(defun jdee-find-project-file (dir &optional file-name)
+  "Finds the next project file named FILE-NAME (defaults to
+`jdee-project-file-name') upwards in the directory tree from
+DIR. Returns nil if it cannot find a project file in DIR or an
+ascendant directory."
   (let* ((directory-sep-char ?/) ;; Override NT/XEmacs setting
-	 (file (cl-find jdee-project-file-name
+	 (file (cl-find (or file-name jdee-project-file-name)
 			(directory-files dir) :test 'string=)))
     (if file
 	(expand-file-name file dir)
       (if (not (jdee-root-dir-p dir))
-	  (jdee-find-project-file (expand-file-name ".." dir))))))
+	  (jdee-find-project-file (expand-file-name ".." dir) file-name)))))
 
 (defvar jdee-buffer-project-file ""
   "Path of project file associated with the current Java source buffer.")

--- a/jdee-project-maven.el
+++ b/jdee-project-maven.el
@@ -1,0 +1,83 @@
+;;; jdee-project-maven.el -- Project maven integration
+
+;; Author: Matthew O. Smith <matt@m0smith.com>
+;; Keywords: java, tools
+
+;; Copyright (C) 2106 Matthew O. Smith
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'jdee)
+(require 'jdee-open-source)
+
+(defun jdee-project-maven-classpath-from-file (file-name &optional sep)
+  "Read a classpath from a file that contains a classpath.  Useful in conjunction with
+a maven plugin to create the classpath like:
+	    <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <version>2.10</version>
+              <executions>
+		<execution>
+		  <id>test-classpath</id>
+		  <phase>generate-sources</phase>
+		  <goals>
+		    <goal>build-classpath</goal>
+		  </goals>
+		  <configuration>
+		    <outputFile>target/test.cp</outputFile>
+		    <includeScope>test</includeScope>
+		  </configuration>
+		</execution>
+		<execution>
+		  <id>compile-classpath</id>
+		  <phase>generate-sources</phase>
+		  <goals>
+		    <goal>build-classpath</goal>
+		  </goals>
+		  <configuration>
+		    <outputFile>target/compile.cp</outputFile>
+		    <includeScope>compile</includeScope>
+		  </configuration>
+		</execution>
+              </executions>
+	    </plugin>
+
+It can be used in a prj.el like this in src/test
+
+(jdee-set-variables
+ '(jdee-global-classpath (jdee-project-classpath-from-file \"./../../target/test.cp\")))
+
+and this in src/main
+
+(jdee-set-variables
+ '(jdee-global-classpath (jdee-project-classpath-from-file \"./../../target/compile.cp\")))
+
+
+"
+  (let ((the-file (jdee-normalize-path file-name)))
+    (message "loading file %s %s" the-file (file-exists-p the-file))
+    (jdee-with-file-contents
+     the-file
+     (split-string (buffer-string) (or sep path-separator t)))))
+
+(provide 'jdee-project-maven)
+
+;;; jdee-project-maven.el ends here

--- a/jdee-project-maven.el
+++ b/jdee-project-maven.el
@@ -27,6 +27,27 @@
 (require 'jdee)
 (require 'jdee-open-source)
 
+(defgroup jdee-project-maven nil
+  "JDEE Maven Project Options"
+  :group 'jdee
+  :prefix "jdee-")
+
+
+(defcustom jdee-project-maven-file-name "pom.xml"
+  "Specify the name of the maven project file."
+  :group 'jdee-project-maven
+  :type 'string)
+
+
+(defun jdee-project-maven-pom-dir (&optional dir)
+  "Find the directory of the closest maven maven project
+file (see `jdee-project-maven-file-name') starting at
+DIR (default to `default-directory')"
+  (let ((pom-path  (jdee-find-project-file (or dir default-directory)
+                                           jdee-project-maven-file-name)))
+    (when pom-path
+      (file-name-directory pom-path))))
+
 (defun jdee-project-maven-classpath-from-file (file-name &optional sep)
   "Read a classpath from a file that contains a classpath.  Useful in conjunction with
 a maven plugin to create the classpath like:

--- a/jdee.el
+++ b/jdee.el
@@ -505,6 +505,7 @@ be an interactive function that can be called by
   :type '(radio
 	  (const :tag "Make" jdee-make)
 	  (const :tag "Ant" jdee-ant-build)
+	  (const :tag "Maven" jdee-maven-build)
 	  (function :tag "Custom function" identity)))
 
 ;;(makunbound 'jdee-debugger)

--- a/test/jdee-maven-test.el
+++ b/test/jdee-maven-test.el
@@ -37,5 +37,24 @@ doesn't try to hit the file system."
           (should (string= (format "%s/" (car (nth 2 dirs)))
                            (jdee-maven-get-default-directory))))))))
 
+
+(ert-deftest test-maven-jdee-scope-file-with-expected-paths ()
+  "Check that `jdee-maven-scope-file' can find the right scope for the path"
+  (let ((source-path "/a/b/c/src/main/java/d/e/f/G.java")
+        (test-path "/a/b/c/src/test/java/d/e/f/G.java"))
+    (should (eq 'compile (car (jdee-maven-scope-file source-path))))
+    (should (eq 'compile (car (let ((default-directory source-path)) (jdee-maven-scope-file)))))
+    (should (eq 'test (car (jdee-maven-scope-file test-path))))
+    (should (eq 'test (car (let ((default-directory test-path)) (jdee-maven-scope-file)))))))
+
+(ert-deftest test-maven-jdee-scope-file-with-non-maven-paths ()
+  "Check that `jdee-maven-scope-file' returns nil for non-maven paths"
+  (let ((source-path "/a/b/c/d/e/f/G.java")
+        (test-path "/a/b/c/d/e/f/G.java"))
+    (should (null (jdee-maven-scope-file source-path)))
+    (should (null (let ((default-directory source-path)) (jdee-maven-scope-file))))
+    (should (null (jdee-maven-scope-file test-path)))
+    (should (null (let ((default-directory test-path)) (jdee-maven-scope-file))))))
+
 (provide 'jdee-maven-test)
 ;;; jdee-maven-test.el ends here

--- a/test/jdee-maven-test.el
+++ b/test/jdee-maven-test.el
@@ -1,0 +1,41 @@
+;;; package --- Summary
+;;; Commentary:
+;;; Code:
+
+(require 'ert)
+(require 'el-mock)
+(require 'jdee-maven)
+(require 'cl)
+
+(ert-deftest test-get-default-directory-no-pom-returns-nil ()
+  "Check that if a pom.xml is not found, it returns nil."
+  (let ((default-directory "/aaaaaaaa/b/c/d/e/f"))
+    (with-mock
+     (stub directory-files => '("." ".."))
+     (should (null (jdee-maven-get-default-directory))))))
+
+(ert-deftest test-get-default-directory-with-pom-returns-dir ()
+  "Check that the case where the pom file is found returns the correct directory.
+Requires directory-files and file-readable-p to be stubbed so it
+doesn't try to hit the file system."
+  (let* ((without-pom '("." ".."))
+         (with-pom '("." ".." "pom.xml"))
+         (dirs (list (list "/a" without-pom)
+                     (list "/a/b" without-pom)
+                     (list "/a/b/c" with-pom)
+                     (list "/a/b/c/src" without-pom)
+                     (list "/a/b/c/src/main" without-pom)
+                     (list "/a/b/c/src/main/java" without-pom))))
+
+
+    (let ((default-directory (caar (last dirs))))
+      
+      (flet ((directory-files (d) (cadr (assoc d dirs))))
+        (with-mock
+          (stub file-readable-p => t)
+          
+          (should (string= (format "%s/" (car (nth 2 dirs)))
+                           (jdee-maven-get-default-directory))))))))
+
+(provide 'jdee-maven-test)
+;;; jdee-maven-test.el ends here

--- a/test/jdee-maven-test.el
+++ b/test/jdee-maven-test.el
@@ -1,5 +1,8 @@
 ;;; package --- Summary
 ;;; Commentary:
+;;
+;; Unit tests of jdee-maven.el
+;;
 ;;; Code:
 
 (require 'ert)
@@ -7,6 +10,10 @@
 (require 'jdee-maven)
 (require 'cl)
 
+
+;;
+;; Testing: jdee-maven-get-default-directory
+;;
 (ert-deftest test-get-default-directory-no-pom-returns-nil ()
   "Check that if a pom.xml is not found, it returns nil."
   (let ((default-directory "/aaaaaaaa/b/c/d/e/f"))
@@ -36,7 +43,9 @@ doesn't try to hit the file system."
           
           (should (string= (format "%s/" (car (nth 2 dirs)))
                            (jdee-maven-get-default-directory))))))))
-
+;;
+;; Testing: jdee-maven-scope-file
+;;
 
 (ert-deftest test-maven-jdee-scope-file-with-expected-paths ()
   "Check that `jdee-maven-scope-file' can find the right scope for the path"
@@ -55,6 +64,37 @@ doesn't try to hit the file system."
     (should (null (let ((default-directory source-path)) (jdee-maven-scope-file))))
     (should (null (jdee-maven-scope-file test-path)))
     (should (null (let ((default-directory test-path)) (jdee-maven-scope-file))))))
+
+;;
+;; Testing: jdee-maven-check-classpath-file
+;;
+;;   No tests - nothing worth testing
+
+;;
+;; Testing: jdee-maven-check-classpath-file*
+;;
+
+(ert-deftest test-jdee-maven-check-classpath-file*-when-file-already-exists ()
+  "Check that `jdee-maven-check-classpath-file*' doesn't call maven if the file already exists"
+  (with-mock
+   (mock (file-readable-p *) => t)
+   (should (jdee-maven-check-classpath-file* nil "some/random/path.cp" "/a/b/c" nil))))
+
+(ert-deftest test-jdee-maven-check-classpath-file*-when-file-is-missing-maven-success ()
+  "Check that `jdee-maven-check-classpath-file*'  calls maven if the file is missing"
+  (cl-letf (((symbol-function 'call-process) (lambda (&rest _) (insert "BUILD SUCCESS"))))
+    (with-mock
+      (mock (file-readable-p *) => nil)
+      (should (jdee-maven-check-classpath-file* nil "some/random/path.cp" "/a/b/c" nil)))))
+
+(ert-deftest test-jdee-maven-check-classpath-file*-when-file-is-missing-maven-fails ()
+  "Check that `jdee-maven-check-classpath-file*' calls maven and returns nul when it fails"
+  (cl-letf (((symbol-function 'call-process) (lambda (&rest _) (insert "BUILD FAILURE"))))
+    (with-mock
+      (mock (file-readable-p *) => nil)
+      (should (null (jdee-maven-check-classpath-file* nil "some/random/path.cp" "/a/b/c" nil))))))
+
+
 
 (provide 'jdee-maven-test)
 ;;; jdee-maven-test.el ends here

--- a/test/jdee-maven-test.el
+++ b/test/jdee-maven-test.el
@@ -30,7 +30,7 @@ doesn't try to hit the file system."
 
     (let ((default-directory (caar (last dirs))))
       
-      (flet ((directory-files (d) (cadr (assoc d dirs))))
+      (cl-letf (((symbol-function 'directory-files) (lambda (d) (cadr (assoc d dirs)))))
         (with-mock
           (stub file-readable-p => t)
           


### PR DESCRIPTION
This provides basic maven integration.  The Compile, Build and Find Symbol Definition are all working.

It works by using the maven dependency plugin build-classpath to write the classpath and sourcepath to disk in the target directory.  This can be included as a plugin in the pom.xml or it will call maven directly.  Once those files are written it goes very fast.

It loads the proper classpath and sourcepath for files in src/main/java versus src/test/java


Known gotchas:

It assumes standard maven src/main/java and src/test/java layout.  It can be controller with `jdee-maven-dir-scope-map`

If mvn dependency:build-classpath fails for the sources classifier it doesn't write the classpath file to disk.  There is a variable `jdee-maven-artifacts-excluded-from-sources` that is a list of artifacts to exclude from the sources as there isn't a jar file containing sources.

Known not to work:
Debugger - Doesn't seem to work anyway
Flymake - Seems to really want make