### PR TITLE
Remove duplicate `&optional`

### DIFF
--- a/jdee-stat.el
+++ b/jdee-stat.el
@@ -31,7 +31,7 @@
 (require 'jdee-project-file)
 
 ;;;###autoload
-(defun jdee-stat-loc-report (&optional count &optional total-files)
+(defun jdee-stat-loc-report (&optional count total-files)
   "Generates a report showing the number of code, comment,
 javadoc, and blank lines in the current Java source buffer. Optionally
 a total count could be passed to be displayed, as well as the number of

--- a/jdee-wiz.el
+++ b/jdee-wiz.el
@@ -940,7 +940,7 @@ return \"Name\"."
     answer))
 
 
-(defun jdee-wiz-get-get-method(type name &optional staticp &optional class-name)
+(defun jdee-wiz-get-get-method(type name &optional staticp class-name)
   "Returns a string representing a get method"
   (let ((filtered-name (jdee-wiz-get-name name))
 	get (javadoc "") temp temp2)


### PR DESCRIPTION
In Lisp, you only need to specify `&optional` once, and these
duplicates actually prevent these two files from byte-compiling.  You
can read the installation log and find the complaint there.