### PR TITLE
unit tests, flycheck, stacktrace, copy FQN

### DIFF
--- a/jdee-compile.el
+++ b/jdee-compile.el
@@ -185,6 +185,10 @@ describing how the compilation finished."
   :group 'jdee-compile-options
   :type 'boolean)
 
+(defvar jdee-compile-mute nil
+  "Setting to non-nil will silence some of the message")
+
+
 (defun jdee-compile-update-class-list ()
   (let ((class-dir
 	 (if (string= jdee-compile-option-directory "")
@@ -192,12 +196,14 @@ describing how the compilation finished."
 	   (jdee-normalize-path
 	    jdee-compile-option-directory
 	    'jdee-compile-option-directory))))
-    (message (concat "Updating class list for " class-dir))
+    (unless jdee-compile-mute
+      (message (concat "Updating class list for " class-dir)))
     (jdee-jeval (concat
 		"jde.util.JdeUtilities.updateClassList(\""
 		class-dir
-	       "\");"))
-    (message "Updating class list...done.")))
+                "\");"))
+    (unless jdee-compile-mute
+      (message "Updating class list...done."))))
 
 (defun jdee-compile-finish-update-class-info (buf msg)
   "Flush the classinfo cache and update the class list used by
@@ -211,7 +217,8 @@ don't know which classes were recompiled."
 	    (progn
 	      (setq jdee-complete-last-compiled-class (jdee-parse-get-buffer-class))
 	      (jdee-complete-flush-classes-in-cache (list jdee-complete-last-compiled-class))
-	      (message "Flushed completion cache.")
+              (unless jdee-compile-mute
+                (message "Flushed completion cache."))
 	      (setq jdee-complete-last-compiled-class nil)
 	      (jdee-compile-update-class-list))))
     (error nil)))
@@ -1490,6 +1497,7 @@ uses the compiler executable specified by
 
 
 
+    
 (provide 'jdee-compile)
 
 ;;; jdee-compile.el ends here

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -60,6 +60,8 @@
     (when (slot-boundp compiler 'interactive-args)
       (oset this interactive-args (oref compiler interactive-args)))))
 
+(defun jdee-flycheck-unmute (&rest _)
+  (set 'jdee-compile-mute nil))
     
 (defmethod jdee-compile-compile ((this jdee-flycheck-compiler))
 
@@ -69,7 +71,9 @@
   (with-current-buffer (oref (oref this buffer) buffer)
     (add-hook 'jdee-compile-finish-hook
               (oref this post-fn)
-              nil t))
+              nil t)
+    (add-hook 'jdee-compile-finish-hook 'jdee-flycheck-unmute t))
+  
 
 
   ;; Pop to compilation buffer.
@@ -136,6 +140,7 @@
         (kill-buffer temp-buffer)
         ;;(kill-buffer buf)
         (set (make-local-variable 'jdee-compile-jump-to-first-error) nil)
+        (set 'jdee-compile-mute t)
         ;(message "ERRORS: %s" errors)
         (funcall cback 'finished errors)))))
 
@@ -213,15 +218,17 @@
 			output)))
     rtnval))
 	
