### PR TITLE
Gh 92 flycheck error

### DIFF
--- a/jdee-checkstyle.el
+++ b/jdee-checkstyle.el
@@ -218,6 +218,7 @@ string describing how the compilation finished."
 		     :documentation
 		     "Window that displays the compilation buffer.")
    (interactive-args :initarg :interactive-args
+                     :initform: nil
 		     :type list
 		     :documentation
 		     "Arguments entered in the minibuffer."))

--- a/jdee-compile.el
+++ b/jdee-compile.el
@@ -724,6 +724,7 @@ If t (or other non-nil non-number) then kill in 2 secs."
 		     :documentation
 		     "Window that displays the compilation buffer.")
    (interactive-args :initarg :interactive-args
+                     :initfom nil
 		     :type list
 		     :documentation
 		     "Arguments entered in the minibuffer.")

--- a/jdee-compile.el
+++ b/jdee-compile.el
@@ -724,7 +724,7 @@ If t (or other non-nil non-number) then kill in 2 secs."
 		     :documentation
 		     "Window that displays the compilation buffer.")
    (interactive-args :initarg :interactive-args
-                     :initfom nil
+                     :initform nil
 		     :type list
 		     :documentation
 		     "Arguments entered in the minibuffer.")


### PR DESCRIPTION
The :interactive-args slots were not initialized until being called.  Setting them to a reasonable default allows things like flycheck to work.  Only impacted the non-server based code.