### PR TITLE
patch to workaround a checkstyle bug

### DIFF
--- a/jdee-checkstyle.el
+++ b/jdee-checkstyle.el
@@ -313,7 +313,7 @@ string describing how the compilation finished."
   (let* ((outbuf (oref this :buffer))
 	 (vm-path (oref (jdee-run-get-vm) :path))
 	 (source-file
-	  (concat (file-name-nondirectory buffer-file-name)))
+	  (concat "./" (file-name-nondirectory buffer-file-name)))
 	 (jdee-java-directory
 	  (concat
 	   (jdee-find-jdee-data-directory)


### PR DESCRIPTION
Workaround the checkstyle bug by preceding `./` before the source file to be
checked. Doing so won't introduce any change of semantics from original code.

This pull request is related to issue [58](https://github.com/jdee-emacs/jdee/issues/58#issuecomment-333488926).