-
-(flycheck-define-generic-checker 'jdee-flycheck-javac-checker
-  "Integrate flycheck with the jdee using javac."
-  :start #'jdee-flycheck-javac-command
-  :modes '(jdee-mode)
+;;;###autoload
+(defun jdee-flycheck-mode ()
+  (flycheck-define-generic-checker 'jdee-flycheck-javac-checker
+    "Integrate flycheck with the jdee using javac."
+    :start #'jdee-flycheck-javac-command
+    :modes '(jdee-mode)
+    )
+  
+  (add-to-list 'flycheck-checkers 'jdee-flycheck-javac-checker)
+  (flycheck-mode)
 )
-
-(add-to-list 'flycheck-checkers 'jdee-flycheck-javac-checker)
-
 (provide 'jdee-flycheck)
 
 ;;; jdee-flycheck.el ends here

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -1,0 +1,216 @@
+;;; -*- lexical-binding: t -*-
+;;; jdee-flycheck.el -- Flycheck mode for jdee
+
+;; Author: Matthew O. Smith <matt@m0smith.com>
+;; Maintainer: Paul Landes <landes <at> mailc dt net>
+;; Keywords: java, tools
+
+;; Copyright (C) 1997, 2000, 2001, 2002, 2003, 2004, 2005 Paul Kinnucan.
+;; Copyright (C) 2009 by Paul Landes
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, US
+;;; Commentary:
+
+
+;;; Code:
+
+
+(require 'flycheck)
+
+
+(defclass jdee-flycheck-compiler (jdee-compile-compiler)()
+  "Compiler used by flycheck")
+
+(defmethod initialize-instance ((this jdee-flycheck-compiler) &rest fields)
+ ;; Call parent initializer.
+
+  (call-next-method)
+
+  (let ((compiler (jdee-compile-get-the-compiler)))
+    (when (slot-boundp compiler 'use-server-p)
+      (oset this use-server-p (oref compiler use-server-p)))
+    (when (slot-boundp compiler 'name)
+      (oset this name (oref compiler name)))
+    (when (slot-boundp compiler 'version)
+      (oset this version (oref compiler version)))
+    (when (slot-boundp compiler 'path)
+      (oset this path (oref compiler path)))
+    (when (slot-boundp compiler 'buffer)
+      (oset this buffer (oref compiler buffer)))
+    (when (slot-boundp compiler 'window)
+      (oset this window (oref compiler window)))
+    (when (slot-boundp compiler 'interactive-args)
+      (oset this interactive-args (oref compiler interactive-args)))))
+
+    
+(defmethod jdee-compile-compile ((this jdee-flycheck-compiler))
+
+  (if (oref this :use-server-p)
+      (oset this buffer (jdee-compile-server-buffer "compilation buffer"))
+    (oset this buffer (jdee-compile-exec-buffer "compilation buffer")))
+
+
+  ;; Pop to compilation buffer.
+  (let* ((outbuf (oref (oref this buffer) buffer)))
+;;    (outwin (display-buffer outbuf)))
+;;    (compilation-set-window-height outwin)
+;;    (oset this :window outwin)
+
+    (if compilation-process-setup-function
+        (funcall compilation-process-setup-function))
+
+    (jdee-compile-launch this)
+
+    (setq compilation-last-buffer outbuf)))
+
+
+(defun jdee-flycheck-javac-command ( checker cback )
+  (message "Calling jdee-flycheck-javac-command")
+  
+  (jdee-flycheck-compile-buffer checker cback)
+
+  )
+
+(defun jdee-flycheck-compile-buffer-error (checker file line col message buffer)
+  "Expects a match with file line message"
+  (flycheck-error-new
+   :buffer buffer
+   :checker checker
+   :filename file
+   :line (string-to-number line)
+   :column col
+   :message message
+   :level 'error))
+
+(defun jdee-flymake-get-col ()
+  "Get the column if the point is looking at spaces and caret"
+  (when (looking-at "\\( *\\)^") 
+     (length (match-string 1))))
+
+(defun jdee-flycheck-compile-buffer-after (checker cback orig-file orig-buffer
+                                                   temp-file temp-buffer)
+  (lambda (buf msg)
+    (with-current-buffer buf
+      (goto-char (point-min))
+      (while (re-search-forward temp-file nil t)
+        (replace-match orig-file))
+      (let ((errors nil))
+        (goto-char (point-min))
+        (while (re-search-forward "^\\(.*\\):\\([0-9]+\\): *error:\\(.*\\)$" nil t)
+          (forward-line 2)
+          (let ((file (match-string 1))
+                (line (match-string 2))
+                (message (match-string 3))
+                ;; jdee-flymake-get-col changes search data; do it last
+                (col (jdee-flymake-get-col)))
+            (add-to-list 'errors
+                         (jdee-flycheck-compile-buffer-error checker
+                                                             file
+                                                             line
+                                                             col
+                                                             message
+                                                             orig-buffer))))
+                                                                   
+        (kill-buffer temp-buffer)
+        ;;(kill-buffer buf)
+        (funcall cback 'finished errors)))))
+
+(defun jdee-flycheck-compile-buffer (checker cback &optional buffer)
+  "Compile the buffer without saving it"
+  (let* ((name (file-name-nondirectory buffer-file-name))
+         (orig-file buffer-file-name)
+         (orig-buffer (or buffer (current-buffer)))
+         (dir (make-temp-file "JDEE" t))
+         (temp-file (expand-file-name name dir)))
+    (with-current-buffer orig-buffer
+      (write-region (point-min) (point-max) temp-file nil :silent))
+    (with-current-buffer (find-file-noselect temp-file)
+      (add-hook 'jdee-compile-finish-hook
+                (jdee-flycheck-compile-buffer-after checker cback
+                                                    orig-file orig-buffer
+                                                    temp-file (current-buffer)) t)
+      (setq compilation-finish-functions
+            (lambda (buf msg)
+              (run-hook-with-args 'jdee-compile-finish-hook buf msg)
+              (setq compilation-finish-functions nil)))
+
+      
+      (jdee-compile-compile (jdee-flycheck-compiler "flycheck")))))
+
+
+
+(defun jdee-flycheck-command-using-server ( checker cback )
+  "Use flycheck to search the current buffer for compiler errrors."
+  (if (not (comint-check-proc "*groovy*"))
+      (funcall cback 'finished nil)
+    (let* ((pom-path malabar-mode-project-file)
+	   (pm  malabar-mode-project-manager)
+	   (buffer (current-buffer))
+	   (func (if (buffer-modified-p) 'malabar-parse-scriptbody-raw 'malabar-parse-script-raw))
+	   (script (if (buffer-modified-p) (buffer-string) (buffer-file-name))))
+      
+      ;;(message "flycheck with func:%s" func) 
+      (funcall func
+       (lambda (_status)
+	 ;(message "%s %s %s" status (current-buffer) url-http-end-of-headers)
+	 (condition-case err
+	     (progn
+	       (goto-char url-http-end-of-headers)
+	       (let ((error-list (jdee-flycheck-error-parser (json-read) checker buffer)))
+		 (kill-buffer (current-buffer))
+		 ;(message "ERROR LIST:%s" error-list)
+		 (with-current-buffer buffer
+		   (funcall cback 'finished error-list))))
+	   (error (let ((msg (error-message-string err)))
+		    (message "flycheck error: %s" msg)
+		    (pop-to-buffer (current-buffer))
+		    (funcall cback 'errored msg)))))
+       pm pom-path script))))
+
+
+
+
+(defun jdee-flycheck-error-new (checker error-info buffer)
+  (flycheck-error-new
+   :buffer buffer
+   :checker checker
+   :filename (buffer-file-name buffer)
+   :line (cdr (assq     'line error-info))
+   :column (cdr (assq   'startColumn error-info))
+   :message (cdr (assq  'message error-info))
+   :level 'error))
+
+   
+
+(defun jdee-flycheck-error-parser (output checker buffer)
+  "Parse errors in OUTPUT which is a JSON array"
+  (let ((rtnval (mapcar (lambda (e)
+			  (jdee-flycheck-error-new checker e buffer))
+			output)))
+    rtnval))
+	
+
+(flycheck-define-generic-checker 'jdee-flycheck-javac-checker
+  "Integrate flycheck with the jdee using javac."
+  :start #'jdee-flycheck-javac-command
+  :modes '(jdee-mode)
+)
+
+(add-to-list 'flycheck-checkers 'jdee-flycheck-javac-checker)
+
+(provide 'jdee-flycheck)
+
+;;; jdee-flycheck.el ends here

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -133,6 +133,7 @@ cleans up after the compilation."
                 (orig-buffer orig-buffer)
                 (temp-file temp-file)
                 (cback cback)
+                (checker checker)
                 (temp-buffer temp-buffer))
     (lambda (buf msg)
       (with-current-buffer buf

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -92,10 +92,7 @@
 
 (defun jdee-flycheck-javac-command ( checker cback )
   ;(message "Calling jdee-flycheck-javac-command")
-  
-  (jdee-flycheck-compile-buffer checker cback)
-
-  )
+  (jdee-flycheck-compile-buffer checker cback))
 
 (defun jdee-flycheck-compile-buffer-error (checker file line col message buffer)
   "Expects a match with file line message"
@@ -153,7 +150,9 @@
          (temp-file (expand-file-name name dir)))
     (with-current-buffer orig-buffer
       (write-region (point-min) (point-max) temp-file nil :silent))
-    (with-current-buffer (find-file-noselect temp-file)
+    (with-current-buffer (generate-new-buffer name)
+      (insert-file-contents-literally temp-file)
+      (setq buffer-file-name temp-file)
       (setq compilation-finish-functions
             (lambda (buf msg)
               (run-hook-with-args 'jdee-compile-finish-hook buf msg)

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -1,4 +1,3 @@
-;;; -*- lexical-binding: t -*-
 ;;; jdee-flycheck.el -- Flycheck mode for jdee
 
 ;; Author: Matthew O. Smith <matt@m0smith.com>

--- a/jdee-flycheck.el
+++ b/jdee-flycheck.el
@@ -128,7 +128,7 @@ for the caret and converts it to a column number.
 Looks for errors and converts then to flycheck errors.  Also
 cleans up after the compilation."
   ;;
-  ;; There are parts of this fiel that break if the entire file is lexically bound.
+  ;; There are parts of this file that break if the entire file is lexically bound.
   (lexical-let ((orig-file orig-file)
                 (orig-buffer orig-buffer)
                 (temp-file temp-file)

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -387,13 +387,6 @@ Return the tag of the method if found, nil otherwise."
 ")
 
 
-(defun jdee-maven-unit-test-finish (buf msg)
-  "Jump somewhere useful"
-  
-    (goto-char (point-min))
-    (when (re-search-forward "T E S T S" nil t)
-      (recenter-top-bottom )
-      (beginning-of-line)))
   
 (defvar jdee-maven-unit-test-finish-hook nil)
 
@@ -413,6 +406,7 @@ With a single prefix C-u, it will skip trying to run a single method.  With a do
          (args (or (jdee-maven-unit-test-run-method-args)
                    (jdee-maven-unit-test-run-class-args)
                    "test"))
+         (compilation-scroll-output 'first-error)
          (compile-buffer (compilation-start (format "%s %s" jdee-maven-program args))))
     (with-current-buffer compile-buffer
       (setq next-error-function 'jdee-maven-unit-test-next-error-function)
@@ -421,7 +415,6 @@ With a single prefix C-u, it will skip trying to run a single method.  With a do
             (run-hook-with-args 'jdee-maven-unit-test-finish-hook buf msg)
             (setq compilation-finish-functions nil)))
 
-      (add-hook 'jdee-maven-unit-test-finish-hook 'jdee-maven-unit-test-finish t)
       (add-to-list 'compilation-error-regexp-alist
                    (list jdee-maven-unit-test-error-regexp
                          'jdee-maven-file nil nil nil

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -122,7 +122,9 @@ relative the maven project dir."
            return (list scope key source-paths runtime-paths sources-file)))
 
 (defun jdee-maven-check-classpath-file (scope classpath-file sources-classpath-file pom-dir)
-  "Check that the CLASSPATH-FILE and SOURCES-CLASSPATH-FILE for the given SOURCE  exist relative to POM-DIR, creating them if they don't.  See `jdee-maven-check-classpath-file*' for more info."
+  "Check that the CLASSPATH-FILE and SOURCES-CLASSPATH-FILE for
+the given SOURCE exist relative to POM-DIR, creating them if they
+don't.  See `jdee-maven-check-classpath-file*' for more info."
   (jdee-maven-check-classpath-file* scope classpath-file pom-dir nil)
   (jdee-maven-check-classpath-file* scope sources-classpath-file pom-dir "sources")
   )
@@ -132,9 +134,13 @@ relative the maven project dir."
 try to load it by calling mvn dependency:build-classpath directly
 with the appropriate arguments.
 
-If there is an error in creating the file, it leaves the maven buffer open so the error can be seen and diagnosed.  See `jdee-maven-dir-scope-map' for the various values of scope and output-file.
+If there is an error in creating the file, it leaves the maven
+buffer open so the error can be seen and diagnosed.  See
+`jdee-maven-dir-scope-map' for the various values of scope and
+output-file.
 
-Returns nil if it is unable to find or create the file, otherwise it returns the full path to the file.
+Returns nil if it is unable to find or create the file, otherwise
+it returns the full path to the file.
 
 SCOPE - the maven scope, probably 'compile or 'test
 
@@ -175,6 +181,8 @@ classpath in a file on disk.  See
 `jdee-maven-dir-scope-map' for how the files are chosen. 
 
 DIR is the directory containing the pom.xml.  If nil, hunt for it."
+
+  ;(message "jdee-maven-from-file-hook: %s" (pwd))
   (let ((pom-dir (or dir (jdee-maven-get-default-directory))))
     (when pom-dir
       (let ((scope-info (jdee-maven-scope-file)))

--- a/jdee-maven.el
+++ b/jdee-maven.el
@@ -39,30 +39,30 @@
 in a maven project.")
 
 (defvar jdee-maven-project-dir nil
-  "*When a buffer is in a maven project, the full path to the project directory, the one with the pom.xml.  It will be set buffer local by the `jdee-maven-hook'.")
+  "When a buffer is in a maven project, the full path to the project directory, the one with the pom.xml.  It will be set buffer local by the `jdee-maven-hook'.")
 
 (defcustom jdee-maven-disabled-p nil
-  "*When nil (default) add maven support to project startup."
+  "When nil (default) add maven support to project startup."
   :group 'jdee-maven
   :type 'boolean)
 
 (defcustom jdee-maven-buildfile "pom.xml"
-  "*Specify the name of the maven project file."
+  "Specify the name of the maven project file."
   :group 'jdee-maven
   :type 'string)
 
 (defcustom jdee-maven-program "mvn"
-  "*Specifies name of ant program/script."
+  "Specifies name of ant program/script."
  :group 'jdee-maven
  :type 'string)
 
 (defcustom jdee-maven-build-phase "package"
-  "*Specifies maven phase to specify when calling Build."
+  "Specifies maven phase to specify when calling Build."
  :group 'jdee-maven
  :type 'string)
 
 (defcustom jdee-maven-artifacts-excluded-from-sources nil
-  "*Specifies a list of artifact IDs to exclude from sources.  Should be added
+  "Specifies a list of artifact IDs to exclude from sources.  Should be added
 to the prj.el with something like:
 
 (jdee-set-variables

--- a/jdee-open-source.el
+++ b/jdee-open-source.el
@@ -313,6 +313,29 @@ you to select one of the interfaces to show."
   buffer.")
 
 
+(defun jdee-open-source-find-file (marker filename directory &rest formats)
+  "See if there is a buffer matching FILENAME that was opened via
+`jdee-find-class-source-file'.  Return that buffer or nil.
+
+This function is designed as :before-until advice for
+`compilation-find-file'.
+"
+  ;; FIXME: If the FILENAME looks like <path to archive>:<path to source>,
+  ;; try and open it
+
+  (let ((buffer (get-file-buffer filename)))
+    (when (and buffer
+               (with-current-buffer buffer
+                 jdee-open-source-archive))
+      buffer)))
+      
+;;
+;; Add support for finding files in archives.
+;;
+(advice-add 'compilation-find-file :before-until  #'jdee-open-source-find-file)
+
+
+
 (defun jdee-find-class-source-file (class)
   "Find the source file for a specified class.
 CLASS is the fully qualified name of the class. This function searchs

--- a/jdee-open-source.el
+++ b/jdee-open-source.el
@@ -343,12 +343,13 @@ This function is designed as :around advice for
 `compilation-find-file'.
 "
 
-  (when (string-match (format "^%s$" (jdee-parse-java-fqn-re)) filename)
-    (let ((path (jdee-find-class-source-file filename)))
-      (cond
-       ((bufferp path) path)
-       ((stringp path) (apply fn marker path directory formats))
-       (t (apply fn marker filename directory formats))))))
+  (if (string-match (format "^%s$" (jdee-parse-java-fqn-re)) filename)
+      (let ((path (jdee-find-class-source-file filename)))
+        (cond
+         ((bufferp path) path)
+         ((stringp path) (apply fn marker path directory formats))
+         (t (apply fn marker filename directory formats))))
+    (apply fn marker filename directory formats)))
 
 
 (advice-add 'compilation-find-file :around  #'jdee-open-source-find-file-of-fqn)

--- a/jdee-open-source.el
+++ b/jdee-open-source.el
@@ -302,6 +302,17 @@ you to select one of the interfaces to show."
 	    (if interface
 		(jdee-show-class-source interface)))))))
 
+(defvar jdee-open-source-archive nil
+  "Will be set to the name of the archive (jar, zip, etc) that is
+  the real source of a buffer.  See `jdee-open-source-resource'
+  and `jdee-find-class-source-file'.")
+
+(defvar jdee-open-source-resource nil
+  "Will be set to the resource path within
+  `jdee-open-source-archive' that is the real source of the
+  buffer.")
+
+
 (defun jdee-find-class-source-file (class)
   "Find the source file for a specified class.
 CLASS is the fully qualified name of the class. This function searchs
@@ -310,7 +321,12 @@ specified by `jdee-sourcepath' for the source file corresponding to
 CLASS. If it finds the source file in a directory, it returns the
 file's path. If it finds the source file in an archive, it returns a
 buffer containing the contents of the file. If this function does not
-find the source for the class, it returns nil."
+find the source for the class, it returns nil.
+
+If CLASS is found in an archive, set both
+`jdee-open-source-archive' and `jdee-open-source-resource' buffer
+local.
+"
   (let* ((outer-class (car (split-string class "[$]")))
          (file (concat
 		(jdee-parse-get-unqualified-name outer-class)
@@ -337,11 +353,14 @@ find the source for the class, it returns nil."
 			    (if (and (numberp exit-status) (= exit-status 0))
 				(progn
 				  (jdee-mode)
+                                  (set (make-local-variable 'jdee-open-source-archive) path)
+                                  (set (make-local-variable 'jdee-open-source-resource) class-file-name)
+
 				  (goto-char (point-min))
 				  (setq buffer-undo-list nil)
 				  (setq buffer-saved-size (buffer-size))
 				  (set-buffer-modified-p nil)
-				  (setq buffer-read-only t)
+                          	  (setq buffer-read-only t)
 				  (throw 'found buffer))
 			      (progn
 				(set-buffer-modified-p nil)

--- a/jdee-open-source.el
+++ b/jdee-open-source.el
@@ -29,6 +29,7 @@
 (require 'jdee-parse)
 (require 'jdee-util)
 (require 'semantic/senator)
+(require 'nadvice)
 
 ;; FIXME: refactor
 (declare-function jdee-expand-wildcards-and-normalize "jdee" (path &optional symbol))

--- a/jdee-parse.el
+++ b/jdee-parse.el
@@ -107,7 +107,32 @@ the type of a class could not be found an it tried to import it")
 	  "."         ;;   - period
 	  (160 . 255) ;;   - accented characters
 	  )))
-"Regular expression that matches any Java symbol.")
+  "Regular expression that matches any Java symbol.")
+
+(defun jdee-parse-java-name-parts-re (&optional sep)
+  " Create a regular expression that will identify java name parts.
+
+Name parts are things like java.util.Map or Map or java/util/Map
+
+Create a match group.
+
+SEP defaults to ."
+  (format "\\([[:alpha:]_$][[:alnum:]_$%s]*\\)" (or sep ".")))
+
+(defun jdee-parse-java-name-part-re ()
+  "Set one match region on the name"
+  (jdee-parse-java-name-parts-re ""))
+
+(defun jdee-parse-java-fqn-re ()
+  "
+Set 3 match regions
+1 - FQN
+2 - package name
+3 - unqualified class name
+"
+  (format "\\(%s[.]%s\\)" (jdee-parse-java-name-parts-re) (jdee-parse-java-name-part-re)))
+
+          
 
 (defun jdee-parse-after-buffer-changed ()
   "Reparse the current buffer after any change.

--- a/jdee-run.el
+++ b/jdee-run.el
@@ -1184,7 +1184,7 @@ to a debugger."
    (jdee-run-vm-1-5 "JDK 1.5 vm")
    (jdee-run-vm-1-6 "JDK 1.6 vm")
    (jdee-run-vm-1-7 "JDK 1.7 vm")
-   (jdee-run-vm-1-8 "JDK 1.8 vm"))
+   (jdee-run-vm-1-8 "JDK 1.8 vm")
    (jdee-run-vm-1-9 "JDK 1.9 vm"))
   "*List of supported virtual machines.")
 

--- a/jdee-run.el
+++ b/jdee-run.el
@@ -1140,6 +1140,28 @@ to a debugger."
 
   (oset this :version "1.6"))
 
+(defclass jdee-run-vm-1-7 (jdee-run-vm-1-6) ()
+  "Represents the JDK 1.7.x vm")
+
+(defmethod initialize-instance ((this jdee-run-vm-1-7) &rest fields)
+  "Constructor for the class representing the JDK 1.7 vm."
+
+  ;; Call parent initializer.
+  (call-next-method)
+
+  (oset this :version "1.7"))
+
+(defclass jdee-run-vm-1-8 (jdee-run-vm-1-7) ()
+  "Represents the JDK 1.8.x vm")
+
+(defmethod initialize-instance ((this jdee-run-vm-1-8) &rest fields)
+  "Constructor for the class representing the JDK 1.8 vm."
+
+  ;; Call parent initializer.
+  (call-next-method)
+
+  (oset this :version "1.8"))
+
 
 
 (defvar jdee-run-virtual-machines
@@ -1149,7 +1171,9 @@ to a debugger."
    (jdee-run-vm-1-3 "JDK 1.3 vm")
    (jdee-run-vm-1-4 "JDK 1.4 vm")
    (jdee-run-vm-1-5 "JDK 1.5 vm")
-   (jdee-run-vm-1-6 "JDK 1.6 vm"))
+   (jdee-run-vm-1-6 "JDK 1.6 vm")
+   (jdee-run-vm-1-7 "JDK 1.7 vm")
+   (jdee-run-vm-1-8 "JDK 1.8 vm"))
   "*List of supported virtual machines.")
 
 (defun jdee-run-get-vm ()

--- a/jdee-run.el
+++ b/jdee-run.el
@@ -1162,6 +1162,17 @@ to a debugger."
 
   (oset this :version "1.8"))
 
+(defclass jdee-run-vm-1-9 (jdee-run-vm-1-8) ()
+  "Represents the JDK 1.9.x vm")
+
+(defmethod initialize-instance ((this jdee-run-vm-1-9) &rest fields)
+  "Constructor for the class representing the JDK 1.9 vm."
+
+  ;; Call parent initializer.
+  (call-next-method)
+
+  (oset this :version "1.9"))
+
 
 
 (defvar jdee-run-virtual-machines
@@ -1174,6 +1185,7 @@ to a debugger."
    (jdee-run-vm-1-6 "JDK 1.6 vm")
    (jdee-run-vm-1-7 "JDK 1.7 vm")
    (jdee-run-vm-1-8 "JDK 1.8 vm"))
+   (jdee-run-vm-1-9 "JDK 1.9 vm"))
   "*List of supported virtual machines.")
 
 (defun jdee-run-get-vm ()

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -63,7 +63,11 @@ qualified name of the class."
 
 (defun jdee-stacktrace-buffer ( clear &optional buffer)
   "Open a buffer to paste a stack trace.  Parses the stack trace
-to allow editting of the source."
+to allow editting of the source.
+
+If called with a prefix, will clear the stake trace buffer.
+
+If a region is active, paste it into the stack trace buffer."
   (interactive "P")
   (let ((buffer (or buffer (current-buffer))))
     (with-current-buffer buffer

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -66,6 +66,7 @@ qualified name).  If not found, return FQN."
 (define-derived-mode jdee-stacktrace-mode compilation-mode "JVM Stack Trace"
   "Major mode for inspecting stack traces.  Expects
 `jdee-sourcepath' to be set appropriately"
+  ;; FIXME: Should be a minor mode 
   (make-local-variable 'compilation-error-regexp-alist)
   (setq compilation-error-regexp-alist
         (list

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -72,7 +72,8 @@ qualified name).  If not found, return FQN."
         (list
          (list
          (jdee-stacktrace-item-re)
-         'jdee-stacktrace-file 6 nil nil
+         1 ;'jdee-stacktrace-file
+         6 nil nil
          1
          '(4 compilation-info-face)
          '(2 compilation-error-face)))))
@@ -94,6 +95,7 @@ If a region is active, paste it into the stack trace buffer."
 	(with-current-buffer (pop-to-buffer  "*JDEE Stack Trace*")
           (when clear (erase-buffer))
 	  (jdee-stacktrace-mode)
+          (make-local-variable 'jdee-sourcepath)
 	  (setq inhibit-read-only t)
 	  (when active
 	    (let ((start (point-max)))

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -53,7 +53,7 @@ qualified name of the class."
         ;; 3 = method
         ;; 4 = file
         ;; 5 = line
-        '(("\tat \\(\\([[:alpha:]_$][[:alnum:]._$]*\\)[.]\\([[:alpha:]_$][[:alnum:]_$]*\\)(\\([[:alnum:].]+\\):\\([0-9]+\\))\\)"
+        '(("\t?at \\(\\([[:alpha:]_$][[:alnum:]._$]*\\)[.]\\([[:alpha:]_$][[:alnum:]_$]*\\)(\\([[:alnum:].]+\\):\\([0-9]+\\))\\)"
            jdee-stacktrace-file 5 nil nil
            1
            (4 compilation-info-face)
@@ -61,16 +61,17 @@ qualified name of the class."
   )
 
 
-(defun jdee-stacktrace-buffer ( &optional buffer)
+(defun jdee-stacktrace-buffer ( clear &optional buffer)
   "Open a buffer to paste a stack trace.  Parses the stack trace
 to allow editting of the source."
-  (interactive)
+  (interactive "P")
   (let ((buffer (or buffer (current-buffer))))
     (with-current-buffer buffer
       (let* ((active (region-active-p))
 	     (beg (if active (region-beginning)))
 	     (end (if active (region-end))))
 	(with-current-buffer (pop-to-buffer  "*JDEE Stack Trace*")
+          (when clear (erase-buffer))
 	  (jdee-stacktrace-mode)
 	  (setq inhibit-read-only t)
 	  (when active

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -1,0 +1,84 @@
+;;; jdee-stacktrace.el --- Support for stacktraces
+
+;; Author: Paul Kinnucan <pkinnucan@attbi.com>
+;; Maintainer: Paul Landes
+;; Keywords: java, tools
+;; URL: http://github.com/jdee-emacs/jdee
+;; Version: 2.4.2
+;; Package-Requires: ((emacs "24.3"))
+
+;; Copyright (C) 1997-2008 Paul Kinnucan.
+;; Copyright (C) 2009 by Paul Landes
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+;;
+;; minimum Emacs version supported is 24.3
+
+;;; Code:
+
+
+(defun jdee-stacktrace-file ()
+  "A function for use in `compilation-error-regexp-alist' as the
+file name.  Expects (match-string 2) to return the fully
+qualified name of the class."
+  (jdee-stacktrace-file* (match-string 2)))
+
+(defun jdee-stacktrace-file* (fqn)
+  "Return the full path to the source file for FQN (fully qualified name).  If not found, return FQN."
+  (let* ((path (save-match-data (jdee-find-class-source-file fqn))))
+    (or path fqn)))
+
+(define-derived-mode jdee-stacktrace-mode compilation-mode "JVM Stack Trace"
+  "Major mode for inspecting stack traces.  Expects
+`jdee-sourcepath' to be set appropriately"
+  (make-local-variable 'compilation-error-regexp-alist)
+  (setq compilation-error-regexp-alist
+        ;; 1 = all
+        ;; 2 = qualified class name
+        ;; 3 = method
+        ;; 4 = file
+        ;; 5 = line
+        '(("\tat \\(\\([[:alpha:]_$][[:alnum:]._$]*\\)[.]\\([[:alpha:]_$][[:alnum:]_$]*\\)(\\([[:alnum:].]+\\):\\([0-9]+\\))\\)"
+           jdee-stacktrace-file 5 nil nil
+           1
+           (4 compilation-info-face)
+           (2 compilation-error-face))))
+  )
+
+
+(defun jdee-stacktrace-buffer ( &optional buffer)
+  "Open a buffer to paste a stack trace.  Parses the stack trace
+to allow editting of the source."
+  (interactive)
+  (let ((buffer (or buffer (current-buffer))))
+    (with-current-buffer buffer
+      (let* ((active (region-active-p))
+	     (beg (if active (region-beginning)))
+	     (end (if active (region-end))))
+	(with-current-buffer (pop-to-buffer  "*JDEE Stack Trace*")
+	  (jdee-stacktrace-mode)
+	  (setq inhibit-read-only t)
+	  (when active
+	    (let ((start (point-max)))
+	      (goto-char start)
+	      (insert-buffer-substring buffer beg end)
+	      (goto-char start))))))))
+
+(provide 'jdee-stacktrace)
+
+;;; jdee-stacktrace.el ends here

--- a/jdee-test.el
+++ b/jdee-test.el
@@ -1,0 +1,73 @@
+;;; jdee-test.el -- Integrated Development Environment for Java.
+
+;; Author: Matthew O. Smith <matt@m0smith.com>
+;; Maintainer: Paul Landes <landes <at> mailc dt net>
+;; Keywords: java, tools
+
+;; Copyright (C) 1997, 1998, 2001, 2002, 2003, 2004, 2005, 2008 Paul Kinnucan.
+;; Copyright (C) 2009 by Paul Landes
+;; Copyright (C) 2006-2007 by Suraj Acharya
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;; This is one of a set of packages that make up the Java Development
+;; Environment (JDE) for Emacs. See the JDE User's Guide for more
+;; information. It includes code for using the Eclipse compiler
+;; originally written by Suraj Acharya.
+
+;; This provides access to unit testing support
+
+;; The latest version of the JDE is available at
+;; <URL:http://jdee.sourceforge.net/>.
+
+;; Please send any comments, bugs, or upgrade requests to
+;; Paul Landes <landes <at> mailc dt net>
+
+;;; Code:
+
+
+(defgroup jdee-test-options nil
+  "JDE Unit Testing Options"
+  :group 'jdee
+  :prefix "jdee-test-option-")
+
+(defcustom jdee-test-function 'jdee-test-function-default
+    "Check if we have the new (21.3+) compile.el.
+Set this to t if you are running an Emacs with the new compile.el
+and want to get slightly better font-locking in the compile
+buffer.  A value of nil will force the use of older style
+compilation-error-regexp.  This variable tries to auto-detect the
+compile.el version by checking if
+`compilation-error-regexp-alist-alist' is defined."
+  :group 'jdee-compile-options
+  :type 'function)
+
+(defun jdee-test-function-default ()
+  "Default unit test function.  
+Currently just tells the user unit testing is not supported"
+  (message "Unit test support is not yet implemented"))
+
+;;;###autoload
+(defun jdee-test-unittest ()
+  "Perform unit test.  Delegates to the function specified by `jdee-test-function'."
+  (interactive)
+  (funcall jdee-test-function))
+
+(provide 'jdee-test)
+
+;;; jdee-test.el ends here

--- a/jdee.el
+++ b/jdee.el
@@ -1080,7 +1080,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 	(list "Browse"
 	      ["Source Files"          jdee-show-speedbar t]
 	      ["Class at Point"        jdee-browse-class-at-point t]
-	      ["Copy Fully Qualifiedf Class Name"        jdee-fqn-to-kill-ring t]
+	      ["Copy Fully Qualified Class Name"        jdee-fqn-to-kill-ring t]
               ["Stack Trace Buffer"        jdee-stacktrace-buffer t]
               )
 	["Check Style"  jdee-checkstyle]

--- a/jdee.el
+++ b/jdee.el
@@ -106,6 +106,7 @@ See also the function `jdee-check-versions'."
    (cons "[?\C-c ?\C-v ?\C-d]" 'jdee-debug)
    (cons "[?\C-c ?\C-v ?\C-f]" 'jdee-find)
    (cons "[?\C-c ?\C-v ?\C-g]" 'jdee-open-class-at-point)
+   (cons "[?\C-c ?\C-v ?*]"    'jdee-copy-qualified-class-name-to-kill-ring)
    (cons "[?\C-c ?\C-v ?\C-k]" 'jdee-bsh-run)
    (cons "[?\C-c ?\C-v ?\C-l]" 'jdee-gen-println)
    (cons "[?\C-c ?\C-v ?\C-n]" 'jdee-help-browse-jdk-doc)
@@ -1074,6 +1075,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 	(list "Browse"
 	      ["Source Files"          jdee-show-speedbar t]
 	      ["Class at Point"        jdee-browse-class-at-point t]
+	      ["Copy Fully Qualified Class Name"        jdee-copy-qualified-class-name-to-kill-ring t]
               )
 	["Check Style"  jdee-checkstyle]
 	(list "Project"
@@ -2210,6 +2212,21 @@ version of speedar is installed."
   (interactive)
   (require 'speedbar)
   (speedbar-frame-mode))
+
+(defun jdee-copy-qualified-class-name-to-kill-ring (mute)
+  "Copy the qualified class name of class containing point to the kill ring.
+Return the fully qualified name."
+  (interactive "P")
+  (let* ((pkg (jdee-db-get-package))
+         (class (or (jdee-db-get-class)
+                    (car (nth 1 (semantic-fetch-tags-fast)))))
+         (rtnval  (if pkg
+                      (format "%s%s" pkg class)
+                    class)))
+    (kill-new rtnval)
+    (unless mute
+      (message "%s added to kill ring" rtnval))
+    rtnval))
 
 (defun jdee-browse-class-at-point ()
   "Displays the class of the object at point in the BeanShell Class

--- a/jdee.el
+++ b/jdee.el
@@ -63,6 +63,7 @@
 (require 'jdee-refactor)
 (require 'jdee-run)
 (require 'jdee-stacktrace)
+(require 'jdee-test)
 (require 'jdee-util)
 (require 'jdee-which-method)
 (require 'jdee-wiz)
@@ -104,6 +105,7 @@ See also the function `jdee-check-versions'."
    (cons "[?\C-c ?\C-v ?\C-a]" 'jdee-run-menu-run-applet)
    (cons "[?\C-c ?\C-v ?\C-b]" 'jdee-build)
    (cons "[?\C-c ?\C-v ?\C-c]" 'jdee-compile)
+   (cons "[?\C-c ?\C-v ?\C-u]" 'jdee-test-unittest)
    (cons "[?\C-c ?\C-v ?\C-d]" 'jdee-debug)
    (cons "[?\C-c ?\C-v ?\C-f]" 'jdee-find)
    (cons "[?\C-c ?\C-v ?\C-g]" 'jdee-open-class-at-point)
@@ -983,6 +985,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 	["Compile"           jdee-compile t]
 	;; ["Run App"           jdee-run (not (jdee-run-application-running-p))]
 	["Run App"           jdee-run t]
+	["Run Unit Test"     jdee-test-unittest t]
 	["Debug App"         jdee-debug t]
 	"-"
 	;;["-"                 ignore nil]

--- a/jdee.el
+++ b/jdee.el
@@ -866,6 +866,10 @@ idle moments.")
 	;; Set up indentation of Java annotations.
 	(jdee-annotations-setup)
 
+        ;; Setup flycheck mode
+        (when (featurep 'flycheck)
+          (require 'jdee-flycheck)
+          (jdee-flycheck-mode))
 
 	;; The next form must be the last executed
 	;; by jdee-mode.

--- a/jdee.el
+++ b/jdee.el
@@ -62,6 +62,7 @@
 (require 'jdee-project-file)
 (require 'jdee-refactor)
 (require 'jdee-run)
+(require 'jdee-stacktrace)
 (require 'jdee-util)
 (require 'jdee-which-method)
 (require 'jdee-wiz)
@@ -107,6 +108,7 @@ See also the function `jdee-check-versions'."
    (cons "[?\C-c ?\C-v ?\C-f]" 'jdee-find)
    (cons "[?\C-c ?\C-v ?\C-g]" 'jdee-open-class-at-point)
    (cons "[?\C-c ?\C-v ?*]"    'jdee-copy-qualified-class-name-to-kill-ring)
+   (cons "[?\C-c ?\C-v ?#]"    'jdee-stacktrace-buffer)
    (cons "[?\C-c ?\C-v ?\C-k]" 'jdee-bsh-run)
    (cons "[?\C-c ?\C-v ?\C-l]" 'jdee-gen-println)
    (cons "[?\C-c ?\C-v ?\C-n]" 'jdee-help-browse-jdk-doc)
@@ -1076,6 +1078,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 	      ["Source Files"          jdee-show-speedbar t]
 	      ["Class at Point"        jdee-browse-class-at-point t]
 	      ["Copy Fully Qualified Class Name"        jdee-copy-qualified-class-name-to-kill-ring t]
+              ["Stack Trace Buffer"        jdee-stacktrace-buffer t]
               )
 	["Check Style"  jdee-checkstyle]
 	(list "Project"

--- a/jdee.el
+++ b/jdee.el
@@ -107,7 +107,7 @@ See also the function `jdee-check-versions'."
    (cons "[?\C-c ?\C-v ?\C-d]" 'jdee-debug)
    (cons "[?\C-c ?\C-v ?\C-f]" 'jdee-find)
    (cons "[?\C-c ?\C-v ?\C-g]" 'jdee-open-class-at-point)
-   (cons "[?\C-c ?\C-v ?*]"    'jdee-copy-qualified-class-name-to-kill-ring)
+   (cons "[?\C-c ?\C-v ?*]"    'jdee-fqn-to-kill-ring)
    (cons "[?\C-c ?\C-v ?#]"    'jdee-stacktrace-buffer)
    (cons "[?\C-c ?\C-v ?\C-k]" 'jdee-bsh-run)
    (cons "[?\C-c ?\C-v ?\C-l]" 'jdee-gen-println)
@@ -1077,7 +1077,7 @@ Does nothing but return nil if `jdee-log-max' is nil."
 	(list "Browse"
 	      ["Source Files"          jdee-show-speedbar t]
 	      ["Class at Point"        jdee-browse-class-at-point t]
-	      ["Copy Fully Qualified Class Name"        jdee-copy-qualified-class-name-to-kill-ring t]
+	      ["Copy Fully Qualifiedf Class Name"        jdee-fqn-to-kill-ring t]
               ["Stack Trace Buffer"        jdee-stacktrace-buffer t]
               )
 	["Check Style"  jdee-checkstyle]
@@ -2216,20 +2216,27 @@ version of speedar is installed."
   (require 'speedbar)
   (speedbar-frame-mode))
 
-(defun jdee-copy-qualified-class-name-to-kill-ring (mute)
-  "Copy the qualified class name of class containing point to the kill ring.
-Return the fully qualified name."
-  (interactive "P")
+(defun jdee-fqn ()
+  "Return the fully qualified class name at point.  If not in a
+class, use the buffer name."
+  (interactive)
   (let* ((pkg (jdee-db-get-package))
          (class (or (jdee-db-get-class)
                     (car (nth 1 (semantic-fetch-tags-fast)))))
          (rtnval  (if pkg
                       (format "%s%s" pkg class)
                     class)))
-    (kill-new rtnval)
-    (unless mute
-      (message "%s added to kill ring" rtnval))
     rtnval))
+
+(defun jdee-fqn-to-kill-ring ()
+  "Copy the qualified class name of class containing point to the kill ring.
+Return the fully qualified name."
+  (interactive)
+  (let* ((fqn (jdee-fqn)))
+    (kill-new fqn)
+    (when (called-interactively-p 'any)
+      (message "%s added to kill ring" fqn))
+    fqn))
 
 (defun jdee-browse-class-at-point ()
   "Displays the class of the object at point in the BeanShell Class


### PR DESCRIPTION
This should be the last big PR I make.  In the future I will try and have a PR for each issue/feature.  This together will make it so working on jdee-server will be much easier.

Changed include:
- Added a basic unit test system with a maven implementation.  It allows jumping directly to the test that failed.  Can run a specific test method. [C-c C-v C-u]
- Added a stacktrace buffer that allows the user to jump to a line in the stacktrace.  
- gh-74: Added flycheck integration.  Is only enabled if flycheck is loaded.  Highlights the syntax errors in the current buffer.
- Copy fully qualified class name bound to [C-c C-v *] which puts the class name in the kill ring.  
- gh62: added summary entries for JDK 1.7 1.8 and 1.9
