### PR TITLE
Fix get FQN when not within the class body

### DIFF
--- a/jdee.el
+++ b/jdee.el
@@ -2229,7 +2229,7 @@ class, use the buffer name."
   (interactive)
   (let* ((pkg (jdee-db-get-package))
          (class (or (jdee-db-get-class)
-                    (car (nth 1 (semantic-fetch-tags-fast)))))
+                    (caar (semantic-find-tags-by-type "class" (current-buffer)))))
          (rtnval  (if pkg
                       (format "%s%s" pkg class)
                     class)))


### PR DESCRIPTION
For gh-87, a simple fix for getting the classname