### PR TITLE
lisp-packages to list-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The project is available in MELPA. To install it do the following:
 ```
 2. Install JDEE from Emacs using its package manager:
 ```
-M-x lisp-packages
+M-x list-packages
 ```
 There select JDEE and install: i x
 


### PR DESCRIPTION
The former did not exist on Emacs 24.5.1, while the latter did just what you expect, shows package list. As of https://www.gnu.org/software/emacs/manual/html_node/emacs/Package-Menu.html