### PR TITLE
Patch formatting

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,6 @@
-((emacs-lisp-mode . ((indent-tabs-mode . nil))))
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)
+  (lisp-indent-function . lisp-indent-function)))

--- a/beanshell.el
+++ b/beanshell.el
@@ -108,8 +108,8 @@ path). To specify a vm, select Path and enter the
 path to the vm. "
   :group 'bsh
   :type '(choice
-	  (const :tag "Default" :value nil)
-	  (file :tag "Path")))
+          (const :tag "Default" :value nil)
+          (file :tag "Path")))
 
 (defcustom bsh-classpath nil
   "Startup classpath for the BeanShell."
@@ -126,7 +126,7 @@ getting timeout errors no matter how large a value you set, try
 setting this variable to no timeout (nil)."
   :group 'bsh
   :type '(choice (const :tag "No timeout" :value nil)
-		 (number :tag "Length")))
+                 (number :tag "Length")))
 
 ;; (makunbound 'bsh-eval-timeout)
 (defcustom bsh-eval-timeout 30
@@ -138,7 +138,7 @@ no matter how large a value you set, try setting this variable to no
 timeout (nil)."
   :group 'bsh
   :type '(choice (const :tag "No timeout" :value nil)
-		 (number :tag "Length")))
+                 (number :tag "Length")))
 
 (defcustom bsh-vm-args nil
   "*Specify arguments to be passed to the Java vm.
@@ -166,23 +166,23 @@ buffer."
 
 (defclass bsh-buffer ()
   ((buffer-name   :initarg :buffer-name
-		  :initform "*bsh*"
-		  :type string
-		  :documentation
-		  "Name of buffer used to interact with BeanShell process.")
+                  :initform "*bsh*"
+                  :type string
+                  :documentation
+                  "Name of buffer used to interact with BeanShell process.")
    (buffer        :initarg :buffer
-		  :type buffer
-		  :documentation
-		  "Buffer used to interact with BeanShell process.")
+                  :type buffer
+                  :documentation
+                  "Buffer used to interact with BeanShell process.")
 
    (process       :initarg :process
-		  :documentation
-		  "Beanshell process.")
+                  :documentation
+                  "Beanshell process.")
 
    (filter        :initarg :filter
-		  :type function
-		  :documentation
-		  "Function used to propcess buffer output."))
+                  :type function
+                  :documentation
+                  "Function used to propcess buffer output."))
   "Buffer that displays BeanShell output.")
 
 
@@ -214,16 +214,16 @@ buffer."
 
 (defmethod bsh-comint-buffer-exec ((this bsh-comint-buffer) vm vm-args)
   (let ((win32-start-process-show-window t)
-	(w32-start-process-show-window t)
-	(w32-quote-process-args ?\")   ;; Emacs
-	(win32-quote-process-args ?\") ;; XEmacs
-	(windowed-process-io t)
-	(process-connection-type nil)
-	;; XEmacs addition
-	(coding-system-for-read
-	 (if (or (member system-type '(cygwin32 cygwin))
-		 (eq system-type 'windows-nt))
-	     'raw-text-dos)))
+        (w32-start-process-show-window t)
+        (w32-quote-process-args ?\")   ;; Emacs
+        (win32-quote-process-args ?\") ;; XEmacs
+        (windowed-process-io t)
+        (process-connection-type nil)
+        ;; XEmacs addition
+        (coding-system-for-read
+         (if (or (member system-type '(cygwin32 cygwin))
+                 (eq system-type 'windows-nt))
+             'raw-text-dos)))
     (comint-exec (oref this buffer) "bsh"  vm  nil vm-args))
 
   (oset this process (get-buffer-process (oref this buffer)))
@@ -271,50 +271,50 @@ buffer."
   (let ((thisdir default-directory))
     (with-current-buffer (oref this buffer)
       (let ((buf (oref this buffer))
-	    ;; Some or all of these variables may not be defined by
-	    ;; the various versions of compile.el shipped with Emacs
-	    ;; and XEmacs.
-	    (error-regexp-alist
-	     (if (boundp  'compilation-error-regexp-alist)
-		 compilation-error-regexp-alist))
-	    (enter-regexp-alist
-	     (if (boundp 'compilation-enter-directory-regexp-alist)
-		 compilation-enter-directory-regexp-alist))
-	    (leave-regexp-alist
-	     (if (boundp 'compilation-leave-directory-regexp-alist)
-		 compilation-leave-directory-regexp-alist))
-	    (file-regexp-alist
-	     (if (boundp 'compilation-file-regexp-alist)
-		 compilation-file-regexp-alist))
-	    (nomessage-regexp-alist
-	     (if (boundp 'compilation-nomessage-regexp-alist)
-		 compilation-nomessage-regexp-alist))
-	    (parser
-	     (if (boundp 'compilation-parse-errors-function)
-		 compilation-parse-errors-function))
-	    (error-message "No further errors"))
+            ;; Some or all of these variables may not be defined by
+            ;; the various versions of compile.el shipped with Emacs
+            ;; and XEmacs.
+            (error-regexp-alist
+             (if (boundp  'compilation-error-regexp-alist)
+                 compilation-error-regexp-alist))
+            (enter-regexp-alist
+             (if (boundp 'compilation-enter-directory-regexp-alist)
+                 compilation-enter-directory-regexp-alist))
+            (leave-regexp-alist
+             (if (boundp 'compilation-leave-directory-regexp-alist)
+                 compilation-leave-directory-regexp-alist))
+            (file-regexp-alist
+             (if (boundp 'compilation-file-regexp-alist)
+                 compilation-file-regexp-alist))
+            (nomessage-regexp-alist
+             (if (boundp 'compilation-nomessage-regexp-alist)
+                 compilation-nomessage-regexp-alist))
+            (parser
+             (if (boundp 'compilation-parse-errors-function)
+                 compilation-parse-errors-function))
+            (error-message "No further errors"))
 
-	;; In case the compilation buffer is current, make sure we get the
-	;; global values of compilation-error-regexp-alist, etc.
-	(kill-all-local-variables)
+        ;; In case the compilation buffer is current, make sure we get the
+        ;; global values of compilation-error-regexp-alist, etc.
+        (kill-all-local-variables)
 
-	;; Clear out the compilation buffer and make it writable.
-	(setq buffer-read-only nil)
-	(buffer-disable-undo (current-buffer))
-	(erase-buffer)
-	(buffer-enable-undo (current-buffer))
+        ;; Clear out the compilation buffer and make it writable.
+        (setq buffer-read-only nil)
+        (buffer-disable-undo (current-buffer))
+        (erase-buffer)
+        (buffer-enable-undo (current-buffer))
 
-	(compilation-mode)
-	(setq buffer-read-only nil)
+        (compilation-mode)
+        (setq buffer-read-only nil)
 
-	(if (boundp 'compilation-parse-errors-function)
-	    (set (make-local-variable 'compilation-parse-errors-function) parser))
-	(if (boundp 'compilation-error-message)
-	    (set (make-local-variable 'compilation-error-message) error-message))
-	(set (make-local-variable 'compilation-error-regexp-alist)
-	     error-regexp-alist)
+        (if (boundp 'compilation-parse-errors-function)
+            (set (make-local-variable 'compilation-parse-errors-function) parser))
+        (if (boundp 'compilation-error-message)
+            (set (make-local-variable 'compilation-error-message) error-message))
+        (set (make-local-variable 'compilation-error-regexp-alist)
+             error-regexp-alist)
 
-	(dolist (elt `((compilation-enter-directory-regexp-alist
+        (dolist (elt `((compilation-enter-directory-regexp-alist
                         ,enter-regexp-alist)
                        (compilation-leave-directory-regexp-alist
                         ,leave-regexp-alist)
@@ -325,45 +325,45 @@ buffer."
           (if (boundp (car elt))
               (set (make-local-variable (car elt)) (cadr elt))))
 
-	(setq default-directory thisdir)
-	(if (boundp 'compilation-directory-stack)
-	    (setq compilation-directory-stack (list default-directory)))))))
+        (setq default-directory thisdir)
+        (if (boundp 'compilation-directory-stack)
+            (setq compilation-directory-stack (list default-directory)))))))
 
 (defmethod bsh-compilation-buffer-filter ((this bsh-compilation-buffer) proc string)
   "This filter prints out the result of the process without buffering.
 The result is inserted as it comes in the compilation buffer."
   (with-current-buffer (oref this buffer)
     (let ((end-of-result (string-match ".*bsh % " string))
-	  (win (get-buffer-window (oref this buffer)))
-	  output len (status " "))
+          (win (get-buffer-window (oref this buffer)))
+          output len (status " "))
       (save-excursion
-	;;Insert the text, advancing the process marker
-	(goto-char (point-max))
-	(if end-of-result
-	    (progn
-	      (setq output (substring string 0 end-of-result))
-	      (set-buffer-modified-p nil)
+        ;;Insert the text, advancing the process marker
+        (goto-char (point-max))
+        (if end-of-result
+            (progn
+              (setq output (substring string 0 end-of-result))
+              (set-buffer-modified-p nil)
 
-	      ;;Searching backwards for the status code
-	      (while (member status '(" " "\r" "\n"))
-		(setq len (length output))
-		(if (not (= len 0))
-		    (progn
-		      (setq status (substring output (- len 1)))
-		      (setq output (substring output 0 (- len 1))))
-		  (progn
-		    (setq status (buffer-substring (- (point-max) 1)
-						   (point-max)))
-		    (delete-region (- (point-max) 1) (point-max)))))
+              ;;Searching backwards for the status code
+              (while (member status '(" " "\r" "\n"))
+                (setq len (length output))
+                (if (not (= len 0))
+                    (progn
+                      (setq status (substring output (- len 1)))
+                      (setq output (substring output 0 (- len 1))))
+                  (progn
+                    (setq status (buffer-substring (- (point-max) 1)
+                                                   (point-max)))
+                    (delete-region (- (point-max) 1) (point-max)))))
 
-	      (insert output)
-	      (compilation-handle-exit
-	       'exit (string-to-number status)
-	       (if (string= "0" status)
-		   "finished\n"
-		 (format "exited abnormally with code %s\n"
-			 status))))
-	  (insert string)))
+              (insert output)
+              (compilation-handle-exit
+               'exit (string-to-number status)
+               (if (string= "0" status)
+                   "finished\n"
+                 (format "exited abnormally with code %s\n"
+                         status))))
+          (insert string)))
       (if compilation-scroll-output
           (save-selected-window
             (if win
@@ -374,84 +374,84 @@ The result is inserted as it comes in the compilation buffer."
 
 (defclass bsh ()
   ((buffer        :initarg :buffer
-		  :type bsh-comint-buffer
-		  :documentation
-		  "Buffer used to interact with BeanShell process.")
+                  :type bsh-comint-buffer
+                  :documentation
+                  "Buffer used to interact with BeanShell process.")
 
 
    (eval-buffer   :initarg :eval-buffer
-		  :type (or null bsh-buffer)
-		  :initform nil
-		  :documentation
-		  "Buffer used to display evaluation result.")
+                  :type (or null bsh-buffer)
+                  :initform nil
+                  :documentation
+                  "Buffer used to display evaluation result.")
 
    (eval-filter   :initarg :eval-filter
-		  :type function
-		  :documentation
-		  "Function used to capture Lisp output from the BeanShell.")
+                  :type function
+                  :documentation
+                  "Function used to capture Lisp output from the BeanShell.")
 
    (async-filter  :initarg :async-filter
-		  :type function
-		  :documentation
-		  "Function used to capture and evaluate BeanShell Lisp output.")
+                  :type function
+                  :documentation
+                  "Function used to capture and evaluate BeanShell Lisp output.")
 
    (redir-filter  :initarg :redir-filter
-		  :type function
-		  :documentation
-		  "Redirects BeanShell output to eval-buffer.")
+                  :type function
+                  :documentation
+                  "Redirects BeanShell output to eval-buffer.")
 
    (java-expr     :initarg :java-expr
-		  :initform ""
-		  :type string
-		  :documentation
-		  "Last Java expression evaluated in the BeanShell.")
+                  :initform ""
+                  :type string
+                  :documentation
+                  "Last Java expression evaluated in the BeanShell.")
 
    (lisp-output   :initarg :lisp-output
-		  :initform ""
-		  :type string
-		  :documentation
-		  "Lisp output from the BeanShell.")
+                  :initform ""
+                  :type string
+                  :documentation
+                  "Lisp output from the BeanShell.")
 
    (vm            :initarg :vm
-		  :initform "java"
-		  :type string
-		  :documentation
-		  "Path of Java vm used to run the BeanShell.")
+                  :initform "java"
+                  :type string
+                  :documentation
+                  "Path of Java vm used to run the BeanShell.")
 
    (vm-args       :initarg :vm-args
-		  :initform nil
-		  :type list
-		  :documentation
-		  "List of arguments to be passed to the Beanshell vm.")
+                  :initform nil
+                  :type list
+                  :documentation
+                  "List of arguments to be passed to the Beanshell vm.")
 
    (startup-dir   :initarg :startup-dir
-		  :initform ""
-		  :type string
-		  :documentation
-		  "Directory in which to start the BeanShell")
+                  :initform ""
+                  :type string
+                  :documentation
+                  "Directory in which to start the BeanShell")
 
    (cp            :initarg :cp
-		  :type list
-		  :documentation
-		  "Startup classpath for BeanShell")
+                  :type list
+                  :documentation
+                  "Startup classpath for BeanShell")
 
    (jar           :initarg :jar
-		  :initform "bsh.jar"
-		  :type string
-		  :documentation
-		  "Path of the BeanShell jar file.")
+                  :initform "bsh.jar"
+                  :type string
+                  :documentation
+                  "Path of the BeanShell jar file.")
 
    (class-name    :initarg :class-name
-		  :initform "bsh.Interpreter"
-		  :type string
-		  :documentation
-		  "Name of BeanShell class.")
+                  :initform "bsh.Interpreter"
+                  :type string
+                  :documentation
+                  "Name of BeanShell class.")
 
    (separate-error-buffer :initarg :separate-error-buffer
-			  :initform nil
-			  :type boolean
-			  :documentation
-			  "Whether or not to use a separate error buffer."))
+                          :initform nil
+                          :type boolean
+                          :documentation
+                          "Whether or not to use a separate error buffer."))
   "Defines an instance of a BeanShell process.")
 
 (defmethod initialize-instance ((this bsh) &rest fields)
@@ -467,14 +467,14 @@ The result is inserted as it comes in the compilation buffer."
      this eval-filter
      (lambda (process output)
        (with-current-buffer (process-buffer process)
-	 (bsh-snag-lisp-output this-bsh process output))))
+         (bsh-snag-lisp-output this-bsh process output))))
 
     ;; Filter for asynchronous Java statement evaluations.
     (oset
      this async-filter
      (lambda (process output)
        (with-current-buffer (process-buffer process)
-	 (bsh-snag-and-eval-lisp-output this-bsh process output))))
+         (bsh-snag-and-eval-lisp-output this-bsh process output))))
 
     ;; Filter for redirecting result of evaluating an expression to the
     ;; buffer specified by eval-buffer. This is typically used to
@@ -483,7 +483,7 @@ The result is inserted as it comes in the compilation buffer."
      this redir-filter
      (lambda (process output)
        (with-current-buffer (process-buffer process)
-	 (bsh-redirect-eval-output this-bsh process output))))))
+         (bsh-redirect-eval-output this-bsh process output))))))
 
 (defmethod bsh-create-buffer ((this bsh))
   "Creates the buffer used by this beanshell instance."
@@ -503,9 +503,9 @@ to the string form required by the vm."
 (defmethod bsh-running-p ((this bsh))
   "Return t if this instance of a BeanShell is running; otherwise nil"
   (let* ((buffer (oref this buffer))
-	 (process
-	  (if (slot-boundp buffer  'process)
-	      (oref buffer process))))
+         (process
+          (if (slot-boundp buffer  'process)
+              (oref buffer process))))
     (and
      process
      (processp process)
@@ -588,36 +588,36 @@ to the string form required by the vm."
       ;; (if (eq end-of-result 0)
       ;; (accept-process-output process 0 5))
       (if end-of-output
-	(oset
-	 this
-	 lisp-output
-	 (concat (oref this lisp-output) (substring output 0 end-of-output)))
-	(oset this lisp-output (concat (oref this lisp-output) output))
-	(accept-process-output process bsh-eval-timeout 5))))
+        (oset
+         this
+         lisp-output
+         (concat (oref this lisp-output) (substring output 0 end-of-output)))
+        (oset this lisp-output (concat (oref this lisp-output) output))
+        (accept-process-output process bsh-eval-timeout 5))))
 
 (defmethod bsh-detect-java-eval-error ((this bsh) bsh-output)
   (if (string-match "// Error:" bsh-output)
       (if (oref this separate-error-buffer)
-	  (with-current-buffer (get-buffer-create "*Beanshell Error*")
-	    (erase-buffer)
-	    (insert (format "Expression: %s" (oref this java-expr)))
-	    (newline)
-	    (insert (format "Error: %s" bsh-output))
-	    (goto-char (point-min))
-	    (display-buffer (current-buffer))
-	    (error "Beanshell eval error."))
-	(message
-	 "Beanshell expression evaluation error.\n  Expression: %s\n  Error: %s"
-	 (oref this java-expr) bsh-output)
-	(error "Beanshell eval error. See messages buffer for details."))))
+          (with-current-buffer (get-buffer-create "*Beanshell Error*")
+            (erase-buffer)
+            (insert (format "Expression: %s" (oref this java-expr)))
+            (newline)
+            (insert (format "Error: %s" bsh-output))
+            (goto-char (point-min))
+            (display-buffer (current-buffer))
+            (error "Beanshell eval error."))
+        (message
+         "Beanshell expression evaluation error.\n  Expression: %s\n  Error: %s"
+         (oref this java-expr) bsh-output)
+        (error "Beanshell eval error. See messages buffer for details."))))
 
 (defmethod bsh-eval-lisp-output ((this bsh))
   (if (not (string= (oref this lisp-output) ""))
       (cl-flet ((format-error-msg (error-symbols)
                                   (mapconcat (lambda (s) (symbol-name s)) error-symbols " ")))
-	(condition-case eval-error
-	    (eval (read (oref this lisp-output)))
-	  (error
+        (condition-case eval-error
+            (eval (read (oref this lisp-output)))
+          (error
            (message "Error evaluating Lisp result of Java expression evaluation.")
            (message "  Java expression: %s." (oref this java-expr))
            (message "  Java evaluation result: %s." (oref this lisp-output))
@@ -625,7 +625,7 @@ to the string form required by the vm."
            ;; trying to load the byte-compiled file:
            ;;
            ;; (message "  Error from evaluating result as Lisp: %s"
-           ;;	  (mapconcat (lambda (s) (symbol-name s)) eval-error " ")
+           ;;          (mapconcat (lambda (s) (symbol-name s)) eval-error " ")
            (message "  Error from evaluating result as Lisp: %s"
                     (format-error-msg eval-error))
            (error "Error evaluating Java expresson. See *Messages* buffer."))))
@@ -648,8 +648,8 @@ to the string form required by the vm."
     ;; the Beanshell prompt reappears.
     (if (string-match ".*bsh % " output)
        (progn
-	(set-process-filter process (oref (oref this buffer) filter))
-	 (oset this eval-buffer nil)))))
+        (set-process-filter process (oref (oref this buffer) filter))
+         (oset this eval-buffer nil)))))
 
 (defmethod bsh-eval ((this bsh) expr &optional eval-return)
   "Uses the BeanShell Java interpreter to evaluate the Java expression
@@ -669,16 +669,16 @@ expression."
     (process-send-string (oref (oref this buffer) process) (concat expr "\n"))
 
     (if (not (accept-process-output (oref (oref this buffer) process) bsh-eval-timeout))
-	(progn
-	  (set-process-filter (oref (oref this buffer) process) (oref (oref this buffer) filter))
-	  (error "No reply from BeanShell")))
+        (progn
+          (set-process-filter (oref (oref this buffer) process) (oref (oref this buffer) filter))
+          (error "No reply from BeanShell")))
 
     (set-process-filter (oref (oref this buffer) process) (oref (oref this buffer) filter))
 
     (bsh-detect-java-eval-error this (oref this lisp-output))
     ;; (if eval-return (message "Evaluating reply: %s" (oref this lisp-output)))
     (if eval-return
-	(bsh-eval-lisp-output this)
+        (bsh-eval-lisp-output this)
       (oref this lisp-output))))
 
 (defmethod bsh-eval-r ((this bsh) java-statement)
@@ -714,7 +714,7 @@ an instance of a subclass of `bsh-compiler-buffer'."
   (unless (bsh-running-p this)
     (bsh-launch this))
   (let* ((comint-buffer (oref this buffer))
-	 (bsh-process (oref comint-buffer process)))
+         (bsh-process (oref comint-buffer process)))
     (oset this eval-buffer buffer)
     (set-process-filter bsh-process (oref this redir-filter))
     (process-send-string bsh-process expr)))
@@ -727,10 +727,10 @@ an instance of a subclass of `bsh-compiler-buffer'."
   "Get the `bsh' object associated
 with the buffer named BUFFER-NAME."
   (let (bsh-object
-	(buffer (get-buffer buffer-name)))
+        (buffer (get-buffer buffer-name)))
     (if buffer
-	(with-current-buffer buffer
-	  (setq bsh-object bsh-the-bsh)))
+        (with-current-buffer buffer
+          (setq bsh-object bsh-the-bsh)))
     bsh-object))
 
 
@@ -752,11 +752,11 @@ or `bsh-vm' point to a Java vm on your system."
 
    (if bsh-vm
        (cl-assert
-	(or
-	 (executable-find bsh-vm)
-	 (file-exists-p bsh-vm))
-	nil
-	"The vm specified by bsh-vm does not exist: %s." bsh-vm)
+        (or
+         (executable-find bsh-vm)
+         (file-exists-p bsh-vm))
+        nil
+        "The vm specified by bsh-vm does not exist: %s." bsh-vm)
      (cl-assert
       (executable-find (if (eq system-type 'windows-nt) "javaw" "java"))
       nil
@@ -764,39 +764,39 @@ or `bsh-vm' point to a Java vm on your system."
 
 
    (let ((beanshell  (get-bsh "*bsh demo*"))
-	 (demo-script
-	  (concat
-	   "demo() {"
-	     "name = JOptionPane.showInputDialog(\"Enter your name.\");"
-	     "print(\"(message \\\"Your name is \" + name + \"\\\")\");"
-	   "};")
-	 ))
+         (demo-script
+          (concat
+           "demo() {"
+             "name = JOptionPane.showInputDialog(\"Enter your name.\");"
+             "print(\"(message \\\"Your name is \" + name + \"\\\")\");"
+           "};")
+         ))
 
      (if (not beanshell)
-	 (progn
+         (progn
 
-	   ;; Create a BeanShell wrapper object
-	   (setq beanshell (bsh "BeanShell"))
+           ;; Create a BeanShell wrapper object
+           (setq beanshell (bsh "BeanShell"))
 
-	   (oset (oref beanshell buffer) buffer-name "*bsh demo*")
+           (oset (oref beanshell buffer) buffer-name "*bsh demo*")
 
-	   ;; Set the wrapper's jar slot (eieio/CLOS speak for field) to
-	   ;; point to the location of the BeanShell on the user's
-	   ;; system.
-	   (oset beanshell jar (expand-file-name bsh-jar))
+           ;; Set the wrapper's jar slot (eieio/CLOS speak for field) to
+           ;; point to the location of the BeanShell on the user's
+           ;; system.
+           (oset beanshell jar (expand-file-name bsh-jar))
 
-	   ;; Set the wrapper's vm slot to point to the location
-	   ;; of a vm on the user's system. The wrapper's launch
-	   ;; method (see below) uses the specified vm to launch
-	   ;; the BeanShell.
-	   (oset
-	    beanshell
-	    vm
-	    (if bsh-vm
-		(or
-		 (executable-find bsh-vm)
-		 bsh-vm)
-	      (executable-find (if (eq system-type 'windows-nt) "javaw" "java"))))))
+           ;; Set the wrapper's vm slot to point to the location
+           ;; of a vm on the user's system. The wrapper's launch
+           ;; method (see below) uses the specified vm to launch
+           ;; the BeanShell.
+           (oset
+            beanshell
+            vm
+            (if bsh-vm
+                (or
+                 (executable-find bsh-vm)
+                 bsh-vm)
+              (executable-find (if (eq system-type 'windows-nt) "javaw" "java"))))))
 
      (unless (bsh-running-p beanshell)
        (bsh-launch beanshell)
@@ -811,9 +811,9 @@ or `bsh-vm' point to a Java vm on your system."
 
 (defclass bsh-standalone-bsh (bsh)
   ((the-bsh        :type bsh-standalone-bsh
-		   :allocation :class
-		   :documentation
-		   "The single instance of the standalone BeanShell."))
+                   :allocation :class
+                   :documentation
+                   "The single instance of the standalone BeanShell."))
   "BeanShell intended to be used independently of any other
 Emacs package.")
 
@@ -831,11 +831,11 @@ Emacs package.")
 
    (if bsh-vm
        (cl-assert
-	(or
-	 (executable-find bsh-vm)
-	 (file-exists-p bsh-vm))
-	nil
-	"The vm specified by bsh-vm does not exist: %s." bsh-vm)
+        (or
+         (executable-find bsh-vm)
+         (file-exists-p bsh-vm))
+        nil
+        "The vm specified by bsh-vm does not exist: %s." bsh-vm)
      (cl-assert
       (executable-find (if (eq system-type 'windows-nt) "javaw" "java"))
       nil
@@ -849,8 +849,8 @@ Emacs package.")
    vm
    (if bsh-vm
        (or
-	(executable-find bsh-vm)
-	bsh-vm)
+        (executable-find bsh-vm)
+        bsh-vm)
      (executable-find (if (eq system-type 'windows-nt) "javaw" "java"))))
 
   (oset this cp bsh-classpath)
@@ -873,10 +873,10 @@ by Pat Niemeyer."
   "Closes the standalone version of the BeanShell."
   (interactive)
   (let ((bsh
-	 (if (slot-boundp 'bsh-standalone-bsh 'the-bsh)
-	     (oref-default 'bsh-standalone-bsh the-bsh))))
+         (if (slot-boundp 'bsh-standalone-bsh 'the-bsh)
+             (oref-default 'bsh-standalone-bsh the-bsh))))
     (if (and bsh (bsh-running-p bsh))
-	(bsh-kill-process bsh)
+        (bsh-kill-process bsh)
       (message "The beanshell is not running"))))
 
 
@@ -902,13 +902,13 @@ by Pat Niemeyer."
   "Display BeanShell User's Guide."
   (interactive)
   (let* ((jdee-dir (jdee-find-jdee-doc-directory))
-	 (bsh-help
-	  (if jdee-dir
-	      (expand-file-name "doc/html/bsh-ug/bsh-ug.html" jdee-dir))))
+         (bsh-help
+          (if jdee-dir
+              (expand-file-name "doc/html/bsh-ug/bsh-ug.html" jdee-dir))))
     (if (and
-	 bsh-help
-	 (file-exists-p bsh-help))
-	(browse-url (concat "file://" bsh-help))
+         bsh-help
+         (file-exists-p bsh-help))
+        (browse-url (concat "file://" bsh-help))
       (signal 'error '("Cannot find BeanShell help file.")))))
 
 (defcustom bsh-script-menu-definition

--- a/efc.el
+++ b/efc.el
@@ -37,18 +37,18 @@
   "If non-nil the function to use for interactively querying options.
 If nil then the default efc custom-based dialogs will be used."
   :type '(choice :tag "Options Query Function"
-		 (const :tag "Dialog" efc-query-options-function-dialog)
-		 (const :tag "Mini-Buffer" efc-query-options-function-minibuf)
-		 (function :tag "Specify Function"
-			   efc-query-options-function-dialog))
+                 (const :tag "Dialog" efc-query-options-function-dialog)
+                 (const :tag "Mini-Buffer" efc-query-options-function-minibuf)
+                 (function :tag "Specify Function"
+                           efc-query-options-function-dialog))
   :group 'jdee)
 
 (defun efc-query-options-function-dialog (options prompt title history default)
   (let ((dialog
-	 (efc-option-dialog
-	  (or title "option dialog")
-	  :text (or prompt "Select option:")
-	  :options options)))
+         (efc-option-dialog
+          (or title "option dialog")
+          :text (or prompt "Select option:")
+          :options options)))
     (efc-dialog-show dialog)
     (oref dialog selection)))
 
@@ -56,10 +56,10 @@ If nil then the default efc custom-based dialogs will be used."
   (let (sel)
     ;; efc doesn't add the end colon
     (setq prompt (format "%s%s"
-			 (or prompt "Select option")
-			 (if default
-			     (format " (default %s): " default)
-			   ": ")))
+                         (or prompt "Select option")
+                         (if default
+                             (format " (default %s): " default)
+                           ": ")))
     (setq sel (completing-read prompt options nil t nil history default))
     (if (= (length sel) 0) (error "Input required"))
     sel))
@@ -73,18 +73,18 @@ If nil then the default efc custom-based dialogs will be used."
 
 (defclass efc-dialog ()
   ((title     :initarg :title
-	      :type string
-	      :initform "Dialog"
-	      :documentation
-	      "Title of dialog")
+              :type string
+              :initform "Dialog"
+              :documentation
+              "Title of dialog")
    (buf       :initarg :buf
-	      :type buffer
-	      :documentation
-	      "Dialog buffer")
+              :type buffer
+              :documentation
+              "Dialog buffer")
    (initbuf   :initarg :initbuf
-	      :type buffer
-	      :documentation
-	      "Buffer from which dialog was called.")
+              :type buffer
+              :documentation
+              "Buffer from which dialog was called.")
    )
   "Super class of EFC dialogs."
   )
@@ -156,19 +156,19 @@ default method kills the dialog buffer."
 
 (defclass efc-option-dialog (efc-dialog)
   ((options        :initarg :options
-		   :documentation
-		   "Options from from which to choose.")
+                   :documentation
+                   "Options from from which to choose.")
    (radio-buttons  :initarg :radio-buttons
-		   :documentation
-		   "Buttons for selecting options.")
+                   :documentation
+                   "Buttons for selecting options.")
    (text           :initarg :text
-		   :type string
-		   :initform "Select option."
-		   :documentation
-		   "Text to be inserted at top of dialog.")
+                   :type string
+                   :initform "Select option."
+                   :documentation
+                   "Text to be inserted at top of dialog.")
    (selection      :initarg :selection
-		   :documentation
-		   "Option chosen by the user."))
+                   :documentation
+                   "Option chosen by the user."))
    "This dialog allows a user to choose one of a set of OPTIONS by clicking
 a radio button next to the option. The dialog sets SELECTION to the option
 chosen by the user when the user selects the OK button on the dialog. This
@@ -182,16 +182,16 @@ dialog uses recursive edit to emulate a modal dialog.")
   (widget-insert (oref this text))
   (widget-insert "\n\n")
   (oset this radio-buttons
-	(widget-create
-	 (list
-	  'radio-button-choice
-	  :value (car (oref this options))
-	  :dialog this
-	  :notify (lambda (button &rest ignore)
-		    (efc-dialog-ok (widget-get button :dialog)))
-	  :args (mapcar
-		 (lambda (x) (list 'item x))
-		 (oref this options)))))
+        (widget-create
+         (list
+          'radio-button-choice
+          :value (car (oref this options))
+          :dialog this
+          :notify (lambda (button &rest ignore)
+                    (efc-dialog-ok (widget-get button :dialog)))
+          :args (mapcar
+                 (lambda (x) (list 'item x))
+                 (oref this options)))))
   (widget-insert "\n"))
 
 (defmethod efc-dialog-show ((this efc-option-dialog))
@@ -209,8 +209,8 @@ an option or canceled the dialog. See `efc-dialog-ok' and
 dialog. Sets the :selection field of THIS to the option chosen by the
 user, kills the dialog buffer, and exits recursive-edit mode."
   (oset this
-	selection
-	(widget-value (oref this radio-buttons)))
+        selection
+        (widget-value (oref this radio-buttons)))
   (delete-window)
   (set-buffer (oref this initbuf))
   (pop-to-buffer (oref this initbuf))
@@ -238,10 +238,10 @@ and then exits recursive edit mode."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass efc-multi-option-dialog (efc-option-dialog)
   ((build-message :initarg :text
-		  :type string
-		  :initform "Building Dialog"
-		  :documentation
-		  "Warning message while building dialog, as this can be slow"))
+                  :type string
+                  :initform "Building Dialog"
+                  :documentation
+                  "Warning message while building dialog, as this can be slow"))
   "Provides a dialog with several sets of OPTIONS.
 The dialog sets SELECTION to the options selected by the user.")
 
@@ -255,31 +255,31 @@ The dialog sets SELECTION to the options selected by the user.")
   (widget-insert "\n\n")
   ;; use radio buttons slot as list of radio buttons rather than.
   (oset this radio-buttons
-	(mapcar
-	 (lambda(list)
-	   (prog1
-	       (widget-create
-		(list
-		 'radio-button-choice
-		 :value
-		 (efc-multi-option-dialog-default this list)
-		 :args (mapcar
-			(lambda (x)
-			  (list 'item x))
-			list)))
-	     (widget-insert "\n")))
-	 (efc-multi-option-dialog-sort this
-				       (oref this options))))
+        (mapcar
+         (lambda(list)
+           (prog1
+               (widget-create
+                (list
+                 'radio-button-choice
+                 :value
+                 (efc-multi-option-dialog-default this list)
+                 :args (mapcar
+                        (lambda (x)
+                          (list 'item x))
+                        list)))
+             (widget-insert "\n")))
+         (efc-multi-option-dialog-sort this
+                                       (oref this options))))
   (widget-insert "\n")
   (message "%s...done" (oref this text)))
 
 (defmethod efc-dialog-ok((this efc-multi-option-dialog))
   ;; set the selection up as a list rather a simple result
   (oset this selection
-	(mapcar
-	 (lambda(widget)
-	   (widget-value widget))
-	 (oref this radio-buttons)))
+        (mapcar
+         (lambda(widget)
+           (widget-value widget))
+         (oref this radio-buttons)))
   (delete-window)
   (set-buffer (oref this initbuf))
   (pop-to-buffer (oref this initbuf))
@@ -296,9 +296,9 @@ The dialog sets SELECTION to the options selected by the user.")
   "Sort the options."
   ;; sort the ones with the most options first...
   (sort list
-	(lambda(a b)
-	  (> (length a)
-	     (length b)))))
+        (lambda(a b)
+          (> (length a)
+             (length b)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -309,22 +309,22 @@ The dialog sets SELECTION to the options selected by the user.")
 
 (defclass efc-compiler ()
   ((name             :initarg :name
-		     :type string
-		     :documentation "Compiler name.")
+                     :type string
+                     :documentation "Compiler name.")
    (buffer           :initarg :buffer
-		     :type buffer
-		     :documentation
-		     "Compilation buffer")
+                     :type buffer
+                     :documentation
+                     "Compilation buffer")
    (window           :initarg :window
-		     :type window
-		     :documentation
-		     "Window that displays the compilation buffer.")
+                     :type window
+                     :documentation
+                     "Window that displays the compilation buffer.")
    (exec-path        :initarg :exec-path
-		     :type string
-		     :documentation "Path of compiler executable.")
+                     :type string
+                     :documentation "Path of compiler executable.")
    (comp-finish-fcn  :initarg :comp-finish-fcn
-		     :type function
-		     :documentation "\
+                     :type function
+                     :documentation "\
 A list of function to invoke at end of compilation.  Each
 function is called with two arguments: the compilation buffer,
 and a string describing how the process finished."))
@@ -334,15 +334,15 @@ and a string describing how the process finished."))
   "Create a buffer to display the output of a compiler process."
   (save-excursion
     (let ((buf (get-buffer-create (format "*%s*" (oref this name))))
-	  (error-regexp-alist compilation-error-regexp-alist)
-	  (enter-regexp-alist (if (boundp 'compilation-enter-directory-regexp-alist)
-				  compilation-enter-directory-regexp-alist))
-	  (leave-regexp-alist (if (boundp 'compilation-leave-directory-regexp-alist)
-				  compilation-leave-directory-regexp-alist))
-	  (file-regexp-alist (if (boundp 'compilation-file-regexp-alist)
-				 compilation-file-regexp-alist))
-	  (error-message "No further errors")
-	  (thisdir default-directory))
+          (error-regexp-alist compilation-error-regexp-alist)
+          (enter-regexp-alist (if (boundp 'compilation-enter-directory-regexp-alist)
+                                  compilation-enter-directory-regexp-alist))
+          (leave-regexp-alist (if (boundp 'compilation-leave-directory-regexp-alist)
+                                  compilation-leave-directory-regexp-alist))
+          (file-regexp-alist (if (boundp 'compilation-file-regexp-alist)
+                                 compilation-file-regexp-alist))
+          (error-message "No further errors")
+          (thisdir default-directory))
 
       (oset this :buffer buf)
 
@@ -351,17 +351,17 @@ and a string describing how the process finished."))
       ;; Make sure a compiler process is not
       ;; already running.
       (let ((compiler-proc (get-buffer-process (current-buffer))))
-	(if compiler-proc
-	    (if (or (not (eq (process-status compiler-proc) 'run))
-		    (yes-or-no-p
+        (if compiler-proc
+            (if (or (not (eq (process-status compiler-proc) 'run))
+                    (yes-or-no-p
                      (format "A %s process is running; kill it?" (oref this name))))
-		(condition-case ()
-		    (progn
-		      (interrupt-process compiler-proc)
-		      (sit-for 1)
-		      (delete-process compiler-proc))
-		  (error nil))
-	      (error "Cannot have two processes in `%s' at once"
+                (condition-case ()
+                    (progn
+                      (interrupt-process compiler-proc)
+                      (sit-for 1)
+                      (delete-process compiler-proc))
+                  (error nil))
+              (error "Cannot have two processes in `%s' at once"
                      (buffer-name)))))
 
       ;; In case the compiler buffer is current, make sure we get the global
@@ -377,9 +377,9 @@ and a string describing how the process finished."))
       (setq buffer-read-only nil)
 
       (if (boundp 'compilation-error-message)
-	  (set (make-local-variable 'compilation-error-message) error-message))
+          (set (make-local-variable 'compilation-error-message) error-message))
       (set (make-local-variable 'compilation-error-regexp-alist)
-	   error-regexp-alist)
+           error-regexp-alist)
 
       (dolist (elt `((compilation-enter-directory-regexp-alist
                       ,enter-regexp-alist)
@@ -391,12 +391,12 @@ and a string describing how the process finished."))
             (set (make-local-variable (car elt)) (cl-second elt))))
 
       (if (slot-boundp this 'comp-finish-fcn)
-	  (set (make-local-variable 'compilation-finish-functions)
-	       (oref this comp-finish-fcn)))
+          (set (make-local-variable 'compilation-finish-functions)
+               (oref this comp-finish-fcn)))
 
       (if (boundp 'compilation-directory-stack)
-	  (setq default-directory thisdir
-		compilation-directory-stack (list default-directory))))))
+          (setq default-directory thisdir
+                compilation-directory-stack (list default-directory))))))
 
 (defmethod get-args ((this efc-compiler))
   "Get a list of command-line arguments to pass to the
@@ -417,32 +417,32 @@ compiler process.")
       (funcall compilation-process-setup-function))
 
   (let* ((outbuf (oref this :buffer))
-	 (executable-path (oref this exec-path))
-	 (args (get-args this)))
+         (executable-path (oref this exec-path))
+         (args (get-args this)))
 
     (with-current-buffer outbuf
 
       (insert (format "cd %s\n" default-directory))
 
       (insert (concat
-	       executable-path
-	       " "
-	       (mapconcat 'identity args " ")
-	       "\n\n"))
+               executable-path
+               " "
+               (mapconcat 'identity args " ")
+               "\n\n"))
 
       (let* ((process-environment (cons "EMACS=t" process-environment))
-	     (w32-quote-process-args ?\")
-	     (win32-quote-process-args ?\") ;; XEmacs
-	     (proc (apply 'start-process
-			  (downcase mode-name)
-			  outbuf
-			  executable-path
-			  args)))
-	(set-process-sentinel proc 'compilation-sentinel)
-	(set-process-filter proc 'compilation-filter)
-	(set-marker (process-mark proc) (point) outbuf)
-	(setq compilation-in-progress
-	      (cons proc compilation-in-progress)))
+             (w32-quote-process-args ?\")
+             (win32-quote-process-args ?\") ;; XEmacs
+             (proc (apply 'start-process
+                          (downcase mode-name)
+                          outbuf
+                          executable-path
+                          args)))
+        (set-process-sentinel proc 'compilation-sentinel)
+        (set-process-filter proc 'compilation-filter)
+        (set-marker (process-mark proc) (point) outbuf)
+        (setq compilation-in-progress
+              (cons proc compilation-in-progress)))
 
       (set-buffer-modified-p nil)
       (setq compilation-last-buffer (oref this :buffer)))))
@@ -456,9 +456,9 @@ compiler process.")
 
 (defclass efc-collection ()
   ((elem-type :initarg :elem-type
-	      :type (or null symbol)
-	      :initform nil
-	      :documentation "Type of element that this collection contains."))
+              :type (or null symbol)
+              :initform nil
+              :documentation "Type of element that this collection contains."))
   "A collection of objects. The collection can be either homogeneous, i.e.,
 composed of elements of one type, or heterogeneous. The ELEM-TYPE property of
 a heterogeneous collection is nil.")
@@ -469,7 +469,7 @@ type-compatible with a collection if the collection is heterogeneous or
 the item's type is the same as the collection's element type."
   (let ((element-type (oref this elem-type)))
     (or (eq element-type nil)
-	(cl-typep item element-type))))
+        (cl-typep item element-type))))
 
 (defmethod efc-coll-iterator ((this efc-collection))
   "Returns an iterator for this collection."
@@ -527,9 +527,9 @@ is an object of efc-visitor class."
 
 (defclass efc-list (efc-collection)
   ((items  :initarg :items
-	   :type list
-	   :initform nil
-	   :documentation "List of items."))
+           :type list
+           :initform nil
+           :documentation "List of items."))
   "List of items.")
 
 (defmethod initialize-instance ((this efc-list) &rest fields)
@@ -541,7 +541,7 @@ is an object of efc-visitor class."
   (if (efc-coll-type-compatible-p this item)
       (oset this items (append (oref this items) (list item)))
     (error "Tried to add an item of type %s to a list of items of type %s"
-	   (type-of item) (oref this elem-type))))
+           (type-of item) (oref this elem-type))))
 
 (defmethod efc-coll-iterator ((this efc-list))
   "Return an iterator for this list."
@@ -563,10 +563,10 @@ is an object of efc-visitor class."
 
 (defclass efc-list-iterator (efc-iterator)
   ((list-obj :initarg :list-obj
-	     :type efc-list
-	     :documentation "List that this iterator iterates.")
+             :type efc-list
+             :documentation "List that this iterator iterates.")
    (list     :type list
-	     :documentation "Lisp list."))
+             :documentation "Lisp list."))
   "Iterates over a list.")
 
 (defmethod initialize-instance ((this efc-list-iterator) &rest fields)
@@ -583,7 +583,7 @@ is an object of efc-visitor class."
 (defmethod efc-iter-next ((this efc-list-iterator))
   "Get next item in the list."
   (let* ((list (oref this list))
-	 (next (car list)))
+         (next (car list)))
     (oset this list (cdr list))
     next))
 
@@ -649,7 +649,7 @@ already contain the item."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass efc-hash-table (efc-collection)
   ((table :type hash-table
-	  :documentation "Lisp table object."))
+          :documentation "Lisp table object."))
   "Hash table.")
 
 
@@ -663,7 +663,7 @@ already contain the item."
   (if (efc-coll-type-compatible-p this value)
       (puthash key value (oref this table))
     (error "Tried to add an item of type %s to a hash table of items of type %s"
-	   (type-of value) (oref this elem-type))))
+           (type-of value) (oref this elem-type))))
 
 (defmethod efc-coll-get ((this efc-hash-table) key)
   "Get an item from the table."
@@ -682,11 +682,11 @@ of efc-visitor class."
   (efc-list-iterator
    "hash table iterator"
    :list-obj (let (values)
-	       (maphash
-		(lambda (key value)
-		  (setq values (append values (list value))))
-		(oref this table))
-	       values)))
+               (maphash
+                (lambda (key value)
+                  (setq values (append values (list value))))
+                (oref this table))
+               values)))
 
 (provide 'efc)
 

--- a/jcomplete.el
+++ b/jcomplete.el
@@ -57,16 +57,16 @@ resulting list. It impliciyly adds the java.lang.* package."
     (goto-char (point-min))
     (let (lst first second)
       (while (not (null
-		   (re-search-forward "import[ \t\n\r]+\\(\\([a-zA-Z0-9]+[.]\\)+\\)\\([*]\\|[a-zA-Z0-9]+\\)" nil t) ))
-	(setq first (match-string 1))
-	(setq second (match-string 3))
-	(if (string= "*" second)
-	    (setq lst (append lst
-			      (list (list first second))))
-	  (setq lst (append (list (list first second))
-			    lst))))
+                   (re-search-forward "import[ \t\n\r]+\\(\\([a-zA-Z0-9]+[.]\\)+\\)\\([*]\\|[a-zA-Z0-9]+\\)" nil t) ))
+        (setq first (match-string 1))
+        (setq second (match-string 3))
+        (if (string= "*" second)
+            (setq lst (append lst
+                              (list (list first second))))
+          (setq lst (append (list (list first second))
+                            lst))))
       (if (not (member "java.lang.*" lst))
-	  (setq lst (append lst (list (list "java.lang." "*")))))
+          (setq lst (append lst (list (list "java.lang." "*")))))
       lst)))
 
 (defun prf2-valid-java-declaration-at (point varname)
@@ -87,15 +87,15 @@ name, it just returns the type as it is declared."
 (save-excursion
     (let (found res pos orgpt resname)
       (while (and (not found)
-		  (search-backward name nil t))
-	(setq pos (point))
-	(backward-word 1)
-	(setq resname (prf2-valid-java-declaration-at (point) name))
-	(goto-char pos)
-	(forward-char -1)
-	(if (not (null resname))
-	    (progn (setq res resname)
-		   (setq found t))))
+                  (search-backward name nil t))
+        (setq pos (point))
+        (backward-word 1)
+        (setq resname (prf2-valid-java-declaration-at (point) name))
+        (goto-char pos)
+        (forward-char -1)
+        (if (not (null resname))
+            (progn (setq res resname)
+                   (setq found t))))
     res)))
 
 (defun prf2-filter-fqn (importlist)
@@ -105,8 +105,8 @@ so that it can stops at the first package import (with a star `*' at
 the end of the declaration)."
   (if (not (null importlist))
       (if (string= "*" (car (cdr (car importlist))))
-	  importlist
-	(prf2-filter-fqn (cdr importlist)))))
+          importlist
+        (prf2-filter-fqn (cdr importlist)))))
 
 
 
@@ -123,11 +123,11 @@ packages otherwise."
       (setq fullname (concat (car tmp) name))
       (cond
        ((string= "*" shortname)
-	(setq result importlist))
+        (setq result importlist))
        ((string= name shortname)
-	(setq result fullname))
+        (setq result fullname))
        (t
-	(setq importlist (cdr importlist)))))
+        (setq importlist (cdr importlist)))))
     result))
 
 (defun prf2-get-classinfo (name)
@@ -137,11 +137,11 @@ possible completion, and the cdr gives additional informations on the
 car."
   (let ((guessed (prf2-guess-type-of name)) result)
     (if (stringp guessed)
-	(setq result (jdee-backend-get-class-info guessed))
+        (setq result (jdee-backend-get-class-info guessed))
       (if (not (null name))
-	  (setq result (jdee-backend-get-class-info-for-import name guessed))))
+          (setq result (jdee-backend-get-class-info-for-import name guessed))))
     (if (not (null result))
-	(eval (read result))
+        (eval (read result))
       nil)))
 
 (defun prf2-java-variable-at-point ()
@@ -150,36 +150,36 @@ A '.' is  part of a name."
   (interactive)
   (save-excursion
     (let (start varname curcar found
-		(original-point (point))
-		intermediate-point beg-point)
+                (original-point (point))
+                intermediate-point beg-point)
       (setq curcar (char-before))
       (while (null found)
-	(cond
-	 ((or (and (>= curcar ?a) (<= curcar ?z))
+        (cond
+         ((or (and (>= curcar ?a) (<= curcar ?z))
               (and (>= curcar ?A) (<= curcar ?Z))
               (member curcar '(?_)))
-	  (forward-char -1))
-	 ((eq ?. curcar)
-	  (setq found (point)))
-	 (t
-	  (setq found t)))
-	(setq curcar (char-before)))
+          (forward-char -1))
+         ((eq ?. curcar)
+          (setq found (point)))
+         (t
+          (setq found t)))
+        (setq curcar (char-before)))
       ;;
       (setq intermediate-point (point))
       (if (not (eq t found))
-	  (progn
-	    (setq curcar (char-before))
-	    (while (or (and (>= curcar ?a) (<= curcar ?z))
-		       (and (>= curcar ?A) (<= curcar ?Z))
-		       (member curcar '(?. ?_)))
-	      (forward-char -1)
-	      (setq curcar (char-before)))
-	    (setq beg-point (point))
-	    (set-marker prf2-current-beginning intermediate-point)
-	    (set-marker prf2-current-end original-point)
-	    (list (buffer-substring beg-point (- intermediate-point 1))
-		  (buffer-substring intermediate-point original-point)))
-	nil))))
+          (progn
+            (setq curcar (char-before))
+            (while (or (and (>= curcar ?a) (<= curcar ?z))
+                       (and (>= curcar ?A) (<= curcar ?Z))
+                       (member curcar '(?. ?_)))
+              (forward-char -1)
+              (setq curcar (char-before)))
+            (setq beg-point (point))
+            (set-marker prf2-current-beginning intermediate-point)
+            (set-marker prf2-current-end original-point)
+            (list (buffer-substring beg-point (- intermediate-point 1))
+                  (buffer-substring intermediate-point original-point)))
+        nil))))
 
 (defun prf2-build-completion-list (classinfo)
   "Build a completion list from the CLASSINFO list, as returned by the
@@ -194,9 +194,9 @@ jdee-backend-get-class-info function."
     (setq tmp (nth 2 classinfo))
     (while (not (null tmp))
       (setq result (append (list (list (concat (car (car tmp))"(")
-				       (prf2-build-information-for-completion (car tmp))
-				       ;; (car tmp)
-				       )) result))
+                                       (prf2-build-information-for-completion (car tmp))
+                                       ;; (car tmp)
+                                       )) result))
       (setq tmp (cdr tmp)))
     result))
 
@@ -207,7 +207,7 @@ jdee-backend-get-class-info function."
       (setq result (concat result (car lst)))
       (setq lst (cdr lst))
       (if (not (null lst))
-	  (setq result (concat result ", "))))
+          (setq result (concat result ", "))))
     (setq result (concat result ")"))
     result))
 
@@ -216,12 +216,12 @@ jdee-backend-get-class-info function."
   (let (elem)
     (setq prf2-current-list-index (+ 1 prf2-current-list-index))
     (if (>= prf2-current-list-index (length prf2-current-list))
-	(setq prf2-current-list-index 0))
+        (setq prf2-current-list-index 0))
     (setq elem (nth prf2-current-list-index prf2-current-list))
     (if (not (null (car elem)))
-	(progn
-	  (delete-region prf2-current-beginning prf2-current-end)
-	  (insert (car elem))))
+        (progn
+          (delete-region prf2-current-beginning prf2-current-end)
+          (insert (car elem))))
     (set-marker prf2-current-end (+ (marker-position prf2-current-beginning) (length (car elem))))
     (message (car (cdr elem)))
   ;;  (goto-char (marker-position prf2-current-end))
@@ -231,7 +231,7 @@ jdee-backend-get-class-info function."
   (let ((result nil))
     (while (not (null lst))
       (if (equal 0 (string-match pat (car (car lst))))
-	  (setq result (append (list (car lst)) result)))
+          (setq result (append (list (car lst)) result)))
       (setq lst (cdr lst)))
     result))
 
@@ -239,29 +239,29 @@ jdee-backend-get-class-info function."
 "Smart-complete the method at point."
   (interactive)
     (if (and
-	 (not (null prf2-current-list))
-	 (markerp prf2-current-beginning)
-	 (markerp prf2-current-end)
-	 (marker-position prf2-current-beginning)
-	 (marker-position prf2-current-end)
-	 (>= (point) (marker-position prf2-current-beginning))
-	 (<= (point) (marker-position prf2-current-end))
-	 (eq last-command this-command))
-	(progn
-	  (prf2-complete-cycle))
+         (not (null prf2-current-list))
+         (markerp prf2-current-beginning)
+         (markerp prf2-current-end)
+         (marker-position prf2-current-beginning)
+         (marker-position prf2-current-end)
+         (>= (point) (marker-position prf2-current-beginning))
+         (<= (point) (marker-position prf2-current-end))
+         (eq last-command this-command))
+        (progn
+          (prf2-complete-cycle))
       (let* ((pair (prf2-java-variable-at-point))
-	     txt classinfo fulllist
-	     )
-	(if (not (null pair))
-	    (progn
-	      (setq classinfo (prf2-get-classinfo (prf2-declared-type-of (car pair))))
-	      (setq fulllist (prf2-build-completion-list classinfo))
-	      (setq prf2-current-list (prf2-all-completions (car (cdr pair)) fulllist))
-	      (setq prf2-current-list-index -1)
-	      (prf2-complete-cycle))
-	  (progn
-	    (setq prf2-current-list nil)
-	    (message "No completion at this point."))))))
+             txt classinfo fulllist
+             )
+        (if (not (null pair))
+            (progn
+              (setq classinfo (prf2-get-classinfo (prf2-declared-type-of (car pair))))
+              (setq fulllist (prf2-build-completion-list classinfo))
+              (setq prf2-current-list (prf2-all-completions (car (cdr pair)) fulllist))
+              (setq prf2-current-list-index -1)
+              (prf2-complete-cycle))
+          (progn
+            (setq prf2-current-list nil)
+            (message "No completion at this point."))))))
 
 
 ;;

--- a/jdee-activator.el
+++ b/jdee-activator.el
@@ -45,19 +45,19 @@ If the activated buffer is a Java buffer, runs the
     (unless (equal curr-buff jdee-current-buffer)
       (setq jdee-current-buffer curr-buff)
       (if (eq major-mode 'jdee-mode)
-	  (condition-case err
-	      (run-hooks 'jdee-entering-java-buffer-hook)
-	    (error
-	     (message "jdee-entering-java-buffer-hook error: %s"
-		      (error-message-string err))))))))
+          (condition-case err
+              (run-hooks 'jdee-entering-java-buffer-hook)
+            (error
+             (message "jdee-entering-java-buffer-hook error: %s"
+                      (error-message-string err))))))))
 
 (defun jdee-monitor-post-command-hook ()
   "Check whether `post-command-hook' includes all hooks required by JDEE.
 If not, it adds the required hooks."
   (if (eq major-mode 'jdee-mode)
       (dolist (hook (list 'jdee-detect-java-buffer-activation))
-	(when (not (member hook post-command-hook))
-	  (add-hook 'post-command-hook hook)))))
+        (when (not (member hook post-command-hook))
+          (add-hook 'post-command-hook hook)))))
 
 (defun jdee-count-open-java-buffers ()
   "Return non-nil if any Java buffers are open."
@@ -68,7 +68,7 @@ If not, it adds the required hooks."
    (lambda (file-type buffer)
      (let ((file-name (buffer-file-name buffer)))
        (if file-name
-	   (save-match-data
+           (save-match-data
              (string-match file-type file-name)))))))
 
 (defun jdee-clean-up-after-jde ()
@@ -76,11 +76,11 @@ If not, it adds the required hooks."
 all Java source buffers have been closed."
   (if (eq major-mode 'jdee-mode)
       (unless  (> (jdee-count-open-java-buffers) 1)
-	(remove-hook 'post-command-hook 'jdee-detect-java-buffer-activation)
-	(when jdee-monitor-post-command-hook-timer
-	  (cancel-timer jdee-monitor-post-command-hook-timer)
-	  (setq jdee-monitor-post-command-hook-timer nil))
-	(remove-hook 'kill-buffer-hook 'jdee-clean-up-after-jde))))
+        (remove-hook 'post-command-hook 'jdee-detect-java-buffer-activation)
+        (when jdee-monitor-post-command-hook-timer
+          (cancel-timer jdee-monitor-post-command-hook-timer)
+          (setq jdee-monitor-post-command-hook-timer nil))
+        (remove-hook 'kill-buffer-hook 'jdee-clean-up-after-jde))))
 
 (defun jdee-activator-init ()
   "Setup jdee-mode activation and deactivation in Java buffers."

--- a/jdee-annotations.el
+++ b/jdee-annotations.el
@@ -41,12 +41,12 @@
   "Find the offset entry for SYMBOL and add OFFSET at the front of the list.
 See `c-set-offset' for a description of OFFSET and SYMBOL."
   (let ((old-offset (cdr-safe (or (assq symbol c-offsets-alist)
-				  (assq symbol (get 'c-offsets-alist
-						      'c-stylevar-fallback))))))
+                                  (assq symbol (get 'c-offsets-alist
+                                                      'c-stylevar-fallback))))))
     (if old-offset
-	(if (listp old-offset)
-	    (c-set-offset symbol (cons offset old-offset))
-	  (c-set-offset symbol (list offset old-offset)))
+        (if (listp old-offset)
+            (c-set-offset symbol (cons offset old-offset))
+          (c-set-offset symbol (list offset old-offset)))
       (c-set-offset symbol offset))))
 
 (defun jdee-annotations-setup ()
@@ -70,15 +70,15 @@ during this traversal, this function only sees whitespaces
 followed by either a '@' or a '(' then it returns t."
   (save-excursion
     (condition-case err ;; return nil if  any errors are thrown by forward-sexp
-	(let* ((lim (1- (c-point 'bol)))
-	       (throws (catch 'notAnno
-		     (goto-char (cdr langelem))
-		     (while (< (point) lim)
-		       (if (not (looking-at "\\(\\s \\|\n\\)*\\(@\\|(\\)"))
-			   (throw 'notAnno t))
-		       (forward-sexp 1)))))
-	  (if (not throws)
-	      t)))))
+        (let* ((lim (1- (c-point 'bol)))
+               (throws (catch 'notAnno
+                     (goto-char (cdr langelem))
+                     (while (< (point) lim)
+                       (if (not (looking-at "\\(\\s \\|\n\\)*\\(@\\|(\\)"))
+                           (throw 'notAnno t))
+                       (forward-sexp 1)))))
+          (if (not throws)
+              t)))))
 
 (defun c-no-indent-after-java-annotations (langelem)
   "If preceeded by java annotations, indent this line the same as the previous.
@@ -131,12 +131,12 @@ Works with arglist-intro.
 
 Indents as
 @RequestForEnhancement(
-    id	     = 2868724,
+    id             = 2868724,
 ...
 
 instead of
 @RequestForEnhancement(
-		       id	     = 2868724,
+                       id             = 2868724,
 ...
 
 Argument LANGELEM The language element being indented."

--- a/jdee-ant.el
+++ b/jdee-ant.el
@@ -109,10 +109,10 @@ ways. The first is via the ant script/program that comes with ant.
 The second is via java and the third is via the Ant Server."
   :group 'jdee-ant
   :type '(list
-	   (radio-button-choice
-	     (const "Script")
-	     (const "Java")
-	     (const "Ant Server"))))
+           (radio-button-choice
+             (const "Script")
+             (const "Java")
+             (const "Ant Server"))))
 
 (defcustom jdee-ant-home ""
   "*Directory where ant is installed."
@@ -217,8 +217,8 @@ option has no effect if jdee-ant-read-target is nil."
   :type 'string)
 
 (defcustom jdee-ant-build-hook '(jdee-compile-finish-kill-buffer
-				jdee-compile-finish-refresh-speedbar
-				jdee-compile-finish-update-class-info)
+                                jdee-compile-finish-refresh-speedbar
+                                jdee-compile-finish-update-class-info)
   "*List of hook functions run by `jdee-ant-build' (see `run-hooks'). Each
 function should accept two arguments: the compilation buffer and a string
 describing how the compilation finished"
@@ -243,58 +243,58 @@ the Ant home from the environment variable ANT_HOME."
     (setq buildfile jdee-ant-buildfile))
 
   (let* ((ant-home (jdee-ant-get-ant-home))
-	 (delimiter (if (or
-			 (string= (car jdee-ant-invocation-method) "Java")
-			 (string= (car jdee-ant-invocation-method) "Script"))
-			"'"
-		      "\""))
-	 (classpath-delimiter  (if (and (or (eq system-type 'windows-nt)
+         (delimiter (if (or
+                         (string= (car jdee-ant-invocation-method) "Java")
+                         (string= (car jdee-ant-invocation-method) "Script"))
+                        "'"
+                      "\""))
+         (classpath-delimiter  (if (and (or (eq system-type 'windows-nt)
                                             (eq system-type 'cygwin32))
                                         (s-matches? "sh$" shell-file-name))
                                    delimiter))
-	 (buildfile-delimiter  (if (eq system-type 'windows-nt)
-				   "\"" delimiter))
-	 (ant-program (if (or (s-matches? "\\\\" jdee-ant-program)
-			      (s-matches? "/" jdee-ant-program))
-			  (jdee-normalize-path jdee-ant-program)
-			jdee-ant-program))
-	 (ant-command
-	  (concat
-	   (if (string= (car jdee-ant-invocation-method) "Script") ant-program)
-	   (if (string= (car jdee-ant-invocation-method) "Java")
-	       (concat
-		(jdee-get-jdk-prog 'java)
-		" -classpath "
-		classpath-delimiter
-		(jdee-ant-build-classpath)
-		classpath-delimiter))
-	   (if ant-home
-	       (concat
-		" -Dant.home="
-		(if (s-matches? " " ant-home) ; Quote paths with spaces
-		    (concat "\"" ant-home "\"")
-		  ant-home)))
+         (buildfile-delimiter  (if (eq system-type 'windows-nt)
+                                   "\"" delimiter))
+         (ant-program (if (or (s-matches? "\\\\" jdee-ant-program)
+                              (s-matches? "/" jdee-ant-program))
+                          (jdee-normalize-path jdee-ant-program)
+                        jdee-ant-program))
+         (ant-command
+          (concat
+           (if (string= (car jdee-ant-invocation-method) "Script") ant-program)
+           (if (string= (car jdee-ant-invocation-method) "Java")
+               (concat
+                (jdee-get-jdk-prog 'java)
+                " -classpath "
+                classpath-delimiter
+                (jdee-ant-build-classpath)
+                classpath-delimiter))
+           (if ant-home
+               (concat
+                " -Dant.home="
+                (if (s-matches? " " ant-home) ; Quote paths with spaces
+                    (concat "\"" ant-home "\"")
+                  ant-home)))
            (if (string= (car jdee-ant-invocation-method) "Java")
                (concat
                 " "
                 "org.apache.tools.ant.Main")))))
 
     (if (not (string= buildfile ""))
-	(setq ant-command
-	      (concat ant-command
-		      " -buildfile " buildfile-delimiter
-		      (jdee-normalize-path buildfile)
-		      buildfile-delimiter)))
+        (setq ant-command
+              (concat ant-command
+                      " -buildfile " buildfile-delimiter
+                      (jdee-normalize-path buildfile)
+                      buildfile-delimiter)))
 
     (if (not (string= jdee-ant-args ""))
-	(setq ant-command (concat ant-command " " jdee-ant-args)))
+        (setq ant-command (concat ant-command " " jdee-ant-args)))
 
     (if (and (not (null more-args))
-	     (not (string= more-args "")))
-	(setq ant-command (concat ant-command " " more-args)))
+             (not (string= more-args "")))
+        (setq ant-command (concat ant-command " " more-args)))
 
     (if (not (string= target ""))
-	(setq ant-command (concat ant-command " " target " ")))
+        (setq ant-command (concat ant-command " " target " ")))
 
     ant-command))
 
@@ -303,29 +303,29 @@ the Ant home from the environment variable ANT_HOME."
 classpath normalized with `jdee-build-classpath'."
 
   (let* ((ant-home (jdee-ant-get-ant-home))
-	 classpath)
+         classpath)
 
     (setq classpath (append (list (expand-file-name "lib" ant-home)
-				  (jdee-get-tools-jar))
-			    jdee-ant-user-jar-files))
+                                  (jdee-get-tools-jar))
+                            jdee-ant-user-jar-files))
 
     ;; silence the compiler
     ;; TODO: remove this boundp and require 'jdee after resolving jde
     ;; compilation warnings
     (with-no-warnings
       (when jdee-ant-use-global-classpath
-	(setq classpath (append classpath jdee-global-classpath))))
+        (setq classpath (append classpath jdee-global-classpath))))
 
     (jdee-build-classpath classpath)))
 
 (defun jdee-ant-get-ant-home ()
   "Calculate an appropriate ant home."
   (let ((ant-home
-	 (if (string= jdee-ant-home "")
-	     (getenv "ANT_HOME")
-	   jdee-ant-home)))
+         (if (string= jdee-ant-home "")
+             (getenv "ANT_HOME")
+           jdee-ant-home)))
     (if ant-home
-	(jdee-normalize-path ant-home))))
+        (jdee-normalize-path ant-home))))
 
 (defun jdee-ant-interactive-get-buildfile ()
   "Get a buildfile interactively.  This is used so that code that needs to read
@@ -335,44 +335,44 @@ classpath normalized with `jdee-build-classpath'."
   (let (buildfile)
 
     (if jdee-ant-read-buildfile
-	;;read the buildfile from the user.
+        ;;read the buildfile from the user.
 
-	;;figure out which directory to execute from.
-	(let (prompt-directory prompt-filename)
+        ;;figure out which directory to execute from.
+        (let (prompt-directory prompt-filename)
 
-	  (if jdee-ant-interactive-buildfile
-	      (progn
-		(setq prompt-directory
-		      (file-name-directory jdee-ant-interactive-buildfile))
-		(setq prompt-filename
-		      (file-name-nondirectory jdee-ant-interactive-buildfile)))
+          (if jdee-ant-interactive-buildfile
+              (progn
+                (setq prompt-directory
+                      (file-name-directory jdee-ant-interactive-buildfile))
+                (setq prompt-filename
+                      (file-name-nondirectory jdee-ant-interactive-buildfile)))
 
-	    (setq prompt-directory (jdee-ant-get-default-directory))
-	    (setq prompt-filename ""))
+            (setq prompt-directory (jdee-ant-get-default-directory))
+            (setq prompt-filename ""))
 
-	  (setq buildfile
-		(read-file-name "Buildfile: " prompt-directory nil t
-				prompt-filename))))
+          (setq buildfile
+                (read-file-name "Buildfile: " prompt-directory nil t
+                                prompt-filename))))
     (if (or (and jdee-ant-enable-find (not jdee-ant-read-buildfile)) ;enable only
-	    (and jdee-ant-enable-find jdee-ant-read-buildfile
-		 (or (null buildfile)   ;no buildfile
-		     (string= "" buildfile)
-		     (and (file-exists-p buildfile) ;buildfile is a directory
-			  (file-directory-p buildfile)))))
-	(progn
-	  (setq buildfile (jdee-ant-find-build-file
-			   (jdee-ant-get-default-directory)))
+            (and jdee-ant-enable-find jdee-ant-read-buildfile
+                 (or (null buildfile)   ;no buildfile
+                     (string= "" buildfile)
+                     (and (file-exists-p buildfile) ;buildfile is a directory
+                          (file-directory-p buildfile)))))
+        (progn
+          (setq buildfile (jdee-ant-find-build-file
+                           (jdee-ant-get-default-directory)))
 
-	  (when (null buildfile)
-	    (error "Could not find Ant build file"))
+          (when (null buildfile)
+            (error "Could not find Ant build file"))
 
-	  (when (not (file-exists-p buildfile))
-	    (error "File does not exist %s " buildfile))))
+          (when (not (file-exists-p buildfile))
+            (error "File does not exist %s " buildfile))))
 
     (if (and (not jdee-ant-enable-find)
-	     (not jdee-ant-read-buildfile))
-	;;use the default buildfile.
-	(setq buildfile (jdee-normalize-path jdee-ant-buildfile)))
+             (not jdee-ant-read-buildfile))
+        ;;use the default buildfile.
+        (setq buildfile (jdee-normalize-path jdee-ant-buildfile)))
     buildfile))
 
 ;;;###autoload
@@ -381,40 +381,40 @@ classpath normalized with `jdee-build-classpath'."
   user for certain variables.."
   (interactive
    (let* ((buildfile (jdee-ant-interactive-get-buildfile))
-	  (build-history (jdee-ant-get-from-history buildfile))
-	  (targets
-	   (if jdee-ant-read-target
-	       (if jdee-ant-complete-target
-		   (if (fboundp 'completing-read-multiple)
-		       (completing-read-multiple
-			"Target to build: "
-			(jdee-ant-get-target-alist buildfile)
-			nil
-			nil
-			(car build-history)
-			'build-history)
-		     (list (completing-read
-			    "Target to build: "
-			    (jdee-ant-get-target-alist buildfile)
-			    nil
-			    t
-			    (car build-history)
-			    'build-history)))
-		 (list (read-from-minibuffer
-			"Target to build: "
-			(car build-history)
-			nil
-			nil
-			'build-history)))))
-	  (target
-	   (jdee-ant-escape (mapconcat 'identity targets " ")))
-	  (interactive-args
-	   (if jdee-ant-read-args
-	       (read-from-minibuffer
-		"Additional build args: "
-		(nth 0 jdee-ant-interactive-args-history)
-		nil nil
-		'(jdee-ant-interactive-args-history . 1)))))
+          (build-history (jdee-ant-get-from-history buildfile))
+          (targets
+           (if jdee-ant-read-target
+               (if jdee-ant-complete-target
+                   (if (fboundp 'completing-read-multiple)
+                       (completing-read-multiple
+                        "Target to build: "
+                        (jdee-ant-get-target-alist buildfile)
+                        nil
+                        nil
+                        (car build-history)
+                        'build-history)
+                     (list (completing-read
+                            "Target to build: "
+                            (jdee-ant-get-target-alist buildfile)
+                            nil
+                            t
+                            (car build-history)
+                            'build-history)))
+                 (list (read-from-minibuffer
+                        "Target to build: "
+                        (car build-history)
+                        nil
+                        nil
+                        'build-history)))))
+          (target
+           (jdee-ant-escape (mapconcat 'identity targets " ")))
+          (interactive-args
+           (if jdee-ant-read-args
+               (read-from-minibuffer
+                "Additional build args: "
+                (nth 0 jdee-ant-interactive-args-history)
+                nil nil
+                '(jdee-ant-interactive-args-history . 1)))))
 
 
      ;; Setting the history for future use
@@ -432,8 +432,8 @@ classpath normalized with `jdee-build-classpath'."
      (list buildfile target interactive-args)))
 
   (let ((compile-command
-	 (jdee-build-ant-command target interactive-args buildfile))
-	process-connection-type)
+         (jdee-build-ant-command target interactive-args buildfile))
+        process-connection-type)
 
     (when compile-command
       ;; Force save-some-buffers to use the minibuffer
@@ -443,29 +443,29 @@ classpath normalized with `jdee-build-classpath'."
       ;; which seems not to be supported--at least on
       ;; the PC.
       (if (eq system-type 'windows-nt)
-	  (let ((temp last-nonmenu-event))
-	    ;; The next line makes emacs think that the command
-	    ;; was invoked from the minibuffer, even when it
-	    ;; is actually invoked from the menu-bar.
-	    (setq last-nonmenu-event t)
-	    (save-some-buffers (not compilation-ask-about-save) nil)
-	    (setq last-nonmenu-event temp))
-	(save-some-buffers (not compilation-ask-about-save) nil))
+          (let ((temp last-nonmenu-event))
+            ;; The next line makes emacs think that the command
+            ;; was invoked from the minibuffer, even when it
+            ;; is actually invoked from the menu-bar.
+            (setq last-nonmenu-event t)
+            (save-some-buffers (not compilation-ask-about-save) nil)
+            (setq last-nonmenu-event temp))
+        (save-some-buffers (not compilation-ask-about-save) nil))
 
       (setq compilation-finish-functions
-	    (lambda (buf msg)
-	      (run-hook-with-args 'jdee-ant-build-hook buf msg)
-	      (setq compilation-finish-functions nil)))
+            (lambda (buf msg)
+              (run-hook-with-args 'jdee-ant-build-hook buf msg)
+              (setq compilation-finish-functions nil)))
 
       (if (string= (car jdee-ant-invocation-method) "Ant Server")
-	  (progn
-	    (while (string-match "\"" compile-command)
-	      (setq compile-command (replace-match "" nil nil
-						   compile-command)))
-	    (jdee-ant-compile-internal compile-command
+          (progn
+            (while (string-match "\"" compile-command)
+              (setq compile-command (replace-match "" nil nil
+                                                   compile-command)))
+            (jdee-ant-compile-internal compile-command
                                        "No more errors"))
-	(let ((default-directory (jdee-ant-get-default-directory)))
-	  (compilation-start compile-command))))))
+        (let ((default-directory (jdee-ant-get-default-directory)))
+          (compilation-start compile-command))))))
 
 (defvar jdee-ant-comint-filter nil)
 
@@ -473,26 +473,26 @@ classpath normalized with `jdee-build-classpath'."
   "Looks for \ characters and escape them, i.e. \\"
   (if (not (null target))
       (let (temp c)
-	(while (not (string= target ""))
-	  (setq c (substring target 0 1))
-	  (if (string= c "\\")
-	      (setq temp (concat temp c)))
-	  (setq temp (concat temp c))
-	  (setq target (substring target 1)))
-	temp)))
+        (while (not (string= target ""))
+          (setq c (substring target 0 1))
+          (if (string= c "\\")
+              (setq temp (concat temp c)))
+          (setq temp (concat temp c))
+          (setq target (substring target 1)))
+        temp)))
 
 (defun jdee-ant-compile-internal (command error-message)
   "This method displays ant output in a compilation buffer.
 error-message is a string to print if the user asks to see another error
 and there are no more errors. "
   (let* (error-regexp-alist
-	 enter-regexp-alist
-	 leave-regexp-alist
-	 file-regexp-alist
-	 nomessage-regexp-alist
-	 outbuf)
+         enter-regexp-alist
+         leave-regexp-alist
+         file-regexp-alist
+         nomessage-regexp-alist
+         outbuf)
 
-    (save-excursion				       ;;getting or creating
+    (save-excursion                                       ;;getting or creating
       (setq outbuf (get-buffer-create "*compilation*"));;the compilation buffer
       (set-buffer outbuf) ;;setting the compilation buffer
 
@@ -569,42 +569,42 @@ and there are no more errors. "
 The result is inserted as it comes in the compilation buffer."
   (let ((compilation-buffer (get-buffer "*compilation*")))
     (if (not (null compilation-buffer))
-	(with-current-buffer compilation-buffer
-	  (let ((stack-trace
-		 (string-match "java.lang.SecurityException" string))
-		(end-of-result (string-match ".*bsh % " string))
-		(win (get-buffer-window "*compilation*")))
+        (with-current-buffer compilation-buffer
+          (let ((stack-trace
+                 (string-match "java.lang.SecurityException" string))
+                (end-of-result (string-match ".*bsh % " string))
+                (win (get-buffer-window "*compilation*")))
 
-	    (save-excursion
-	      ;;Insert the text, advancing the process marker
-	      (goto-char (point-max))
+            (save-excursion
+              ;;Insert the text, advancing the process marker
+              (goto-char (point-max))
 
-	      ;;if the security exception has been thrown set the
-	      ;;jdee-ant-passed-security-exception flag and filter the stack
-	      ;;trace out of the ouput
-	      (if stack-trace
-		  (progn
-		    (setq jdee-ant-passed-security-exception t)
-		    (insert (substring string 0 stack-trace))
-		    (set-buffer-modified-p nil)
-		    (compilation-mode)
-		    (jdee-ant-set-build-status (buffer-string))
-		    (jdee-ant-handle-exit)))
+              ;;if the security exception has been thrown set the
+              ;;jdee-ant-passed-security-exception flag and filter the stack
+              ;;trace out of the ouput
+              (if stack-trace
+                  (progn
+                    (setq jdee-ant-passed-security-exception t)
+                    (insert (substring string 0 stack-trace))
+                    (set-buffer-modified-p nil)
+                    (compilation-mode)
+                    (jdee-ant-set-build-status (buffer-string))
+                    (jdee-ant-handle-exit)))
 
-	      (if end-of-result
-		  (progn
-		    (if (not jdee-ant-passed-security-exception)
-			(progn
-			  (insert (substring string 0 end-of-result))
-			  (set-buffer-modified-p nil)
-			  (compilation-mode)
-			  (jdee-ant-set-build-status (buffer-string))
-			  (jdee-ant-handle-exit)))
-		    (set-process-filter proc jdee-ant-comint-filter)))
-	      (if (and (not end-of-result)
-		       (not jdee-ant-passed-security-exception))
-		  (insert string)))
-	    (if compilation-scroll-output
+              (if end-of-result
+                  (progn
+                    (if (not jdee-ant-passed-security-exception)
+                        (progn
+                          (insert (substring string 0 end-of-result))
+                          (set-buffer-modified-p nil)
+                          (compilation-mode)
+                          (jdee-ant-set-build-status (buffer-string))
+                          (jdee-ant-handle-exit)))
+                    (set-process-filter proc jdee-ant-comint-filter)))
+              (if (and (not end-of-result)
+                       (not jdee-ant-passed-security-exception))
+                  (insert string)))
+            (if compilation-scroll-output
                 (save-selected-window
                   (if win
                       (progn
@@ -642,13 +642,13 @@ function uses the same rules as `jdee-ant-build' for finding the buildfile."
   "Find the next Ant build file upwards in the directory tree from DIR.
 Returns nil if it cannot find a project file in DIR or an ascendant directory."
   (let ((file (cl-find (cond ((string= jdee-ant-buildfile "") "build.xml")
-			  (t jdee-ant-buildfile))
-		    (directory-files dir) :test 'string=)))
+                          (t jdee-ant-buildfile))
+                    (directory-files dir) :test 'string=)))
 
     (if file
-	(setq file (expand-file-name file dir))
+        (setq file (expand-file-name file dir))
       (if (not (jdee-root-dir-p dir))
-	  (setq file (jdee-ant-find-build-file (concat dir "../")))))
+          (setq file (jdee-ant-find-build-file (concat dir "../")))))
 
     file))
 
@@ -656,14 +656,14 @@ Returns nil if it cannot find a project file in DIR or an ascendant directory."
   "Returns asociation list of valid Ant project targets."
 
   (let ((targets nil )
-	(temp-buf (get-buffer-create "*jdee-ant-get-target-list-temp-buffer*")))
+        (temp-buf (get-buffer-create "*jdee-ant-get-target-list-temp-buffer*")))
     (unwind-protect
-	(with-current-buffer temp-buf
-	  (erase-buffer)
-	  (insert-file-contents buildfile)
-	  (goto-char (point-min))
-	  (while (re-search-forward jdee-ant-target-regexp (point-max) t)
-	    (setq targets (append targets (list (list (match-string 1)))))))
+        (with-current-buffer temp-buf
+          (erase-buffer)
+          (insert-file-contents buildfile)
+          (goto-char (point-min))
+          (while (re-search-forward jdee-ant-target-regexp (point-max) t)
+            (setq targets (append targets (list (list (match-string 1)))))))
       (kill-buffer temp-buf))
 
     targets))
@@ -683,29 +683,29 @@ Returns nil if it cannot find a project file in DIR or an ascendant directory."
 
 (defun jdee-ant-add-to-history (buildfile build-history)
   (let ((temp (nth 0 jdee-ant-interactive-target-history))
-	(index -1) (found nil))
+        (index -1) (found nil))
     (while (and temp (not found))
       (setq index (1+ index))
       (setq temp (nth index jdee-ant-interactive-target-history))
       (if (string= (car temp) buildfile)
-	  (setq found t)))
+          (setq found t)))
     (if found
-	(setcdr temp build-history)
+        (setcdr temp build-history)
       (setq jdee-ant-interactive-target-history
-	    (append
-	     jdee-ant-interactive-target-history
-	     (list (list buildfile (car build-history))))))))
+            (append
+             jdee-ant-interactive-target-history
+             (list (list buildfile (car build-history))))))))
 
 (defun jdee-ant-get-from-history (buildfile)
   (let ((temp (nth 0 jdee-ant-interactive-target-history))
-	(index -1) (found nil))
+        (index -1) (found nil))
     (while (and temp (not found))
       (setq index (1+ index))
       (setq temp (nth index jdee-ant-interactive-target-history))
       (if (string= (car temp) buildfile)
-	  (setq found t)))
+          (setq found t)))
     (if found
-	(cdr temp)
+        (cdr temp)
       nil)))
 
 ;; Register and initialize the customization variables defined

--- a/jdee-bookmark.el
+++ b/jdee-bookmark.el
@@ -43,8 +43,8 @@ Function `jdee-find-class-source' is used to visit these Java source files (see
 `jdee-bookmark-visit')."
   :group 'jdee-bookmark
   :type '(repeat (cons :tag "Entry"
-		       (string :tag "Name")
-		       (string :tag "Class"))))
+                       (string :tag "Name")
+                       (string :tag "Class"))))
 
 (defvar jdee-bookmark-history nil
   "History item list for `jdee-bookmark-prompt'.")
@@ -52,14 +52,14 @@ Function `jdee-find-class-source' is used to visit these Java source files (see
 (defun jdee-bookmark-prompt (&optional prompt)
   (let ((default (car jdee-bookmark-history)))
     (setq prompt (or prompt
-		     (format "Class%s"
-			     (if default
-				 (format " (default %s): " default)
-			       ": "))))
+                     (format "Class%s"
+                             (if default
+                                 (format " (default %s): " default)
+                               ": "))))
     (completing-read prompt
-		     (mapcar #'car jdee-bookmark-class-bookmarks)
-		     nil t nil 'jdee-bookmark-history
-		     (car jdee-bookmark-history))))
+                     (mapcar #'car jdee-bookmark-class-bookmarks)
+                     nil t nil 'jdee-bookmark-history
+                     (car jdee-bookmark-history))))
 
 (defun jdee-bookmark-class (key)
   (cdr (assoc key jdee-bookmark-class-bookmarks)))
@@ -80,10 +80,10 @@ Function `jdee-find-class-source' is used to visit these Java source files (see
   (jdee-assert-mode)
   (setq fq-class (or fq-class (jdee-parse-get-buffer-class)))
   (message (format "Adding bookmark `%s' as class `%s'"
-		   key fq-class))
+                   key fq-class))
   (customize-save-variable 'jdee-bookmark-class-bookmarks
-			   (append jdee-bookmark-class-bookmarks
-				   (list (cons key fq-class)))))
+                           (append jdee-bookmark-class-bookmarks
+                                   (list (cons key fq-class)))))
 
 ;;;###autoload
 (defun jdee-bookmark-list ()
@@ -92,18 +92,18 @@ Function `jdee-find-class-source' is used to visit these Java source files (see
   ;; a more dynamnic display is needed, like what's currently in bookmark.el
   ;; would be nice
   (let ((max-name-len (apply #'max
-			     (mapcar #'(lambda (arg)
-					 (length (car arg)))
-				     jdee-bookmark-class-bookmarks))))
+                             (mapcar #'(lambda (arg)
+                                         (length (car arg)))
+                                     jdee-bookmark-class-bookmarks))))
     (with-current-buffer (get-buffer-create "*JDEE Bookmarks*")
       (setq buffer-read-only nil)
       (erase-buffer)
       (dolist (entry jdee-bookmark-class-bookmarks)
-	(insert (format "%s:%s%s\n"
-			(car entry)
-			(make-string (+ 1 (- max-name-len
-					     (length (car entry)))) ? )
-			(cdr entry))))
+        (insert (format "%s:%s%s\n"
+                        (car entry)
+                        (make-string (+ 1 (- max-name-len
+                                             (length (car entry)))) ? )
+                        (cdr entry))))
       (setq buffer-read-only t)
       (set-buffer-modified-p nil)
       (display-buffer (current-buffer)))))

--- a/jdee-bsh.el
+++ b/jdee-bsh.el
@@ -79,24 +79,24 @@ use in testing the JDEE's java classes."
 
 (defclass jdee-bsh (bsh)
   ((bsh-cmd-dir      :initarg :bsh-cmd-dir
-		     :type string
-		     :documentation
-		     "Path of the BeanShell commmand directory.")
+                     :type string
+                     :documentation
+                     "Path of the BeanShell commmand directory.")
 
    (jdee-jar         :initarg :jdee-jar
-		    :type string
-		    :documentation
-		    "Path of the JDEE jar.")
+                    :type string
+                    :documentation
+                    "Path of the JDEE jar.")
 
    (jdee-classes-dir :initarg :jdee-classes-dir
-		    :type string
-		    :documentation
-		    "Path of the JDEE classes directory.")
+                    :type string
+                    :documentation
+                    "Path of the JDEE classes directory.")
 
    (the-bsh        :type jdee-bsh
-		   :allocation :class
-		   :documentation
-		   "The single instance of the JDEE's BeanShell."))
+                   :allocation :class
+                   :documentation
+                   "The single instance of the JDEE's BeanShell."))
   "Class of JDEE BeanShells. There is only one per Emacs session.")
 
 (defmethod initialize-instance ((this jdee-bsh) &rest fields)
@@ -122,21 +122,21 @@ use in testing the JDEE's java classes."
   "Sets the vm and classpath to the vm and classpath for the current project before
 the PRIMARY launch method is invoked."
   (let* ((project-ant-home
-	  ;; Code referring to jdee-ant variables uses symbols to
-	  ;; avoid causing compilation errors since jdee-ant is not required.
-	  (jdee-get-project 'jdee-ant-home jdee-current-project))
-	 (ant-home (if (and (boundp 'jdee-ant-home)
-			    (not (string= (symbol-value 'jdee-ant-home) "")))
-		       (symbol-value 'jdee-ant-home)     ;jdee-ant loaded
-		     (if (and project-ant-home
-			      (not (string= project-ant-home "")))
-			 project-ant-home ; jdee-ant not loaded but
-					; jdee-ant-home set in project
-					; file
-		       (getenv "ANT_HOME")))) ; jdee-ant-home not set in
-					; project file and not
-					; customized
-	 )
+          ;; Code referring to jdee-ant variables uses symbols to
+          ;; avoid causing compilation errors since jdee-ant is not required.
+          (jdee-get-project 'jdee-ant-home jdee-current-project))
+         (ant-home (if (and (boundp 'jdee-ant-home)
+                            (not (string= (symbol-value 'jdee-ant-home) "")))
+                       (symbol-value 'jdee-ant-home)     ;jdee-ant loaded
+                     (if (and project-ant-home
+                              (not (string= project-ant-home "")))
+                         project-ant-home ; jdee-ant not loaded but
+                                        ; jdee-ant-home set in project
+                                        ; file
+                       (getenv "ANT_HOME")))) ; jdee-ant-home not set in
+                                        ; project file and not
+                                        ; customized
+         )
 
     (oset this vm (oref (jdee-run-get-vm) :path))
     (oset this cp (delq
@@ -164,21 +164,21 @@ the PRIMARY launch method is invoked."
   "Read an expression as input guessing initial input at the current point."
   (if mark-active
       (progn
-	(setq java-bsh-read-java-expression-history
-	      (cons (buffer-substring (region-beginning)
-				      (region-end))
-		    java-bsh-read-java-expression-history))
-	(jdee-bsh-quote-expr (region-beginning) (region-end) t t))
+        (setq java-bsh-read-java-expression-history
+              (cons (buffer-substring (region-beginning)
+                                      (region-end))
+                    java-bsh-read-java-expression-history))
+        (jdee-bsh-quote-expr (region-beginning) (region-end) t t))
     (let ((bnd (if (eq major-mode 'jdee-mode)
-		   (bounds-of-thing-at-point 'java-expression)))
-	  initial)
+                   (bounds-of-thing-at-point 'java-expression)))
+          initial)
       (if bnd (setq initial (buffer-substring (car bnd) (cdr bnd))))
       (if (and initial
-	       (or (>= (length initial) 80)
-		   (save-match-data (string-match "\n" initial))))
-	  (setq initial nil))
+               (or (>= (length initial) 80)
+                   (save-match-data (string-match "\n" initial))))
+          (setq initial nil))
       (read-string "Expression: " initial
-		   'java-bsh-read-java-expression-history))))
+                   'java-bsh-read-java-expression-history))))
 
 (defvar jdee-jeval-debug nil
   "*Whether or not turn on debug logging.
@@ -200,22 +200,22 @@ for most things since unless `show()' was invoked and output
 prints out, Emacs has nothing to evaluate or report."
   (interactive (list (jdee-bsh-read-java-expression)))
   (cl-flet ((log
-	     (msg logtype)
-	     (when jdee-jeval-debug
-	       (with-current-buffer (get-buffer-create "*Bsh Debug Log*")
-		 (goto-char (point-max))
-		 (insert (format "%S<" logtype))
-		 (insert (if (stringp msg) msg (prin1-to-string msg)))
-		 (insert ">")
-		 (newline)))))
+             (msg logtype)
+             (when jdee-jeval-debug
+               (with-current-buffer (get-buffer-create "*Bsh Debug Log*")
+                 (goto-char (point-max))
+                 (insert (format "%S<" logtype))
+                 (insert (if (stringp msg) msg (prin1-to-string msg)))
+                 (insert ">")
+                 (newline)))))
     (let ((the-bsh (oref-default 'jdee-bsh the-bsh)))
       (when (not (bsh-running-p the-bsh))
-	(bsh-launch the-bsh)
-	(bsh-eval the-bsh (jdee-backend-create-prj-values-str)))
+        (bsh-launch the-bsh)
+        (bsh-eval the-bsh (jdee-backend-create-prj-values-str)))
       (when (not no-print-p)
-	(if (string= (substring java-statement -1) ";")
-	    (setq java-statement (substring java-statement 0 -1)))
-	(setq java-statement (format "\
+        (if (string= (substring java-statement -1) ";")
+            (setq java-statement (substring java-statement 0 -1)))
+        (setq java-statement (format "\
 {
   boolean _prevShowValue = this.interpreter.getShowResults();
   Object _retVal = null;
@@ -229,22 +229,22 @@ prints out, Emacs has nothing to evaluate or report."
 }" java-statement)))
       (log java-statement 'request)
       (let ((output (bsh-eval the-bsh java-statement eval-return))
-	    len)
-	(when (stringp output)
-	  (when (> (length output) 0)
-	    (setq len (length output))
-	    (if (eq ?\n (elt output (1- len)))
-		(setq output (substring output 0 (1- len)))))
-	  (if (= 0 (length output)) (setq output nil)))
-	(log output 'response)
-	(when (called-interactively-p 'interactive)
-	  (if output (kill-new output))
-	  (message (if output
-		       (concat "Copied `"
-			       (replace-regexp-in-string "%" "%%" output t t)
-			       "'")
-		     "No result")))
-	output))))
+            len)
+        (when (stringp output)
+          (when (> (length output) 0)
+            (setq len (length output))
+            (if (eq ?\n (elt output (1- len)))
+                (setq output (substring output 0 (1- len)))))
+          (if (= 0 (length output)) (setq output nil)))
+        (log output 'response)
+        (when (called-interactively-p 'interactive)
+          (if output (kill-new output))
+          (message (if output
+                       (concat "Copied `"
+                               (replace-regexp-in-string "%" "%%" output t t)
+                               "'")
+                     "No result")))
+        output))))
 
 (defun jdee-jeval-r (java-statement)
   "Uses the JDEE's instance of the BeanShell to
@@ -274,19 +274,19 @@ a file in the current directory:
  (jdee-bsh-compile-mode-eval \"jde.util.CompileServer.compile(\\\"Test.java\\\");\"
    \"Compile Test.java\" 'jdee-compile-finish-kill-buffer)"
   (let* ((buffer-obj (bsh-compilation-buffer "buffer"))
-	 (native-buf (oref buffer-obj buffer))
-	 (bufwin (display-buffer native-buf)))
+         (native-buf (oref buffer-obj buffer))
+         (bufwin (display-buffer native-buf)))
 
     (compilation-set-window-height bufwin)
 
     (save-some-buffers (not compilation-ask-about-save) nil)
 
     (if finish-fcn
-	(lexical-let ((finish finish-fcn))
-	  (setq compilation-finish-functions
-		(lambda (buf msg)
-		  (funcall finish buf msg)
-		  (setq compilation-finish-functions nil)))))
+        (lexical-let ((finish finish-fcn))
+          (setq compilation-finish-functions
+                (lambda (buf msg)
+                  (funcall finish buf msg)
+                  (setq compilation-finish-functions nil)))))
 
 
     (if compilation-process-setup-function
@@ -298,16 +298,16 @@ a file in the current directory:
     (with-current-buffer native-buf
 
       (if buffer-head
-	  (insert buffer-head)
-	(insert java-expr))
+          (insert buffer-head)
+        (insert java-expr))
 
       (insert "\n")
 
 
       (if (not (jdee-bsh-running-p))
-	  (progn
-	    (bsh-launch (oref-default 'jdee-bsh the-bsh))
-	    (bsh-eval (oref-default 'jdee-bsh the-bsh)
+          (progn
+            (bsh-launch (oref-default 'jdee-bsh the-bsh))
+            (bsh-eval (oref-default 'jdee-bsh the-bsh)
                       (jdee-backend-create-prj-values-str))))
 
       (bsh-buffer-eval
@@ -327,11 +327,11 @@ a file in the current directory:
   "Closes the existing beanshell process."
   (if (jdee-bsh-running-p)
       (let ((process (bsh-get-process (oref-default 'jdee-bsh the-bsh))))
-	(if (and
-	     (boundp 'jdee-ant-invocation-method) ;; ant package may not be loaded.
-	     (string= (car (symbol-value 'jdee-ant-invocation-method)) "Ant Server"))
-	    (process-send-string process "jde.util.JdeUtilities.exit();\n")
-	  (process-send-string process "exit();\n")))
+        (if (and
+             (boundp 'jdee-ant-invocation-method) ;; ant package may not be loaded.
+             (string= (car (symbol-value 'jdee-ant-invocation-method)) "Ant Server"))
+            (process-send-string process "jde.util.JdeUtilities.exit();\n")
+          (process-send-string process "exit();\n")))
     (message "The beanshell is not running")))
 
 
@@ -351,32 +351,32 @@ this syntax change.
 NO-QUOTE-WRAP-P, if non-nil, don't add double quotes around the whole statement."
   (interactive "r")
   (setq start (or start (point-min))
-	end (or end (point-max)))
+        end (or end (point-max)))
   (let ((expr (buffer-substring-no-properties start end))
-	(repls (append '(("\\" . "\\\\"))
-		       (if (not no-param-p)
-			   '(("\n" . "\\n"))))))
+        (repls (append '(("\\" . "\\\\"))
+                       (if (not no-param-p)
+                           '(("\n" . "\\n"))))))
     (save-match-data
       (if (not no-param-p)
-	  (setq expr (mapconcat #'identity (split-string expr "\"")
-				"\" + '\"' + \"")))
+          (setq expr (mapconcat #'identity (split-string expr "\"")
+                                "\" + '\"' + \"")))
       (setq expr (with-temp-buffer
-		   (insert expr)
-		   (dolist (repl repls)
-		     (goto-char (point-min))
-		     (while (search-forward (car repl) nil t)
-		       (replace-match (cdr repl) nil t)))
-		   (when (not no-quote-wrap-p)
-		     (goto-char (point-min))
-		     (insert "\"")
-		     (goto-char (point-max))
-		     (insert "\""))
-		   (buffer-substring (point-min) (point-max))))
+                   (insert expr)
+                   (dolist (repl repls)
+                     (goto-char (point-min))
+                     (while (search-forward (car repl) nil t)
+                       (replace-match (cdr repl) nil t)))
+                   (when (not no-quote-wrap-p)
+                     (goto-char (point-min))
+                     (insert "\"")
+                     (goto-char (point-max))
+                     (insert "\""))
+                   (buffer-substring (point-min) (point-max))))
       (when (called-interactively-p 'interactive)
-	(save-excursion
-	  (delete-region start end)
-	  (goto-char start)
-	  (insert expr)))
+        (save-excursion
+          (delete-region start end)
+          (goto-char start)
+          (insert expr)))
       expr)))
 
 (provide 'jdee-bsh)

--- a/jdee-bug.el
+++ b/jdee-bug.el
@@ -87,10 +87,10 @@ executable used to run the debugger itself."
 This defaults to java on Unix platforms and javaw on Windows platforms"
   :group 'jdee-bug
   :type '(list
-	  (radio-button-choice
-	  (const "java")
-	  (const "javaw")
-	  (const "java_g"))))
+          (radio-button-choice
+          (const "java")
+          (const "javaw")
+          (const "java_g"))))
 
 (defcustom jdee-bug-raise-frame-p t
   "*Raise frame when a breakpoint is hit."
@@ -109,8 +109,8 @@ the value of this variable. If you are running JDK 1.2, you must also
 specifiy the options  -Xnoagent and -Djava.compiler=NONE."
   :group 'jdee-bug
   :type '(cons
-	  (boolean :tag "Prompt for")
-	  (string :tag "Address")))
+          (boolean :tag "Prompt for")
+          (string :tag "Address")))
 
 (defcustom jdee-bug-server-shmem-name (cons t "JDEbug")
   "*Shared memory name under which the debugger listens for apps
@@ -121,8 +121,8 @@ the value of this variable. If you are running JDK 1.2, you must also
 specifiy the options  -Xnoagent and -Djava.compiler=NONE."
   :group 'jdee-bug
   :type '(cons
-	  (boolean :tag "Prompt for")
-	  (string :tag "Name")))
+          (boolean :tag "Prompt for")
+          (string :tag "Name")))
 
 
 (defcustom jdee-bug-debugger-host-address system-name
@@ -145,9 +145,9 @@ a local host: 127.0.0.1 ."
 "*Breakpoints to be set for the current project."
   :group 'jdee-bug
   :type '(repeat
-	  (cons :tag "Break at"
-	   (string :tag "File Name")
-	   (integer :tag "Line Number"))))
+          (cons :tag "Break at"
+           (string :tag "File Name")
+           (integer :tag "Line Number"))))
 
 
 (defcustom jdee-bug-breakpoint-cursor-colors (cons "cyan" "brown")
@@ -155,13 +155,13 @@ a local host: 127.0.0.1 ."
 breakpoint cursor."
   :group 'jdee-bug
   :type '(cons
-	  (string :tag "Foreground Color")
-	  (string :tag "Background Color"))
+          (string :tag "Foreground Color")
+          (string :tag "Background Color"))
   :set '(lambda (sym val)
-	  (make-face 'jdee-bug-breakpoint-cursor)
-	  (set-face-foreground 'jdee-bug-breakpoint-cursor (car val))
-	  (set-face-background 'jdee-bug-breakpoint-cursor (cdr val))
-	  (set-default sym val)))
+          (make-face 'jdee-bug-breakpoint-cursor)
+          (set-face-foreground 'jdee-bug-breakpoint-cursor (car val))
+          (set-face-background 'jdee-bug-breakpoint-cursor (cdr val))
+          (set-default sym val)))
 
 
 (defgroup jdee-bug-window nil
@@ -194,356 +194,356 @@ consuming and slows down stepping through the code."
 (defvar jdee-bug-menu-spec
   (list "JDEbug"
 
-	["Step Over"
-	 jdee-bug-step-over
-	 (jdee-dbs-target-process-steppable-p)]
+        ["Step Over"
+         jdee-bug-step-over
+         (jdee-dbs-target-process-steppable-p)]
 
-	["Step Into"
-	 jdee-bug-step-into
-	 (jdee-dbs-target-process-steppable-p)]
+        ["Step Into"
+         jdee-bug-step-into
+         (jdee-dbs-target-process-steppable-p)]
 
-	["Step Into All"
-	 jdee-bug-step-into-all
-	 (jdee-dbs-target-process-steppable-p)]
+        ["Step Into All"
+         jdee-bug-step-into-all
+         (jdee-dbs-target-process-steppable-p)]
 
-	["Step Out"
-	 jdee-bug-step-out
-	 (jdee-dbs-target-process-steppable-p)]
+        ["Step Out"
+         jdee-bug-step-out
+         (jdee-dbs-target-process-steppable-p)]
 
-	["Run"
-	 jdee-debug
-	 :active                    t
-	 :included                  (null (jdee-dbs-debugger-running-p)) ]
+        ["Run"
+         jdee-debug
+         :active                    t
+         :included                  (null (jdee-dbs-debugger-running-p)) ]
 
-	["Continue"
-	 jdee-bug-continue
-	 :active                    (jdee-dbs-target-process-runnable-p)
-	 :included                  (jdee-dbs-debugger-running-p)        ]
+        ["Continue"
+         jdee-bug-continue
+         :active                    (jdee-dbs-target-process-runnable-p)
+         :included                  (jdee-dbs-debugger-running-p)        ]
 
-	["Exit Debugger"
-	 jdee-bug-exit
-	 (jdee-dbs-debugger-running-p)]
+        ["Exit Debugger"
+         jdee-bug-exit
+         (jdee-dbs-debugger-running-p)]
 
-	"-"
-	;; Added by lea
-	["Toggle Breakpoint"
-	 jdee-bug-toggle-breakpoint t]
-	["Set Conditional Breakpoint"
-	 jdee-bug-set-conditional-breakpoint nil]
-	["Break on exception"
-	 jdee-bug-break-on-exception
-	 :active (and
-		  (jdee-dbs-debugger-running-p)
-		  (jdee-dbs-get-target-process))]
-	["Save Breakpoints"
-	 jdee-bug-save-breakpoints nil]
-	(list
-	 "Watch for Field"
+        "-"
+        ;; Added by lea
+        ["Toggle Breakpoint"
+         jdee-bug-toggle-breakpoint t]
+        ["Set Conditional Breakpoint"
+         jdee-bug-set-conditional-breakpoint nil]
+        ["Break on exception"
+         jdee-bug-break-on-exception
+         :active (and
+                  (jdee-dbs-debugger-running-p)
+                  (jdee-dbs-get-target-process))]
+        ["Save Breakpoints"
+         jdee-bug-save-breakpoints nil]
+        (list
+         "Watch for Field"
 
-	 ["Access"
-	  jdee-bug-watch-field-access
-	  :style    nil
-	  :active   (and
-		     (jdee-dbs-debugger-running-p)
-		     (jdee-dbs-get-target-process))]
-
-
-	 ["Modification"
-	  jdee-bug-watch-field-modification
-	  :style   nil
-	  :active  (and
-		    (jdee-dbs-debugger-running-p)
-		    (jdee-dbs-get-target-process))]
-
-	 ["Cancel"
-	  jdee-bug-cancel-watch
-	  :style     nil
-	  :active    (and
-		      (jdee-dbs-debugger-running-p)
-		      (jdee-dbs-get-target-process)
-		      (slot-boundp
-		       (jdee-dbs-get-target-process)
-		       'watch-req))]
-
-	 )
-
-	(list
-	 "Trace"
-
-	 ["Class Prep..."
-	  jdee-bug-trace-class-prep
-	  :style    nil
-	  :active	 (and
-			  (jdee-dbs-debugger-running-p)
-			  (jdee-dbs-get-target-process))]
-
-	 ["Class Unload..."
-	  jdee-bug-trace-class-unload
-	  :style    nil
-	  :active	 (and
-			  (jdee-dbs-debugger-running-p)
-			  (jdee-dbs-get-target-process))]
+         ["Access"
+          jdee-bug-watch-field-access
+          :style    nil
+          :active   (and
+                     (jdee-dbs-debugger-running-p)
+                     (jdee-dbs-get-target-process))]
 
 
-	 ["Method Entry..."
-	  jdee-bug-trace-method-entry
-	  :style    nil
-	  :active	 (and
-			  (jdee-dbs-debugger-running-p)
-			  (jdee-dbs-get-target-process))]
+         ["Modification"
+          jdee-bug-watch-field-modification
+          :style   nil
+          :active  (and
+                    (jdee-dbs-debugger-running-p)
+                    (jdee-dbs-get-target-process))]
 
-	 ["Method Exit..."
-	  jdee-bug-trace-method-exit
-	  :style    nil
-	  :active	 (and
-			  (jdee-dbs-debugger-running-p)
-			  (jdee-dbs-get-target-process))]
+         ["Cancel"
+          jdee-bug-cancel-watch
+          :style     nil
+          :active    (and
+                      (jdee-dbs-debugger-running-p)
+                      (jdee-dbs-get-target-process)
+                      (slot-boundp
+                       (jdee-dbs-get-target-process)
+                       'watch-req))]
 
-	 ["Exceptions..."
-	  jdee-bug-trace-exceptions
-	  :style    nil
-	  :active	 (and
-			  (jdee-dbs-debugger-running-p)
-			  (jdee-dbs-get-target-process))]
+         )
+
+        (list
+         "Trace"
+
+         ["Class Prep..."
+          jdee-bug-trace-class-prep
+          :style    nil
+          :active         (and
+                          (jdee-dbs-debugger-running-p)
+                          (jdee-dbs-get-target-process))]
+
+         ["Class Unload..."
+          jdee-bug-trace-class-unload
+          :style    nil
+          :active         (and
+                          (jdee-dbs-debugger-running-p)
+                          (jdee-dbs-get-target-process))]
 
 
-	 ["Cancel..."
-	  jdee-bug-cancel-trace
-	  :style     nil
-	  :active    (and
-		      (jdee-dbs-debugger-running-p)
-		      (jdee-dbs-get-target-process)
-		      (slot-boundp
-		       (jdee-dbs-get-target-process)
-		       'trace-req))]
+         ["Method Entry..."
+          jdee-bug-trace-method-entry
+          :style    nil
+          :active         (and
+                          (jdee-dbs-debugger-running-p)
+                          (jdee-dbs-get-target-process))]
 
-	 )
+         ["Method Exit..."
+          jdee-bug-trace-method-exit
+          :style    nil
+          :active         (and
+                          (jdee-dbs-debugger-running-p)
+                          (jdee-dbs-get-target-process))]
 
-	"-"
+         ["Exceptions..."
+          jdee-bug-trace-exceptions
+          :style    nil
+          :active         (and
+                          (jdee-dbs-debugger-running-p)
+                          (jdee-dbs-get-target-process))]
 
-	(list
-	 "Display"
 
-	 ["Loaded Classes"
-	  jdee-bug-display-loaded-classes
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Cancel..."
+          jdee-bug-cancel-trace
+          :style     nil
+          :active    (and
+                      (jdee-dbs-debugger-running-p)
+                      (jdee-dbs-get-target-process)
+                      (slot-boundp
+                       (jdee-dbs-get-target-process)
+                       'trace-req))]
 
-	 ["Object Monitors"
-	  jdee-bug-show-object-monitors
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         )
 
-	 ["Path Info"
-	  jdee-bug-display-path-info
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
-	 )
+        "-"
 
-	["Display Variable At Point"
-	 jdee-bug-display-variable
-	 (and
+        (list
+         "Display"
+
+         ["Loaded Classes"
+          jdee-bug-display-loaded-classes
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
+
+         ["Object Monitors"
+          jdee-bug-show-object-monitors
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
+
+         ["Path Info"
+          jdee-bug-display-path-info
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
+         )
+
+        ["Display Variable At Point"
+         jdee-bug-display-variable
+         (and
           (jdee-dbs-debugger-running-p)
           (jdee-dbs-get-target-process))]
 
-	["Evaluate Expression"
-	 jdee-bug-evaluate-expression
-	 (and
-	  (jdee-dbs-debugger-running-p)
-	  (jdee-dbs-get-target-process))]
+        ["Evaluate Expression"
+         jdee-bug-evaluate-expression
+         (and
+          (jdee-dbs-debugger-running-p)
+          (jdee-dbs-get-target-process))]
 
-	(list
-	 "Stack"
-	 `["Enable"
-	   jdee-bug-toggle-stack-info
-	   :enable t
-	   :style radio
-	   :selected jdee-bug-stack-info]
-	 ["Up"
-	  jdee-bug-up-stack
-	  (and
-	   (jdee-dbs-target-process-steppable-p)
-	   (let* ((process (jdee-dbs-get-target-process))
-		  (stack-max
-		   (if (slot-boundp process 'stack)
-		       (1- (length (oref process stack)))
-		     0))
-		  (stack-ptr (oref process stack-ptr)))
-	     (< stack-ptr stack-max)))]
+        (list
+         "Stack"
+         `["Enable"
+           jdee-bug-toggle-stack-info
+           :enable t
+           :style radio
+           :selected jdee-bug-stack-info]
+         ["Up"
+          jdee-bug-up-stack
+          (and
+           (jdee-dbs-target-process-steppable-p)
+           (let* ((process (jdee-dbs-get-target-process))
+                  (stack-max
+                   (if (slot-boundp process 'stack)
+                       (1- (length (oref process stack)))
+                     0))
+                  (stack-ptr (oref process stack-ptr)))
+             (< stack-ptr stack-max)))]
 
-	 ["Down"
-	  jdee-bug-down-stack
-	  (and
-	   (jdee-dbs-target-process-steppable-p)
-	   (let* ((process (jdee-dbs-get-target-process))
-		  (stack-ptr (oref process stack-ptr)))
-	     (> stack-ptr 0)))]
+         ["Down"
+          jdee-bug-down-stack
+          (and
+           (jdee-dbs-target-process-steppable-p)
+           (let* ((process (jdee-dbs-get-target-process))
+                  (stack-ptr (oref process stack-ptr)))
+             (> stack-ptr 0)))]
 
-	 )
-	(list
-	 "Thread"
+         )
+        (list
+         "Thread"
 
-	 ["Suspend"
-	  jdee-bug-suspend-thread
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Suspend"
+          jdee-bug-suspend-thread
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
 
-	 ["Resume"
-	  jdee-bug-resume-thread
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Resume"
+          jdee-bug-resume-thread
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
-	 ["Interrupt"
-	  jdee-bug-interrupt-thread
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Interrupt"
+          jdee-bug-interrupt-thread
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
-	 ["Stop"
-	  jdee-bug-stop-thread
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Stop"
+          jdee-bug-stop-thread
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
                                         ; ["Show Thread Info"
                                         ;   jdee-bug-thread-show-thread-info nil]
-	 )
+         )
 
-	(list
-	 "Processes"
-	 ["Start Debugger"
-	  jdee-bug-start-debugger
-	  (not (jdee-dbs-debugger-running-p))]
+        (list
+         "Processes"
+         ["Start Debugger"
+          jdee-bug-start-debugger
+          (not (jdee-dbs-debugger-running-p))]
 
-	 ["Launch Process"
-	  jdee-bug-launch-process
-	  (jdee-dbs-debugger-running-p)]
+         ["Launch Process"
+          jdee-bug-launch-process
+          (jdee-dbs-debugger-running-p)]
 
-	 ["Suspend Process"
-	  jdee-bug-suspend-process
-	  (let ((process (jdee-dbs-get-target-process)))
-	    (and
-	     (jdee-dbs-debugger-running-p)
-	     process
-	     (not (oref process suspendedp))))]
+         ["Suspend Process"
+          jdee-bug-suspend-process
+          (let ((process (jdee-dbs-get-target-process)))
+            (and
+             (jdee-dbs-debugger-running-p)
+             process
+             (not (oref process suspendedp))))]
 
-	 ["Resume Process"
-	  jdee-bug-resume-process
-	  (let ((process (jdee-dbs-get-target-process)))
-	    (and
-	     (jdee-dbs-debugger-running-p)
-	     process
-	     (oref process suspendedp)))]
+         ["Resume Process"
+          jdee-bug-resume-process
+          (let ((process (jdee-dbs-get-target-process)))
+            (and
+             (jdee-dbs-debugger-running-p)
+             process
+             (oref process suspendedp)))]
 
-	 ["Finish Process"
-	  jdee-bug-finish-process
-	  (let ((process (jdee-dbs-get-target-process)))
-	    (and
-	     (jdee-dbs-debugger-running-p)
-	     process
-	     (not (oref process attachedp))))]
+         ["Finish Process"
+          jdee-bug-finish-process
+          (let ((process (jdee-dbs-get-target-process)))
+            (and
+             (jdee-dbs-debugger-running-p)
+             process
+             (not (oref process attachedp))))]
 
-	 "-"
+         "-"
 
-	 (list
-	  "Attach Process"
-	  ["Via Shared Memory"
-	   jdee-bug-attach-via-shared-memory
-	   (and
-	    (eq system-type 'windows-nt)
-	    (jdee-dbs-debugger-running-p))]
+         (list
+          "Attach Process"
+          ["Via Shared Memory"
+           jdee-bug-attach-via-shared-memory
+           (and
+            (eq system-type 'windows-nt)
+            (jdee-dbs-debugger-running-p))]
 
-	  ["On Local Host"
-	   jdee-bug-attach-local-host
-	   (jdee-dbs-debugger-running-p)]
+          ["On Local Host"
+           jdee-bug-attach-local-host
+           (jdee-dbs-debugger-running-p)]
 
-	  ["On Remote Host"
-	   jdee-bug-attach-remote-host
-	   (jdee-dbs-debugger-running-p)]
-	  )
+          ["On Remote Host"
+           jdee-bug-attach-remote-host
+           (jdee-dbs-debugger-running-p)]
+          )
 
-	 (list
-	  "Listen on"
-	  ["Shared Memory"
-	   jdee-bug-listen-shmem
-	   (and
-	    (eq system-type 'windows-nt)
-	    (jdee-dbs-debugger-running-p))]
+         (list
+          "Listen on"
+          ["Shared Memory"
+           jdee-bug-listen-shmem
+           (and
+            (eq system-type 'windows-nt)
+            (jdee-dbs-debugger-running-p))]
 
-	  ["Socket"
-	   jdee-bug-listen-socket
-	   (jdee-dbs-debugger-running-p)]
-	  )
+          ["Socket"
+           jdee-bug-listen-socket
+           (jdee-dbs-debugger-running-p)]
+          )
 
-	 ["Detach Process"
-	  jdee-bug-detach-process
-	  (let ((process (jdee-dbs-get-target-process)))
-	    (and
-	     (jdee-dbs-debugger-running-p)
-	     process
-	     (oref process attachedp)))]
+         ["Detach Process"
+          jdee-bug-detach-process
+          (let ((process (jdee-dbs-get-target-process)))
+            (and
+             (jdee-dbs-debugger-running-p)
+             process
+             (oref process attachedp)))]
 
 
-	 "-"
+         "-"
 
-	 ["Set Target Process"
-	  jdee-bug-set-target-process
-	  (> (jdee-dbs-proc-set-get-size
-	      jdee-dbs-the-process-registry)
-	     0)]
+         ["Set Target Process"
+          jdee-bug-set-target-process
+          (> (jdee-dbs-proc-set-get-size
+              jdee-dbs-the-process-registry)
+             0)]
 
-	 ["Show Processes"
-	  jdee-bug-set-show-processes nil]
+         ["Show Processes"
+          jdee-bug-set-show-processes nil]
 
-	 ["Remove Dead Processes"
-	  jdee-bug-remove-dead-processes
-	  (oref jdee-dbs-the-process-morgue proc-alist)]
+         ["Remove Dead Processes"
+          jdee-bug-remove-dead-processes
+          (oref jdee-dbs-the-process-morgue proc-alist)]
 
-	 )
-	(list
-	 "Show Buffer"
+         )
+        (list
+         "Show Buffer"
 
-	 ["Locals"
-	  jdee-bug-show-locals-buf
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["Locals"
+          jdee-bug-show-locals-buf
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
-	 ["CLI"
-	  jdee-bug-show-cli-buf
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
+         ["CLI"
+          jdee-bug-show-cli-buf
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
 
-	 ["Threads"
-	  jdee-bug-show-threads-buf
-	  (and
-	   (jdee-dbs-debugger-running-p)
-	   (jdee-dbs-get-target-process))]
-	 )
-	["Show Debug Frame"
-	 jdee-bug-show-debug-frame
-	 (and (jdee-dbs-debugger-running-p)
-	      (jdee-dbs-get-target-process))]
-	"-"
-	["Preferences"
-	 jdee-bug-show-preferences t]
-	"-"
-	["Help"
-	 jdee-bug-help t]
-	)
+         ["Threads"
+          jdee-bug-show-threads-buf
+          (and
+           (jdee-dbs-debugger-running-p)
+           (jdee-dbs-get-target-process))]
+         )
+        ["Show Debug Frame"
+         jdee-bug-show-debug-frame
+         (and (jdee-dbs-debugger-running-p)
+              (jdee-dbs-get-target-process))]
+        "-"
+        ["Preferences"
+         jdee-bug-show-preferences t]
+        "-"
+        ["Help"
+         jdee-bug-help t]
+        )
   "JDEbug menu specification")
 
 (defvar jdee-bug-mode-map
   (let ((km (make-sparse-keymap)))
     (easy-menu-define jdee-bug-menu km "JDEbug Minor Mode Menu"
-		      jdee-bug-menu-spec)
+                      jdee-bug-menu-spec)
     km)
   "Keymap for JDEbug minor mode.")
 
@@ -556,11 +556,11 @@ consuming and slows down stepping through the code."
 ;; (fmakunbound 'jdee-bug-key-bindings)
 (defcustom jdee-bug-key-bindings
   (list (cons "[?\C-c ?\C-z ?\C-s]" 'jdee-bug-step-over)
-	(cons "[?\C-c ?\C-z ?\C-x]" 'jdee-bug-step-into)
-	(cons "[?\C-c ?\C-z ?\C-a]" 'jdee-bug-step-into-all)
-	(cons "[?\C-c ?\C-z ?\C-w]" 'jdee-bug-step-out)
-	(cons "[?\C-c ?\C-z ?\C-c]" 'jdee-bug-continue)
-	(cons "[?\C-c ?\C-z ?\C-b]" 'jdee-bug-toggle-breakpoint))
+        (cons "[?\C-c ?\C-z ?\C-x]" 'jdee-bug-step-into)
+        (cons "[?\C-c ?\C-z ?\C-a]" 'jdee-bug-step-into-all)
+        (cons "[?\C-c ?\C-z ?\C-w]" 'jdee-bug-step-out)
+        (cons "[?\C-c ?\C-z ?\C-c]" 'jdee-bug-continue)
+        (cons "[?\C-c ?\C-z ?\C-b]" 'jdee-bug-toggle-breakpoint))
   "*Specifies key bindings for JDEbug.
 The value of this variable is an association list. The car of
 each element specifies a key sequence. The cdr specifies
@@ -571,40 +571,40 @@ bound, type C-q C-s in the key field in the customization buffer.
 You can use the notation [f1], [f2], etc., to specify function keys."
   :group 'jdee-bug
   :type '(repeat
-	  (cons :tag "Key binding"
-	   (string :tag "Key")
-	   (function :tag "Command")))
+          (cons :tag "Key binding"
+           (string :tag "Key")
+           (function :tag "Command")))
   :set '(lambda (sym val)
-	  ;; Unmap existing key bindings
-	  (if (and
-	       (boundp 'jdee-bug-key-bindings)
-	       jdee-bug-key-bindings)
-	      (mapc
-	       (lambda (binding)
-		 (let ((key (car binding))
-		       (fcn (cdr binding)))
-		   (if (string-match "\\[.+]"key)
-		       (setq key (car (read-from-string key))))
-		   (define-key jdee-bug-mode-map key nil)))
-	       jdee-bug-key-bindings))
-	  ;; Map new key bindings.
-	  (mapc
-	   (lambda (binding)
-	     (let ((key (car binding))
-		   (fcn (cdr binding)))
-	       (if (string-match "\\[.+]"key)
-		   (setq key (car (read-from-string key))))
-	       (define-key jdee-bug-mode-map key fcn)))
-	   val)
-	  (set-default sym val)))
+          ;; Unmap existing key bindings
+          (if (and
+               (boundp 'jdee-bug-key-bindings)
+               jdee-bug-key-bindings)
+              (mapc
+               (lambda (binding)
+                 (let ((key (car binding))
+                       (fcn (cdr binding)))
+                   (if (string-match "\\[.+]"key)
+                       (setq key (car (read-from-string key))))
+                   (define-key jdee-bug-mode-map key nil)))
+               jdee-bug-key-bindings))
+          ;; Map new key bindings.
+          (mapc
+           (lambda (binding)
+             (let ((key (car binding))
+                   (fcn (cdr binding)))
+               (if (string-match "\\[.+]"key)
+                   (setq key (car (read-from-string key))))
+               (define-key jdee-bug-mode-map key fcn)))
+           val)
+          (set-default sym val)))
 
 
 (defun jdee-bug-step-over ()
   "Advances the process to the next line in the current method."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-step "step over" :process process)))
+         (cmd
+          (jdee-dbs-step "step over" :process process)))
     (jdee-dbs-cmd-exec cmd)))
 
 (defun jdee-bug-step-into ()
@@ -612,24 +612,24 @@ You can use the notation [f1], [f2], etc., to specify function keys."
    belongs to the java, javax, or sun packages."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-step "step into" :process process :step-type "into")))
+         (cmd
+          (jdee-dbs-step "step into" :process process :step-type "into")))
     (jdee-dbs-cmd-exec cmd)))
 
 (defun jdee-bug-step-into-all ()
   "Advances the process into the function invoked at point."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-step "step into" :process process :step-type "into-all")))
+         (cmd
+          (jdee-dbs-step "step into" :process process :step-type "into-all")))
     (jdee-dbs-cmd-exec cmd)))
 
 (defun jdee-bug-step-out ()
   "Advances the process to the next line in the invoking method."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-step "step into" :process process :step-type "out")))
+         (cmd
+          (jdee-dbs-step "step into" :process process :step-type "out")))
     (jdee-dbs-cmd-exec cmd)))
 
 
@@ -637,9 +637,9 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   "Runs the target process. Execution continues from the current breakpoint."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (run (jdee-dbs-run-process
-	       (format "run %d" (oref process id))
-		  :process process)))
+         (run (jdee-dbs-run-process
+               (format "run %d" (oref process id))
+                  :process process)))
     (oset process startupp nil)
     (oset process suspendedp nil)
     (oset process steppablep nil)
@@ -652,17 +652,17 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (interactive)
   (if (jdee-dbs-debugger-running-p)
       (progn
-	(mapc
-	 (lambda (assoc-x)
-	   (let* ((process (cdr assoc-x))
-		  (finish-cmd (jdee-dbs-finish-process
-			       (format "finish %d" (oref process id))
-			       :process process))
-		  (result (jdee-dbs-cmd-exec finish-cmd)))
-	     (jdee-dbs-proc-move-to-morgue process)))
-	 (oref jdee-dbs-the-process-registry proc-alist))
-	(slot-makeunbound jdee-dbs-the-process-registry :target-process)
-	(jdee-dbs-debugger-quit jdee-dbs-the-debugger))
+        (mapc
+         (lambda (assoc-x)
+           (let* ((process (cdr assoc-x))
+                  (finish-cmd (jdee-dbs-finish-process
+                               (format "finish %d" (oref process id))
+                               :process process))
+                  (result (jdee-dbs-cmd-exec finish-cmd)))
+             (jdee-dbs-proc-move-to-morgue process)))
+         (oref jdee-dbs-the-process-registry proc-alist))
+        (slot-makeunbound jdee-dbs-the-process-registry :target-process)
+        (jdee-dbs-debugger-quit jdee-dbs-the-debugger))
     (error "Debugger is not running.")))
 
 
@@ -671,43 +671,43 @@ You can use the notation [f1], [f2], etc., to specify function keys."
  (lambda ()
    (if (buffer-file-name)
        (let ((this-file (file-name-nondirectory (buffer-file-name))))
-	 (mapc
-	  (lambda (spec)
-	    (let* ((file (car spec))
-		   (line (cdr spec))
-		   (bp (jdee-db-find-breakpoint file line)))
-	      (when (not bp)
-		(setq jdee-db-breakpoint-id-counter (1+ jdee-db-breakpoint-id-counter))
-		(setq bp
-		      (jdee-db-breakpoint
-		       (format "breakpoint%d" jdee-db-breakpoint-id-counter)
-		       :id jdee-db-breakpoint-id-counter
-		       :file file
-		       :line line))
-		(jdee-db-breakpoints-add bp))
-	      (if (string-match file this-file)
-		  (jdee-db-mark-breakpoint-specified file line))))
-	  jdee-bug-saved-breakpoints)))))
+         (mapc
+          (lambda (spec)
+            (let* ((file (car spec))
+                   (line (cdr spec))
+                   (bp (jdee-db-find-breakpoint file line)))
+              (when (not bp)
+                (setq jdee-db-breakpoint-id-counter (1+ jdee-db-breakpoint-id-counter))
+                (setq bp
+                      (jdee-db-breakpoint
+                       (format "breakpoint%d" jdee-db-breakpoint-id-counter)
+                       :id jdee-db-breakpoint-id-counter
+                       :file file
+                       :line line))
+                (jdee-db-breakpoints-add bp))
+              (if (string-match file this-file)
+                  (jdee-db-mark-breakpoint-specified file line))))
+          jdee-bug-saved-breakpoints)))))
 
 
 (defun jdee-bug-set-breakpoint()
   "Sets a breakpoint at the current line in the current buffer."
   (interactive)
   (let* ((file (buffer-file-name))
-	 (line (jdee-get-line-at-point))
-	 (bp (jdee-db-find-breakpoint file line))
-	 (proc (jdee-dbs-get-target-process)))
+         (line (jdee-get-line-at-point))
+         (bp (jdee-db-find-breakpoint file line))
+         (proc (jdee-dbs-get-target-process)))
     (unless bp
       (setq bp (jdee-db-spec-breakpoint))
       (oset bp line line)
       (jdee-db-breakpoints-add bp))
     (if (and bp proc)
-	(let* ((set-breakpoint (jdee-dbs-set-breakpoint
-				"set breakpoint"
-				:process proc
-				:breakpoint bp))
-	       (result (jdee-dbs-cmd-exec set-breakpoint)))
-	  (message "Breakpoint set at line %d in class %s." line file)))))
+        (let* ((set-breakpoint (jdee-dbs-set-breakpoint
+                                "set breakpoint"
+                                :process proc
+                                :breakpoint bp))
+               (result (jdee-dbs-cmd-exec set-breakpoint)))
+          (message "Breakpoint set at line %d in class %s." line file)))))
 
 
 (defun jdee-bug-set-conditional-breakpoint ()
@@ -725,18 +725,18 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   "Clear the breakpoint at the current line in the current buffer."
   (interactive)
   (let* ((file (buffer-file-name))
-	 (line (jdee-get-line-at-point))
-	 (bp (jdee-db-find-breakpoint file line))
-	 (proc (jdee-dbs-get-target-process)))
+         (line (jdee-get-line-at-point))
+         (bp (jdee-db-find-breakpoint file line))
+         (proc (jdee-dbs-get-target-process)))
     (if (and bp proc)
-	(let* ((clear-breakpoint
-		(jdee-dbs-clear-breakpoint
-		 "clear breakpoint"
-		 :process proc
-		 :breakpoint bp))
-	       (result (jdee-dbs-cmd-exec clear-breakpoint)))))
+        (let* ((clear-breakpoint
+                (jdee-dbs-clear-breakpoint
+                 "clear breakpoint"
+                 :process proc
+                 :breakpoint bp))
+               (result (jdee-dbs-cmd-exec clear-breakpoint)))))
     (if bp
-	(jdee-db-delete-breakpoint bp))))
+        (jdee-db-delete-breakpoint bp))))
 
 ;; test by lea
 
@@ -751,16 +751,16 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (interactive)
 
   (assert (equal major-mode 'jdee-mode)
-	  nil "You can only toggle a breakpoint within jdee-mode")
+          nil "You can only toggle a breakpoint within jdee-mode")
 
   (assert (jdee-db-src-dir-matches-file-p (buffer-file-name))
-	  nil "The current buffer is not in the source path.  See `jdee-sourcepath' for more information.")
+          nil "The current buffer is not in the source path.  See `jdee-sourcepath' for more information.")
 
   (let*  ((file (buffer-file-name))
-	  (line (jdee-get-line-at-point))
-	  (bp (jdee-db-find-breakpoint file line)))
+          (line (jdee-get-line-at-point))
+          (bp (jdee-db-find-breakpoint file line)))
     (if bp
-	(jdee-bug-clear-breakpoint)
+        (jdee-bug-clear-breakpoint)
       (jdee-bug-set-breakpoint))))
 
 
@@ -784,22 +784,22 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 
 (defclass jdee-bug-trace-methods-dialog (efc-dialog)
   ((trace-type               :initarg :trace-type
-			     :type string
-			     :initform "entry"
-			     :documentation
-			     "Values may be entry or exit.")
+                             :type string
+                             :initform "entry"
+                             :documentation
+                             "Values may be entry or exit.")
    (thread-restriction-field :initarg :thread-restriction-field
-			     :documentation
-			     "Text field that contains thread restriction.")
+                             :documentation
+                             "Text field that contains thread restriction.")
    (suspend-policy-field     :initarg :suspend-policy-field
-			     :documentation
-			     "Text field that specifies the thread suspension policy.")
+                             :documentation
+                             "Text field that specifies the thread suspension policy.")
    (class-inclusion-field    :initarg :class-inclusion-field
-			     :documentation
-			     "Specifies class inclusion filters.")
+                             :documentation
+                             "Specifies class inclusion filters.")
    (class-exclusion-field    :initarg :class-exclusion-field
-			     :documentation
-			     "Specifies class exclusion filters.")
+                             :documentation
+                             "Specifies class exclusion filters.")
    )
   "Class of trace methods dialogs."
 )
@@ -811,84 +811,84 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (call-next-method)
 
   (assert (or (string= (oref this trace-type) "entry")
-	      (string= (oref this trace-type) "exit")))
+              (string= (oref this trace-type) "exit")))
 )
 
 
 (defmethod efc-dialog-create ((this jdee-bug-trace-methods-dialog))
 
   (widget-insert (concat "Trace method "
-			 (oref this trace-type)
-			 "\n\n"))
+                         (oref this trace-type)
+                         "\n\n"))
 
   (oset this thread-restriction-field
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Thread restriction"
-	 :doc "Restrict trace to the specified thread."))
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Thread restriction"
+         :doc "Restrict trace to the specified thread."))
 
   (oset this suspend-policy-field
-	(widget-create
-	 '(choice
-	   :tag "Thread Suspension Policy"
-	   :value "none"
-	   :format "  %t: %[Options%] %v  %h\n\n"
-	   :doc "Specify which thread to suspend on method entry or exit."
-	   (const "all")
-	   (const "thread")
-	   (const "none"))))
+        (widget-create
+         '(choice
+           :tag "Thread Suspension Policy"
+           :value "none"
+           :format "  %t: %[Options%] %v  %h\n\n"
+           :doc "Specify which thread to suspend on method entry or exit."
+           (const "all")
+           (const "thread")
+           (const "none"))))
 
 
   (oset this class-inclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class inclusion filters"
-	   :doc "Regular expressions that specify classes whose methods should be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class inclusion filters"
+           :doc "Regular expressions that specify classes whose methods should be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
 
     (oset this class-exclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class exclusion filters"
-	   :doc "Regular expressions that specify classes whose methods should not be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class exclusion filters"
+           :doc "Regular expressions that specify classes whose methods should not be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
   )
 
 (defmethod efc-dialog-ok ((this jdee-bug-trace-methods-dialog))
   (let* ((thread-restriction (widget-value (oref this thread-restriction-field)))
-	 (thread-suspension-policy (widget-value (oref this suspend-policy-field)))
-	 (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
-	 (class-exclusion-filters (widget-value (oref this class-exclusion-field)))
-	 (process (jdee-dbs-get-target-process))
-	 (request (jdee-dbs-trace-methods-request "trace methods request"
-						 :trace-type (oref this trace-type)))
-	 (cmd  (jdee-dbs-trace-methods
-		"trace methods command"
-		:process process :trace-request request)))
+         (thread-suspension-policy (widget-value (oref this suspend-policy-field)))
+         (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
+         (class-exclusion-filters (widget-value (oref this class-exclusion-field)))
+         (process (jdee-dbs-get-target-process))
+         (request (jdee-dbs-trace-methods-request "trace methods request"
+                                                 :trace-type (oref this trace-type)))
+         (cmd  (jdee-dbs-trace-methods
+                "trace methods command"
+                :process process :trace-request request)))
 
     (if (and thread-restriction (not (string= thread-restriction "")))
-	(oset request :thread-restriction thread-restriction))
+        (oset request :thread-restriction thread-restriction))
 
     (if (and thread-suspension-policy (not (string= thread-suspension-policy "")))
-	(oset request :suspend-policy thread-suspension-policy))
+        (oset request :suspend-policy thread-suspension-policy))
 
     (if class-inclusion-filters
-	(oset request :inclusion-filters class-inclusion-filters))
+        (oset request :inclusion-filters class-inclusion-filters))
 
     (if class-exclusion-filters
-	(oset request :exclusion-filters class-exclusion-filters))
+        (oset request :exclusion-filters class-exclusion-filters))
 
     (jdee-dbs-cmd-exec cmd)
     (call-next-method)))
@@ -904,7 +904,7 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   "Displays the trace method exit dialog."
   (interactive)
   (let ((dialog (jdee-bug-trace-methods-dialog
-		 "trace method exit dialog" :trace-type "exit")))
+                 "trace method exit dialog" :trace-type "exit")))
     (efc-dialog-show dialog)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -916,19 +916,19 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 
 (defclass jdee-bug-trace-classes-dialog (efc-dialog)
   ((trace-type               :initarg :trace-type
-			     :type string
-			     :initform "preparation"
-			     :documentation
-			     "Values may be preparation or unloading.")
+                             :type string
+                             :initform "preparation"
+                             :documentation
+                             "Values may be preparation or unloading.")
    (suspend-policy-field     :initarg :suspend-policy-field
-			     :documentation
-			     "Text field that specifies the thread suspension policy.")
+                             :documentation
+                             "Text field that specifies the thread suspension policy.")
    (class-inclusion-field    :initarg :class-inclusion-field
-			     :documentation
-			     "Specifies class inclusion filters.")
+                             :documentation
+                             "Specifies class inclusion filters.")
    (class-exclusion-field    :initarg :class-exclusion-field
-			     :documentation
-			     "Specifies class exclusion filters.")
+                             :documentation
+                             "Specifies class exclusion filters.")
    )
   "Class of trace classes dialogs."
 )
@@ -940,72 +940,72 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (call-next-method)
 
   (assert (or (string= (oref this trace-type) "preparation")
-	      (string= (oref this trace-type) "unloading")))
+              (string= (oref this trace-type) "unloading")))
 )
 
 
 (defmethod efc-dialog-create ((this jdee-bug-trace-classes-dialog))
 
   (widget-insert (concat "Trace class "
-			 (oref this trace-type)
-			 "\n\n"))
+                         (oref this trace-type)
+                         "\n\n"))
 
   (oset this suspend-policy-field
-	(widget-create
-	 '(choice
-	   :tag "Thread Suspension Policy"
-	   :value "none"
-	   :format "  %t: %[Options%] %v  %h\n\n"
-	   :doc "Specify which thread to suspend on class preparation or unloading."
-	   (const "all")
-	   (const "thread")
-	   (const "none"))))
+        (widget-create
+         '(choice
+           :tag "Thread Suspension Policy"
+           :value "none"
+           :format "  %t: %[Options%] %v  %h\n\n"
+           :doc "Specify which thread to suspend on class preparation or unloading."
+           (const "all")
+           (const "thread")
+           (const "none"))))
 
 
   (oset this class-inclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class inclusion filters"
-	   :doc "Regular expressions that specify classes whose preparation or unloading should be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class inclusion filters"
+           :doc "Regular expressions that specify classes whose preparation or unloading should be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
 
     (oset this class-exclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class exclusion filters"
-	   :doc "Regular expressions that specify classes whose preparation or unloading should not be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class exclusion filters"
+           :doc "Regular expressions that specify classes whose preparation or unloading should not be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
   )
 
 (defmethod efc-dialog-ok ((this jdee-bug-trace-classes-dialog))
   (let* ((thread-suspension-policy (widget-value (oref this suspend-policy-field)))
-	 (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
-	 (class-exclusion-filters (widget-value (oref this class-inclusion-field)))
-	 (process (jdee-dbs-get-target-process))
-	 (request (jdee-dbs-trace-classes-request "trace classes request"
-						 :trace-type (oref this trace-type)))
-	 (cmd  (jdee-dbs-trace-classes
-		"trace classes command"
-		:process process :trace-request request)))
+         (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
+         (class-exclusion-filters (widget-value (oref this class-inclusion-field)))
+         (process (jdee-dbs-get-target-process))
+         (request (jdee-dbs-trace-classes-request "trace classes request"
+                                                 :trace-type (oref this trace-type)))
+         (cmd  (jdee-dbs-trace-classes
+                "trace classes command"
+                :process process :trace-request request)))
 
     (if (and thread-suspension-policy (not (string= thread-suspension-policy "")))
-	(oset request :suspend-policy thread-suspension-policy))
+        (oset request :suspend-policy thread-suspension-policy))
 
     (if class-inclusion-filters
-	(oset request :inclusion-filters class-inclusion-filters))
+        (oset request :inclusion-filters class-inclusion-filters))
 
     (if class-exclusion-filters
-	(oset request :exclusion-filters class-exclusion-filters))
+        (oset request :exclusion-filters class-exclusion-filters))
 
     (jdee-dbs-cmd-exec cmd)
     (call-next-method)))
@@ -1021,7 +1021,7 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   "Displays the trace class unloading dialog."
   (interactive)
   (let ((dialog (jdee-bug-trace-classes-dialog
-		 "trace class unloading dialog" :trace-type "unloading")))
+                 "trace class unloading dialog" :trace-type "unloading")))
     (efc-dialog-show dialog)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1033,23 +1033,23 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 
 (defclass jdee-bug-trace-exceptions-dialog (efc-dialog)
   ((exception-class-field    :initarg :exception-class
-			     :documentation
-			     "Class of exception to trace.")
+                             :documentation
+                             "Class of exception to trace.")
    (trace-type-field         :initarg :trace-type
-			     :documentation
-			     "Values may be caught, uncaught, or both.")
+                             :documentation
+                             "Values may be caught, uncaught, or both.")
    (thread-restriction-field :initarg :thread-restriction-field
-			     :documentation
-			     "Text field that contains thread restriction.")
+                             :documentation
+                             "Text field that contains thread restriction.")
    (suspend-policy-field     :initarg :suspend-policy-field
-			     :documentation
-			     "Text field that specifies the thread suspension policy.")
+                             :documentation
+                             "Text field that specifies the thread suspension policy.")
    (class-inclusion-field    :initarg :class-inclusion-field
-			     :documentation
-			     "Specifies class inclusion filters.")
+                             :documentation
+                             "Specifies class inclusion filters.")
    (class-exclusion-field    :initarg :class-exclusion-field
-			     :documentation
-			     "Specifies class exclusion filters.")
+                             :documentation
+                             "Specifies class exclusion filters.")
    )
   "Defines a trace exception dialog."
 )
@@ -1068,96 +1068,96 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (widget-insert (concat "Trace exception\n\n"))
 
   (oset this exception-class-field
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Exception class"
-	 :doc "Name of class of exception to trace. May be a wild card pattern of the form *.name. This allows you to omit a package qualifier from a class name. For example, to trace occurences of java.io.IOException, specify *.IOException."))
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Exception class"
+         :doc "Name of class of exception to trace. May be a wild card pattern of the form *.name. This allows you to omit a package qualifier from a class name. For example, to trace occurences of java.io.IOException, specify *.IOException."))
 
   (oset this trace-type-field
-	(widget-create
-	 '(choice
-	   :tag "Exception type"
-	   :value "both"
-	   :format "  %t: %[Options%] %v  %h\n\n"
-	   :doc "Specify the type of exception to trace."
-	   (const "caught")
-	   (const "uncaught")
-	   (const "both"))))
+        (widget-create
+         '(choice
+           :tag "Exception type"
+           :value "both"
+           :format "  %t: %[Options%] %v  %h\n\n"
+           :doc "Specify the type of exception to trace."
+           (const "caught")
+           (const "uncaught")
+           (const "both"))))
 
   (oset this thread-restriction-field
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Thread restriction"
-	 :doc "Restrict trace to the specified thread."))
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Thread restriction"
+         :doc "Restrict trace to the specified thread."))
 
   (oset this suspend-policy-field
-	(widget-create
-	 '(choice
-	   :tag "Thread Suspension Policy"
-	   :value "none"
-	   :format "  %t: %[Options%] %v  %h\n\n"
-	   :doc "Specify which thread to suspend on class preparation or unloading."
-	   (const "all")
-	   (const "thread")
-	   (const "none"))))
+        (widget-create
+         '(choice
+           :tag "Thread Suspension Policy"
+           :value "none"
+           :format "  %t: %[Options%] %v  %h\n\n"
+           :doc "Specify which thread to suspend on class preparation or unloading."
+           (const "all")
+           (const "thread")
+           (const "none"))))
 
 
   (oset this class-inclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class inclusion filters"
-	   :doc "Regular expressions that specify classes whose preparation or unloading should be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class inclusion filters"
+           :doc "Regular expressions that specify classes whose preparation or unloading should be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
 
     (oset this class-exclusion-field
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class exclusion filters"
-	   :doc "Regular expressions that specify classes whose preparation or unloading should not be traced."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class exclusion filters"
+           :doc "Regular expressions that specify classes whose preparation or unloading should not be traced."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
   )
 
 (defmethod efc-dialog-ok ((this jdee-bug-trace-exceptions-dialog))
   (let* ((exception-class (widget-value (oref this exception-class-field)))
-	 (trace-type (widget-value (oref this trace-type-field)))
-	 (thread-restriction (widget-value (oref this thread-restriction-field)))
-	 (thread-suspension-policy (widget-value (oref this suspend-policy-field)))
-	 (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
-	 (class-exclusion-filters (widget-value (oref this class-inclusion-field)))
-	 (process (jdee-dbs-get-target-process))
-	 (request (jdee-dbs-trace-exceptions-request
-		   "trace exceptions request"
-		   :exception-class exception-class
-		   :trace-type trace-type))
-	 (cmd  (jdee-dbs-trace-exceptions
-		"trace exceptions command"
-		:process process :trace-request request)))
+         (trace-type (widget-value (oref this trace-type-field)))
+         (thread-restriction (widget-value (oref this thread-restriction-field)))
+         (thread-suspension-policy (widget-value (oref this suspend-policy-field)))
+         (class-inclusion-filters (widget-value (oref this class-inclusion-field)))
+         (class-exclusion-filters (widget-value (oref this class-inclusion-field)))
+         (process (jdee-dbs-get-target-process))
+         (request (jdee-dbs-trace-exceptions-request
+                   "trace exceptions request"
+                   :exception-class exception-class
+                   :trace-type trace-type))
+         (cmd  (jdee-dbs-trace-exceptions
+                "trace exceptions command"
+                :process process :trace-request request)))
 
     (if (and thread-restriction (not (string= thread-restriction "")))
-	(oset request :thread-restriction thread-restriction))
+        (oset request :thread-restriction thread-restriction))
 
     (if (and thread-suspension-policy (not (string= thread-suspension-policy "")))
-	(oset request :suspend-policy thread-suspension-policy))
+        (oset request :suspend-policy thread-suspension-policy))
 
     (if class-inclusion-filters
-	(oset request :inclusion-filters class-inclusion-filters))
+        (oset request :inclusion-filters class-inclusion-filters))
 
     (if class-exclusion-filters
-	(oset request :exclusion-filters class-exclusion-filters))
+        (oset request :exclusion-filters class-exclusion-filters))
 
     (jdee-dbs-cmd-exec cmd)
     (call-next-method)))
@@ -1165,14 +1165,14 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 (defun jdee-bug-break-on-exception (exception-class)
   (interactive "sFully qualified exception: ")
   (let* ((process (jdee-dbs-get-target-process))
-	 (request (jdee-dbs-trace-exceptions-request
-		   "break on exceptions request"
-		   :exception-class exception-class
-		   :trace-type "both"
-		   :suspend-policy "all"))
-	 (cmd (jdee-dbs-trace-exceptions
-	       "break on exceptions command"
-	       :process process :trace-request request)))
+         (request (jdee-dbs-trace-exceptions-request
+                   "break on exceptions request"
+                   :exception-class exception-class
+                   :trace-type "both"
+                   :suspend-policy "all"))
+         (cmd (jdee-dbs-trace-exceptions
+               "break on exceptions command"
+               :process process :trace-request request)))
     (jdee-dbs-cmd-exec cmd)
     (jdee-dbs-proc-display-debug-message process "Use JDEbug->Trace->Cancel to remove this breakpoint")))
 
@@ -1195,55 +1195,55 @@ You can use the notation [f1], [f2], etc., to specify function keys."
 (defun jdee-bug-cancel-trace-request (process request)
   "Cancels a specified trace request on a specified process."
   (let ((cmd (jdee-dbs-cancel-trace "cancel trace" :process process
-				  :trace-request request)))
+                                  :trace-request request)))
     (jdee-dbs-cmd-exec cmd)))
 
 (defclass jdee-bug-cancel-trace-dialog (efc-dialog)
   ((process          :initarg :process
-		     :type jdee-dbs-proc)
+                     :type jdee-dbs-proc)
    (requests         :initarg :requests
-		     :type list)
+                     :type list)
    (check-boxes      :initarg :check-boxes))
 )
 
 (defmethod efc-dialog-create ((this jdee-bug-cancel-trace-dialog))
   (let ((items
-	 (mapcar
-	  (lambda (x)
-	    (let ((request (cdr x)))
-	      (list
-	       'const
-	       :format "%t %v  %d"
-	       :tag "Request"
-	       :doc
-	       (concat
-		(if (typep request 'jdee-dbs-trace-methods-request)
-		    (progn
-		      (concat
-		      (format "Trace method %s." (oref request trace-type))
-		      (if (slot-boundp request 'thread-restriction)
-			  (format " Thread restriction: %s."
-				  (oref request thread-restriction)))))
-		  (format "Trace class %s." (oref request trace-type)))
-		(if (slot-boundp request 'suspend-policy)
-		    (format " Suspend policy: %s." (oref request suspend-policy)))
-		(if (slot-boundp request 'inclusion-filters)
-		    (format " Inclusion filters: %s." (oref request inclusion-filters)))
-		(if (slot-boundp request 'exclusion-filters)
-		    (format " Exclusion filters: %s." (oref request exclusion-filters)))
-		)
-	       (car x))))
-	  (oref this requests))))
+         (mapcar
+          (lambda (x)
+            (let ((request (cdr x)))
+              (list
+               'const
+               :format "%t %v  %d"
+               :tag "Request"
+               :doc
+               (concat
+                (if (typep request 'jdee-dbs-trace-methods-request)
+                    (progn
+                      (concat
+                      (format "Trace method %s." (oref request trace-type))
+                      (if (slot-boundp request 'thread-restriction)
+                          (format " Thread restriction: %s."
+                                  (oref request thread-restriction)))))
+                  (format "Trace class %s." (oref request trace-type)))
+                (if (slot-boundp request 'suspend-policy)
+                    (format " Suspend policy: %s." (oref request suspend-policy)))
+                (if (slot-boundp request 'inclusion-filters)
+                    (format " Inclusion filters: %s." (oref request inclusion-filters)))
+                (if (slot-boundp request 'exclusion-filters)
+                    (format " Exclusion filters: %s." (oref request exclusion-filters)))
+                )
+               (car x))))
+          (oref this requests))))
 
   (widget-insert "Check the trace requests you want to cancel.\n\n")
 
   (oset this check-boxes
-	(widget-create
-	 (list
-	  'checklist
-	  :entry-format "  %b %v\n"
-	  :args items
-	   )))
+        (widget-create
+         (list
+          'checklist
+          :entry-format "  %b %v\n"
+          :args items
+           )))
   ))
 
 (defmethod efc-dialog-ok ((this jdee-bug-cancel-trace-dialog))
@@ -1251,10 +1251,10 @@ You can use the notation [f1], [f2], etc., to specify function keys."
   (mapc
    (lambda (id-x)
      (let ((request
-	    (cdr
-	     (cl-find-if
-	      (lambda (x) (= (car x) id-x))
-	     (oref this requests)))))
+            (cdr
+             (cl-find-if
+              (lambda (x) (= (car x) id-x))
+             (oref this requests)))))
      (jdee-bug-cancel-trace-request  (oref this process) request)))
    (widget-value (oref this check-boxes)))
   (call-next-method))
@@ -1269,15 +1269,15 @@ requests to cancel."
  (let* ((process (jdee-dbs-get-target-process)))
    (if process
        (if (slot-boundp process 'trace-req)
-	   (let ((trace-requests (oref process :trace-req)))
-	     (if (= (length trace-requests) 1)
-		 (jdee-bug-cancel-trace-request process (cdr (car trace-requests)))
-	       (let ((dialog
-		      (jdee-bug-cancel-trace-dialog "cancel trace dialog"
-						   :process process
-						   :requests trace-requests)))
-		 (efc-dialog-show dialog))))
-	 (error "The target process has no outstanding trace requests"))
+           (let ((trace-requests (oref process :trace-req)))
+             (if (= (length trace-requests) 1)
+                 (jdee-bug-cancel-trace-request process (cdr (car trace-requests)))
+               (let ((dialog
+                      (jdee-bug-cancel-trace-dialog "cancel trace dialog"
+                                                   :process process
+                                                   :requests trace-requests)))
+                 (efc-dialog-show dialog))))
+         (error "The target process has no outstanding trace requests"))
      (error "There is no active process."))))
 
 
@@ -1292,44 +1292,44 @@ requests to cancel."
 
 (defclass jdee-bug-watch-field-dialog (efc-dialog)
   ((watch-type                :initarg :watch-type
-			      :type string
-			      :initform "access"
-			      :documentation
-			      "Watch type: field access or modification.")
+                              :type string
+                              :initform "access"
+                              :documentation
+                              "Watch type: field access or modification.")
    (object-class              :initarg :object-class
-			      :type string
-			      :initform ""
-			      :documentation
-			      "Default value of class to watch.")
+                              :type string
+                              :initform ""
+                              :documentation
+                              "Default value of class to watch.")
    (field                     :initarg :field
-			      :type string
-			      :initform ""
-			      :documentation
-			      "Default value of the field to watch.")
+                              :type string
+                              :initform ""
+                              :documentation
+                              "Default value of the field to watch.")
    (object-class-widget       :initarg :object-class-widget
-			      :documentation
-			      "Widget specifying class of objects to watch.")
+                              :documentation
+                              "Widget specifying class of objects to watch.")
    (field-name-widget         :initarg :field-name-widget
-			      :documentation
-			      "Widget specify name of field to watch.")
+                              :documentation
+                              "Widget specify name of field to watch.")
    (expression-widget         :initarg :expression-widget
-			      :documentation
-			      "Widget specify watch restriction expression.")
+                              :documentation
+                              "Widget specify watch restriction expression.")
    (object-id-widget          :initarg :object-id-widget
-			      :documentation
-			      "Widget specify id of object to watch.")
+                              :documentation
+                              "Widget specify id of object to watch.")
    (thread-restriction-widget :initarg :thread-restriction-widget
-			      :documentation
-			      "Text field that contains thread restriction.")
+                              :documentation
+                              "Text field that contains thread restriction.")
    (suspend-policy-widget     :initarg :suspend-policy-widget
-			      :documentation
-			      "Text field that specifies the thread suspension policy.")
+                              :documentation
+                              "Text field that specifies the thread suspension policy.")
    (class-inclusion-widget    :initarg :class-inclusion-widget
-			      :documentation
-			     "Specifies class inclusion filters.")
+                              :documentation
+                             "Specifies class inclusion filters.")
    (class-exclusion-widget    :initarg :class-exclusion-widget
-			     :documentation
-			     "Specifies class exclusion filters.")
+                             :documentation
+                             "Specifies class exclusion filters.")
    )
   "Defines a watch field dialog."
 )
@@ -1348,122 +1348,122 @@ requests to cancel."
   (widget-insert (format "Watch for field %s\n\n" (oref this watch-type)))
 
   (oset this object-class-widget
-	(widget-create
-	 'editable-field
-	 :value (oref this object-class)
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Class"
-	 :doc "Class of object or objects to watch.
+        (widget-create
+         'editable-field
+         :value (oref this object-class)
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Class"
+         :doc "Class of object or objects to watch.
 May be a wild card pattern of the form *.name. This allows you to omit a package qualifier from a class name. For example, to watch a field of java.io.IOException, specify *.IOException."))
 
 
   (oset this field-name-widget
-	(widget-create
-	 'editable-field
-	 :value (oref this field)
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Field name"
-	 :doc "Name of field to watch."))
+        (widget-create
+         'editable-field
+         :value (oref this field)
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Field name"
+         :doc "Name of field to watch."))
 
   (oset this expression-widget
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Watch expression"
-	 :doc "A boolean expression.
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Watch expression"
+         :doc "A boolean expression.
 Execution of the process is suspended only if the expression is true. The expression can contain any variable that is in scope when a field changes."))
 
   (oset this object-id-widget
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Object ID"
-	 :doc "ID of the object to watch."))
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Object ID"
+         :doc "ID of the object to watch."))
 
   (oset this thread-restriction-widget
-	(widget-create
-	 'editable-field
-	 :format "  %t:  %v\n  %h \n\n"
-	 :size 40
-	 :tag "Thread restriction"
-	 :doc "Restrict watch to the specified thread."))
+        (widget-create
+         'editable-field
+         :format "  %t:  %v\n  %h \n\n"
+         :size 40
+         :tag "Thread restriction"
+         :doc "Restrict watch to the specified thread."))
 
   (oset this suspend-policy-widget
-	(widget-create
-	 '(choice
-	   :tag "Thread Suspension Policy"
-	   :value "all"
-	   :format "  %t: %[Options%] %v  %h\n\n"
-	   :doc "Specify which threads to suspend on field access or modification."
-	   (const "all")
-	   (const "thread")
-	   (const "none"))))
+        (widget-create
+         '(choice
+           :tag "Thread Suspension Policy"
+           :value "all"
+           :format "  %t: %[Options%] %v  %h\n\n"
+           :doc "Specify which threads to suspend on field access or modification."
+           (const "all")
+           (const "thread")
+           (const "none"))))
 
 
   (oset this class-inclusion-widget
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class inclusion filters"
-	   :doc "Regular expressions that specify classes whose field should be watched."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter"))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class inclusion filters"
+           :doc "Regular expressions that specify classes whose field should be watched."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter"))))
 
     (oset this class-exclusion-widget
-	(widget-create
-	 '(editable-list
-	   :format "  %t:\n  %i\n%v  %h\n\n"
-	   :entry-format "  %i %d %v\n"
-	   :tag "Class exclusion filters"
-	   :doc "Regular expressions that specify classes whose fields should not be watched."
-	   (string
-	    :format "%t: %v"
-	    :size 40
-	    :tag "Filter")))))
+        (widget-create
+         '(editable-list
+           :format "  %t:\n  %i\n%v  %h\n\n"
+           :entry-format "  %i %d %v\n"
+           :tag "Class exclusion filters"
+           :doc "Regular expressions that specify classes whose fields should not be watched."
+           (string
+            :format "%t: %v"
+            :size 40
+            :tag "Filter")))))
 
 (defmethod efc-dialog-ok ((this jdee-bug-watch-field-dialog))
   (let* ((obj-class (widget-value (oref this object-class-widget)))
-	 (field-name (widget-value (oref this field-name-widget)))
-	 (expression (widget-value (oref this expression-widget)))
-	 (object-id (widget-value (oref this object-id-widget)))
-	 (thread-restriction (widget-value (oref this thread-restriction-widget)))
-	 (thread-suspension-policy (widget-value (oref this suspend-policy-widget)))
-	 (class-inclusion-filters (widget-value (oref this class-inclusion-widget)))
-	 (class-exclusion-filters (widget-value (oref this class-inclusion-widget)))
-	 (process (jdee-dbs-get-target-process))
-	 (request (jdee-dbs-watch-field-request
-		   "watch field request"
-		   :watch-type (oref this watch-type)
-		   :object-class obj-class
-		   :field-name field-name))
-	 (cmd  (jdee-dbs-watch-field
-		"watch field command"
-		:process process :watch-request request)))
+         (field-name (widget-value (oref this field-name-widget)))
+         (expression (widget-value (oref this expression-widget)))
+         (object-id (widget-value (oref this object-id-widget)))
+         (thread-restriction (widget-value (oref this thread-restriction-widget)))
+         (thread-suspension-policy (widget-value (oref this suspend-policy-widget)))
+         (class-inclusion-filters (widget-value (oref this class-inclusion-widget)))
+         (class-exclusion-filters (widget-value (oref this class-inclusion-widget)))
+         (process (jdee-dbs-get-target-process))
+         (request (jdee-dbs-watch-field-request
+                   "watch field request"
+                   :watch-type (oref this watch-type)
+                   :object-class obj-class
+                   :field-name field-name))
+         (cmd  (jdee-dbs-watch-field
+                "watch field command"
+                :process process :watch-request request)))
 
     (if (and expression (not (string= expression "")))
-	(oset request :expression expression))
+        (oset request :expression expression))
 
     (if (and object-id (not (string= object-id "")))
-	(oset request :object-id object-id))
+        (oset request :object-id object-id))
 
     (if (and thread-restriction (not (string= thread-restriction "")))
-	(oset request :thread-restriction thread-restriction))
+        (oset request :thread-restriction thread-restriction))
 
     (if (and thread-suspension-policy (not (string= thread-suspension-policy "")))
-	(oset request :suspend-policy thread-suspension-policy))
+        (oset request :suspend-policy thread-suspension-policy))
 
     (if class-inclusion-filters
-	(oset request :inclusion-filters class-inclusion-filters))
+        (oset request :inclusion-filters class-inclusion-filters))
 
     (if class-exclusion-filters
-	(oset request :exclusion-filters class-exclusion-filters))
+        (oset request :exclusion-filters class-exclusion-filters))
 
     (jdee-dbs-cmd-exec cmd)
     (call-next-method)))
@@ -1474,12 +1474,12 @@ Execution of the process is suspended only if the expression is true. The expres
 field of an object or class of objects."
   (interactive)
   (let ((dialog
-	 (jdee-bug-watch-field-dialog
-	  "watch field dialog"
-	  :object-class (concat
-			 "*."
-			 (car (jdee-parse-get-innermost-class-at-point)))
-	  :field (thing-at-point 'symbol))))
+         (jdee-bug-watch-field-dialog
+          "watch field dialog"
+          :object-class (concat
+                         "*."
+                         (car (jdee-parse-get-innermost-class-at-point)))
+          :field (thing-at-point 'symbol))))
     (efc-dialog-show dialog)))
 
 (defun jdee-bug-watch-field-modification ()
@@ -1487,12 +1487,12 @@ field of an object or class of objects."
 field of an object or class of objects."
   (interactive)
   (let ((dialog (jdee-bug-watch-field-dialog
-		 "watch field dialog"
-		 :watch-type "modification"
-		 :object-class (concat
-				"*."
-				(car (jdee-parse-get-innermost-class-at-point)))
-		 :field (thing-at-point 'symbol))))
+                 "watch field dialog"
+                 :watch-type "modification"
+                 :object-class (concat
+                                "*."
+                                (car (jdee-parse-get-innermost-class-at-point)))
+                 :field (thing-at-point 'symbol))))
     (efc-dialog-show dialog)))
 
 
@@ -1505,48 +1505,48 @@ field of an object or class of objects."
 (defun jdee-bug-cancel-watch-request (process request)
   "Cancels a specified watch field request on a specified process."
   (let ((cmd (jdee-dbs-cancel-watch "cancel watch" :process process
-				  :watch-request request)))
+                                  :watch-request request)))
     (jdee-dbs-cmd-exec cmd)))
 
 (defclass jdee-bug-cancel-watch-dialog (efc-dialog)
   ((process          :initarg :process
-		     :type jdee-dbs-proc)
+                     :type jdee-dbs-proc)
    (requests         :initarg :requests
-		     :type list)
+                     :type list)
    (check-boxes      :initarg :check-boxes))
 )
 
 (defmethod efc-dialog-create ((this jdee-bug-cancel-watch-dialog))
   (let ((items
-	 (mapcar
-	  (lambda (x)
-	    (let ((request (cdr x)))
-	      (list
-	       'const
-	       :format "%t %v  %d"
-	       :tag "Request"
-	       :doc
-	       (concat
-		(format "Watch type: %s. Class: %s. Field: %s."
-		       (oref request watch-type)
-		       (oref request object-class)
-		       (oref request field-name))
-		(if (slot-boundp request 'object-id)
-		    (concat " Object id: " (oref request object-id) "."))
-		(if (slot-boundp request 'expression)
-		    (concat " Expression: " (oref request expression) ".")))
-	       (car x))))
-	  (oref this requests))))
+         (mapcar
+          (lambda (x)
+            (let ((request (cdr x)))
+              (list
+               'const
+               :format "%t %v  %d"
+               :tag "Request"
+               :doc
+               (concat
+                (format "Watch type: %s. Class: %s. Field: %s."
+                       (oref request watch-type)
+                       (oref request object-class)
+                       (oref request field-name))
+                (if (slot-boundp request 'object-id)
+                    (concat " Object id: " (oref request object-id) "."))
+                (if (slot-boundp request 'expression)
+                    (concat " Expression: " (oref request expression) ".")))
+               (car x))))
+          (oref this requests))))
 
   (widget-insert "Check the watch requests you want to cancel.\n\n")
 
   (oset this check-boxes
-	(widget-create
-	 (list
-	  'checklist
-	  :entry-format "  %b %v\n"
-	  :args items
-	   )))
+        (widget-create
+         (list
+          'checklist
+          :entry-format "  %b %v\n"
+          :args items
+           )))
   ))
 
 (defmethod efc-dialog-ok ((this jdee-bug-cancel-watch-dialog))
@@ -1554,10 +1554,10 @@ field of an object or class of objects."
   (mapc
    (lambda (id-x)
      (let ((request
-	    (cdr
-	     (cl-find-if
-	      (lambda (x) (= (car x) id-x))
-	     (oref this requests)))))
+            (cdr
+             (cl-find-if
+              (lambda (x) (= (car x) id-x))
+             (oref this requests)))))
      (jdee-bug-cancel-watch-request  (oref this process) request)))
    (widget-value (oref this check-boxes)))
   (call-next-method))
@@ -1572,30 +1572,30 @@ requests to cancel."
  (let* ((process (jdee-dbs-get-target-process)))
    (if process
        (if (slot-boundp process 'watch-req)
-	   (let ((watch-requests (oref process :watch-req)))
-	     (if (= (length watch-requests) 1)
-		 (jdee-bug-cancel-watch-request process (cdr (car watch-requests)))
-	       (let ((dialog
-		      (jdee-bug-cancel-watch-dialog "cancel watch dialog"
-						   :process process
-						   :requests watch-requests)))
-		 (efc-dialog-show dialog))))
-	 (error "The target process has no outstanding watch requests"))
+           (let ((watch-requests (oref process :watch-req)))
+             (if (= (length watch-requests) 1)
+                 (jdee-bug-cancel-watch-request process (cdr (car watch-requests)))
+               (let ((dialog
+                      (jdee-bug-cancel-watch-dialog "cancel watch dialog"
+                                                   :process process
+                                                   :requests watch-requests)))
+                 (efc-dialog-show dialog))))
+         (error "The target process has no outstanding watch requests"))
      (error "There is no active process."))))
 
 (defun jdee-make-frame-names-alist ()
   (let* ((current-frame (selected-frame))
-	 (falist
-	  (cons
-	   (cons (frame-parameter current-frame 'name)
-		 current-frame) nil))
-	 (frame (next-frame nil t)))
+         (falist
+          (cons
+           (cons (frame-parameter current-frame 'name)
+                 current-frame) nil))
+         (frame (next-frame nil t)))
     (while (not (eq frame current-frame))
       (progn
-	(setq falist (cons (cons
-			    (frame-parameter frame 'name)
-			    frame) falist))
-	(setq frame (next-frame frame t))))
+        (setq falist (cons (cons
+                            (frame-parameter frame 'name)
+                            frame) falist))
+        (setq frame (next-frame frame t))))
     falist))
 
 (defun jdee-bug-show-debug-frame ()
@@ -1608,46 +1608,46 @@ requests to cancel."
           (raise-frame existing-frame)
           (select-frame existing-frame))
       (let* ((process (jdee-dbs-get-target-process))
-	     (cli-buffer (when (slot-boundp process 'cli-buf)
+             (cli-buffer (when (slot-boundp process 'cli-buf)
                            (oref process cli-buf)))
-	     (locals-buffer (when (slot-boundp process 'locals-buf)
+             (locals-buffer (when (slot-boundp process 'locals-buf)
                               (oref process locals-buf)))
-	     (threads-buffer (when (slot-boundp process 'threads-buf)
+             (threads-buffer (when (slot-boundp process 'threads-buf)
                                (oref process threads-buf)))
-	     (msg-buffer (when (slot-boundp process 'msg-buf)
+             (msg-buffer (when (slot-boundp process 'msg-buf)
                            (oref process msg-buf)))
-	     (frame (make-frame '((name . "JDebug") (minibuffer . nil))))
-	     (height (/ (frame-height frame)
-			(cl-count-if 'identity
-				     (list cli-buffer
-					   locals-buffer
-					   threads-buffer
-					   msg-buffer))))
-	     (init-frame (selected-frame))
-	     (init-config (current-window-configuration))
-	     (prev-window))
-	(save-excursion
-	  (select-frame frame)
-	  ;; msg buffer should always be there, if not this could break
-	  (switch-to-buffer msg-buffer)
-	  (setq prev-window (get-buffer-window msg-buffer))
-	  (when locals-buffer
-	    (let ((locals-win (split-window prev-window height)))
-	      (setq prev-window locals-win)
-	      (when (not jdee-bug-local-variables)
-		(jdee-bug-toggle-local-variables)
-		(sleep-for 0 100))
-	      (set-window-buffer locals-win locals-buffer)))
-	  (when threads-buffer
-	    (let ((threads-win (split-window prev-window height)))
-	      (setq prev-window threads-win)
-	      (jdee-bug-show-threads)
-	      (set-window-buffer threads-win threads-buffer)))
-	  (when cli-buffer
-	    (let ((cli-win (split-window prev-window height)))
-	      (set-window-buffer cli-win cli-buffer)))
-	  (select-frame init-frame)
-	  (set-window-configuration init-config))))))
+             (frame (make-frame '((name . "JDebug") (minibuffer . nil))))
+             (height (/ (frame-height frame)
+                        (cl-count-if 'identity
+                                     (list cli-buffer
+                                           locals-buffer
+                                           threads-buffer
+                                           msg-buffer))))
+             (init-frame (selected-frame))
+             (init-config (current-window-configuration))
+             (prev-window))
+        (save-excursion
+          (select-frame frame)
+          ;; msg buffer should always be there, if not this could break
+          (switch-to-buffer msg-buffer)
+          (setq prev-window (get-buffer-window msg-buffer))
+          (when locals-buffer
+            (let ((locals-win (split-window prev-window height)))
+              (setq prev-window locals-win)
+              (when (not jdee-bug-local-variables)
+                (jdee-bug-toggle-local-variables)
+                (sleep-for 0 100))
+              (set-window-buffer locals-win locals-buffer)))
+          (when threads-buffer
+            (let ((threads-win (split-window prev-window height)))
+              (setq prev-window threads-win)
+              (jdee-bug-show-threads)
+              (set-window-buffer threads-win threads-buffer)))
+          (when cli-buffer
+            (let ((cli-win (split-window prev-window height)))
+              (set-window-buffer cli-win cli-buffer)))
+          (select-frame init-frame)
+          (set-window-configuration init-config))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1684,23 +1684,23 @@ any variables in scope in the program being debugged."
       (error "Empty expression."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (state-info (oref process state-info))
-	 (thread-id (oref state-info thread-id))
-	 (evaluate-command
-	  (jdee-dbs-evaluate
-	   (format "Evaluate %s" expression)
-	   :process process
-	   :expression expression
-	   :thread-id thread-id))
-	 (result
-	  (jdee-dbs-cmd-exec evaluate-command)))
+         (state-info (oref process state-info))
+         (thread-id (oref state-info thread-id))
+         (evaluate-command
+          (jdee-dbs-evaluate
+           (format "Evaluate %s" expression)
+           :process process
+           :expression expression
+           :thread-id thread-id))
+         (result
+          (jdee-dbs-cmd-exec evaluate-command)))
     (if result
-	(let* ((type  (nth 0 result))
-	       (value (nth 1 result))
-	       (buf (get-buffer-create (concat "Expression: " expression))))
-	    (jdee-dbo-view-var-in-buf (jdee-dbs-objectify-value result)
-				     expression process t buf t)
-	    (pop-to-buffer buf (split-window nil (- (window-height) 4))))
+        (let* ((type  (nth 0 result))
+               (value (nth 1 result))
+               (buf (get-buffer-create (concat "Expression: " expression))))
+            (jdee-dbo-view-var-in-buf (jdee-dbs-objectify-value result)
+                                     expression process t buf t)
+            (pop-to-buffer buf (split-window nil (- (window-height) 4))))
       (message "Error: could not evaluate \"%s\"." expression))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1717,12 +1717,12 @@ any variables in scope in the program being debugged."
       (error "No target process or process is not suspended."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-get-loaded-classes
-	   "get_loaded_classes"
-	   :process process))
-	 (result
-	  (jdee-dbs-cmd-exec cmd)))
+         (cmd
+          (jdee-dbs-get-loaded-classes
+           "get_loaded_classes"
+           :process process))
+         (result
+          (jdee-dbs-cmd-exec cmd)))
     (if (not result)
       (error "Could not get loaded classes."))))
 
@@ -1747,16 +1747,16 @@ button 2."
 
   (if (not jdee-bug-stack-info)
       (progn
-	(jdee-bug-toggle-stack-info)
-	(sleep-for 0 100)))
+        (jdee-bug-toggle-stack-info)
+        (sleep-for 0 100)))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (get-threads-command
-	  (jdee-dbs-get-threads
-	   "get_threads"
-	   :process process))
-	 (result
-	  (jdee-dbs-cmd-exec get-threads-command)))
+         (get-threads-command
+          (jdee-dbs-get-threads
+           "get_threads"
+           :process process))
+         (result
+          (jdee-dbs-cmd-exec get-threads-command)))
     (if (not result)
         (error "Could not get threads"))))
 
@@ -1781,12 +1781,12 @@ that currently owns the object and threads that are waiting to access the object
       (error "No target process or process is not suspended."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (get-monitors-command
-	  (jdee-dbs-get-object-monitors
-	   "get_object_monitors"
-	   :process process :object-id object-id))
-	 (result
-	  (jdee-dbs-cmd-exec get-monitors-command)))))
+         (get-monitors-command
+          (jdee-dbs-get-object-monitors
+           "get_object_monitors"
+           :process process :object-id object-id))
+         (result
+          (jdee-dbs-cmd-exec get-monitors-command)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1803,12 +1803,12 @@ that currently owns the object and threads that are waiting to access the object
       (error "No target process or process is not suspended."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (cmd
-	  (jdee-dbs-get-path-info
-	   "get_path_info"
-	   :process process))
-	 (result
-	  (jdee-dbs-cmd-exec cmd)))
+         (cmd
+          (jdee-dbs-get-path-info
+           "get_path_info"
+           :process process))
+         (result
+          (jdee-dbs-cmd-exec cmd)))
     (if (not result)
       (error "Could not get path info."))))
 
@@ -1840,20 +1840,20 @@ the thread at a breakpoint or step point."
 
   (if (not
        (let* ((process (jdee-dbs-get-target-process))
-	      (stack-max (1- (length (oref process stack))))
-	      (stack-ptr (oref process stack-ptr)))
-	 (< stack-ptr stack-max)))
+              (stack-max (1- (length (oref process stack))))
+              (stack-ptr (oref process stack-ptr)))
+         (< stack-ptr stack-max)))
       (error "The debugger is displaying the top of the stack."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (state-info (oref process :state-info))
-	 (thread-id (oref state-info :thread-id))
-	 (stack (oref process stack))
-	 (stack-ptr (1+ (oref process stack-ptr)))
-	 (frame (nth stack-ptr stack))
-	 (class (nth 1 frame))
-	 (file (nth 2 frame))
-	 (line (nth 3 frame)))
+         (state-info (oref process :state-info))
+         (thread-id (oref state-info :thread-id))
+         (stack (oref process stack))
+         (stack-ptr (1+ (oref process stack-ptr)))
+         (frame (nth stack-ptr stack))
+         (class (nth 1 frame))
+         (file (nth 2 frame))
+         (line (nth 3 frame)))
 
     (oset process :stack-ptr stack-ptr)
     (jdee-db-set-debug-cursor class file line)
@@ -1876,19 +1876,19 @@ the thread at a breakpoint or step point."
       (error "The target process is not suspended at a breakpoint or steppoint."))
 
   (if (not (let* ((process (jdee-dbs-get-target-process))
-		  (stack-ptr (oref process stack-ptr)))
-	     (> stack-ptr 0)))
+                  (stack-ptr (oref process stack-ptr)))
+             (> stack-ptr 0)))
       (error "The debugger is displaying the bottom of the stack."))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (state-info (oref process :state-info))
-	 (thread-id (oref state-info :thread-id))
-	 (stack (oref process stack))
-	 (stack-ptr (1- (oref process stack-ptr)))
-	 (frame (nth stack-ptr stack))
-	 (class (nth 1 frame))
-	 (file (nth 2 frame))
-	 (line (nth 3 frame)))
+         (state-info (oref process :state-info))
+         (thread-id (oref state-info :thread-id))
+         (stack (oref process stack))
+         (stack-ptr (1- (oref process stack-ptr)))
+         (frame (nth stack-ptr stack))
+         (class (nth 1 frame))
+         (file (nth 2 frame))
+         (line (nth 3 frame)))
 
     (oset process :stack-ptr stack-ptr)
     (jdee-db-set-debug-cursor class file line)
@@ -1907,11 +1907,11 @@ Threads->Resume Thread (`jdee-bug-resume-thread') to resume the thread."
   (interactive
    "nThread ID: ")
   (let* ((process (jdee-dbs-get-target-process))
-	 (suspend-command
-	  (jdee-dbs-suspend-thread
-	       (format "suspend thread %d" thread-id)
-	       :process process
-	       :thread-id thread-id)))
+         (suspend-command
+          (jdee-dbs-suspend-thread
+               (format "suspend thread %d" thread-id)
+               :process process
+               :thread-id thread-id)))
     (jdee-dbs-cmd-exec suspend-command)))
 
 
@@ -1930,11 +1930,11 @@ the entire process."
   (interactive
    "nThread ID: ")
   (let* ((process (jdee-dbs-get-target-process))
-	 (resume-command
-	  (jdee-dbs-resume-thread
-	       (format "resume thread %d" thread-id)
-	       :process process
-	       :thread-id thread-id)))
+         (resume-command
+          (jdee-dbs-resume-thread
+               (format "resume thread %d" thread-id)
+               :process process
+               :thread-id thread-id)))
     (jdee-dbs-cmd-exec resume-command)))
 
 
@@ -1953,11 +1953,11 @@ running in the target process. Use Threads->Suspend Thread
   (interactive
    "nThread ID: ")
   (let* ((process (jdee-dbs-get-target-process))
-	 (interrupt-command
-	  (jdee-dbs-interrupt-thread
-	       (format "interrupt thread %d" thread-id)
-	       :process process
-	       :thread-id thread-id)))
+         (interrupt-command
+          (jdee-dbs-interrupt-thread
+               (format "interrupt thread %d" thread-id)
+               :process process
+               :thread-id thread-id)))
     (jdee-dbs-cmd-exec interrupt-command)))
 
 
@@ -1970,12 +1970,12 @@ to creae the exception object."
  (interactive
    "nThread ID: \nnException Id: ")
   (let* ((process (jdee-dbs-get-target-process))
-	 (stop-command
-	  (jdee-dbs-stop-thread
-	       (format "stop thread %d" thread-id)
-	       :process process
-	       :thread-id thread-id
-	       :exception-id exception-id)))
+         (stop-command
+          (jdee-dbs-stop-thread
+               (format "stop thread %d" thread-id)
+               :process process
+               :thread-id thread-id
+               :exception-id exception-id)))
     (jdee-dbs-cmd-exec stop-command)))
 
 (defun jdee-bug-jpda-installed-p ()
@@ -1988,10 +1988,10 @@ to creae the exception object."
     (error "jdee-bug-jpda-directory variable is not set.")
     nil)
    ((not (file-exists-p
-	  (expand-file-name "lib/jpda.jar" (jdee-normalize-path
-					    'jdee-bug-jpda-directory))))
+          (expand-file-name "lib/jpda.jar" (jdee-normalize-path
+                                            'jdee-bug-jpda-directory))))
     (error "Cannot find JPDA jar file at %s"
-	     (expand-file-name "lib/jpda.jar" jdee-bug-jpda-directory))
+             (expand-file-name "lib/jpda.jar" jdee-bug-jpda-directory))
     nil)
    (t
     t)))
@@ -2002,7 +2002,7 @@ to creae the exception object."
   (interactive)
   (if (not (jdee-dbs-debugger-running-p))
       (if (and (jdee-bug-jpda-installed-p)
-	   (jdee-dbs-debugger-start jdee-dbs-the-debugger))
+           (jdee-dbs-debugger-start jdee-dbs-the-debugger))
       (message "Debugger started successfully." )
       (message "Could not start debugger."))
     (message "Debugger is already started")))
@@ -2024,36 +2024,36 @@ to set another process as the target process."
   (interactive)
   (let* ((main-class (jdee-run-get-main-class)))
     (unless (and
-	     (jdee-dbs-proc-set-find jdee-dbs-the-process-registry
-				    :main-class main-class)
-	     (not (yes-or-no-p
-		   (format "An instance of %s is already running. Continue?" main-class))))
+             (jdee-dbs-proc-set-find jdee-dbs-the-process-registry
+                                    :main-class main-class)
+             (not (yes-or-no-p
+                   (format "An instance of %s is already running. Continue?" main-class))))
       (let* ((process
-	      (jdee-dbs-proc (format "process%d"
-				    (setq jdee-dbs-proc-counter
-					  (1+ jdee-dbs-proc-counter)))
-			    :id jdee-dbs-proc-counter :main-class main-class))
-	     (old-target (jdee-dbs-get-target-process))
-	     (launch (jdee-dbs-launch-process
-		      (format "Launch %s" main-class)
-		      :process process
-		      :vmexec (car jdee-bug-vm-executable)
-		      ;; :vmexec "xyz"
-		      ))
-	     (succeededp t))
-	(jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
-	(if (not (string= jdee-bug-jre-home ""))
-	    (oset launch :jre-home (jdee-normalize-path 'jdee-bug-jre-home)))
-	(oset jdee-dbs-the-process-registry :target-process process)
-	(when (not (jdee-dbs-cmd-exec launch))
-	  (jdee-dbs-proc-move-to-morgue process)
-	  (if old-target
-	      (oset jdee-dbs-the-process-registry :target-process old-target))
-	  (jdee-dbs-proc-set-state process "unknown")
-	  (jdee-dbs-proc-set-state-reason process "Error launching process.")
-	  (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
-	  (setq succeededp nil))
-	succeededp))))
+              (jdee-dbs-proc (format "process%d"
+                                    (setq jdee-dbs-proc-counter
+                                          (1+ jdee-dbs-proc-counter)))
+                            :id jdee-dbs-proc-counter :main-class main-class))
+             (old-target (jdee-dbs-get-target-process))
+             (launch (jdee-dbs-launch-process
+                      (format "Launch %s" main-class)
+                      :process process
+                      :vmexec (car jdee-bug-vm-executable)
+                      ;; :vmexec "xyz"
+                      ))
+             (succeededp t))
+        (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
+        (if (not (string= jdee-bug-jre-home ""))
+            (oset launch :jre-home (jdee-normalize-path 'jdee-bug-jre-home)))
+        (oset jdee-dbs-the-process-registry :target-process process)
+        (when (not (jdee-dbs-cmd-exec launch))
+          (jdee-dbs-proc-move-to-morgue process)
+          (if old-target
+              (oset jdee-dbs-the-process-registry :target-process old-target))
+          (jdee-dbs-proc-set-state process "unknown")
+          (jdee-dbs-proc-set-state-reason process "Error launching process.")
+          (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
+          (setq succeededp nil))
+        succeededp))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2068,26 +2068,26 @@ memory. This command works only on Windows."
   (interactive
    "sProcess name: ")
   (let* ((process
-	  (jdee-dbs-proc (format "process%d"
-				(setq jdee-dbs-proc-counter
-				      (1+ jdee-dbs-proc-counter)))
-			:id jdee-dbs-proc-counter :main-class process-name))
-	 (old-target (jdee-dbs-get-target-process))
-	 (attach (jdee-dbs-attach-shmem
-		  (format "Attach %s" process-name)
-		  :process process
-		  :process-name process-name)))
+          (jdee-dbs-proc (format "process%d"
+                                (setq jdee-dbs-proc-counter
+                                      (1+ jdee-dbs-proc-counter)))
+                        :id jdee-dbs-proc-counter :main-class process-name))
+         (old-target (jdee-dbs-get-target-process))
+         (attach (jdee-dbs-attach-shmem
+                  (format "Attach %s" process-name)
+                  :process process
+                  :process-name process-name)))
     (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
     (oset jdee-dbs-the-process-registry :target-process process)
     (if (not (jdee-dbs-cmd-exec attach))
-	(progn
-	  (jdee-dbs-proc-move-to-morgue process)
-	  (if old-target
-	      (oset jdee-dbs-the-process-registry :target-process old-target))
-	  (jdee-dbs-proc-set-state process "unknown")
-	  (jdee-dbs-proc-set-state-reason process "Error launching process.")
-	  (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
-	  nil)
+        (progn
+          (jdee-dbs-proc-move-to-morgue process)
+          (if old-target
+              (oset jdee-dbs-the-process-registry :target-process old-target))
+          (jdee-dbs-proc-set-state process "unknown")
+          (jdee-dbs-proc-set-state-reason process "Error launching process.")
+          (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
+          nil)
       (jdee-bug-set-breakpoints process jdee-db-breakpoints))
     t))
 
@@ -2102,26 +2102,26 @@ to the process via a socket."
   (interactive
    "sProcess Port: ")
   (let* ((process
-	  (jdee-dbs-proc (format "process%d"
-				(setq jdee-dbs-proc-counter
-				      (1+ jdee-dbs-proc-counter)))
-			:id jdee-dbs-proc-counter :main-class process-port))
-	     (old-target (jdee-dbs-get-target-process))
-	     (attach (jdee-dbs-attach-socket
-		      (format "Attach %s" process-port)
-		      :process process
-		      :port process-port)))
+          (jdee-dbs-proc (format "process%d"
+                                (setq jdee-dbs-proc-counter
+                                      (1+ jdee-dbs-proc-counter)))
+                        :id jdee-dbs-proc-counter :main-class process-port))
+             (old-target (jdee-dbs-get-target-process))
+             (attach (jdee-dbs-attach-socket
+                      (format "Attach %s" process-port)
+                      :process process
+                      :port process-port)))
     (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
     (oset jdee-dbs-the-process-registry :target-process process)
     (if (not (jdee-dbs-cmd-exec attach))
-	(progn
-	  (jdee-dbs-proc-move-to-morgue process)
-	  (if old-target
-	      (oset jdee-dbs-the-process-registry :target-process old-target))
-	  (jdee-dbs-proc-set-state process "unknown")
-	  (jdee-dbs-proc-set-state-reason process "Error launching process.")
-	  (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
-	  nil)
+        (progn
+          (jdee-dbs-proc-move-to-morgue process)
+          (if old-target
+              (oset jdee-dbs-the-process-registry :target-process old-target))
+          (jdee-dbs-proc-set-state process "unknown")
+          (jdee-dbs-proc-set-state-reason process "Error launching process.")
+          (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
+          nil)
       (jdee-bug-set-breakpoints process jdee-db-breakpoints))
     t))
 
@@ -2137,27 +2137,27 @@ to the process via a socket."
  (interactive
    "sHost: \nsProcess Port: ")
   (let* ((process
-	  (jdee-dbs-proc (format "process%d"
-				(setq jdee-dbs-proc-counter
-				      (1+ jdee-dbs-proc-counter)))
-			:id jdee-dbs-proc-counter :main-class process-port))
-	     (old-target (jdee-dbs-get-target-process))
-	     (attach (jdee-dbs-attach-socket
-		      (format "Attach %s" process-port)
-		      :process process
-		      :host process-host
-		      :port process-port)))
+          (jdee-dbs-proc (format "process%d"
+                                (setq jdee-dbs-proc-counter
+                                      (1+ jdee-dbs-proc-counter)))
+                        :id jdee-dbs-proc-counter :main-class process-port))
+             (old-target (jdee-dbs-get-target-process))
+             (attach (jdee-dbs-attach-socket
+                      (format "Attach %s" process-port)
+                      :process process
+                      :host process-host
+                      :port process-port)))
     (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
     (oset jdee-dbs-the-process-registry :target-process process)
     (if (not (jdee-dbs-cmd-exec attach))
-	(progn
-	  (jdee-dbs-proc-move-to-morgue process)
-	  (if old-target
-	      (oset jdee-dbs-the-process-registry :target-process old-target))
-	  (jdee-dbs-proc-set-state process "unknown")
-	  (jdee-dbs-proc-set-state-reason process "Error launching process.")
-	  (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
-	  nil)
+        (progn
+          (jdee-dbs-proc-move-to-morgue process)
+          (if old-target
+              (oset jdee-dbs-the-process-registry :target-process old-target))
+          (jdee-dbs-proc-set-state process "unknown")
+          (jdee-dbs-proc-set-state-reason process "Error launching process.")
+          (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
+          nil)
       (jdee-bug-set-breakpoints process jdee-db-breakpoints))
     t))
 
@@ -2175,27 +2175,27 @@ to the process via a socket."
   (interactive
    (list
     (if (car jdee-bug-server-shmem-name)
-	(read-from-minibuffer "Name: "
-			      (car jdee-bug-server-shmem-name-history)
-			      nil nil
-			      'jdee-bug-server-shmem-name-history)
+        (read-from-minibuffer "Name: "
+                              (car jdee-bug-server-shmem-name-history)
+                              nil nil
+                              'jdee-bug-server-shmem-name-history)
       (cdr jdee-bug-server-shmem-name))))
   (let* ((process
-	  (jdee-dbs-proc (format "process%d"
-				(setq jdee-dbs-proc-counter
-				      (1+ jdee-dbs-proc-counter)))
-			:id jdee-dbs-proc-counter :main-class shmem-name))
-	     (old-target (jdee-dbs-get-target-process))
-	     (listen (jdee-dbs-listen-for-process
-		      (format "Listen %s" shmem-name)
-		      :process process
-		      :address shmem-name)))
+          (jdee-dbs-proc (format "process%d"
+                                (setq jdee-dbs-proc-counter
+                                      (1+ jdee-dbs-proc-counter)))
+                        :id jdee-dbs-proc-counter :main-class shmem-name))
+             (old-target (jdee-dbs-get-target-process))
+             (listen (jdee-dbs-listen-for-process
+                      (format "Listen %s" shmem-name)
+                      :process process
+                      :address shmem-name)))
     (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
     (oset jdee-dbs-the-process-registry :target-process process)
     (when (not (jdee-dbs-cmd-exec listen))
       (jdee-dbs-proc-move-to-morgue process)
       (if old-target
-	  (oset jdee-dbs-the-process-registry :target-process old-target))
+          (oset jdee-dbs-the-process-registry :target-process old-target))
       (jdee-dbs-proc-set-state process "unknown")
       (jdee-dbs-proc-set-state-reason process "Error listening for process.")
       (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
@@ -2219,28 +2219,28 @@ listens on the socket specified by `jdee-bug-server-socket'."
   (interactive
    (list
     (if (car jdee-bug-server-socket)
-	(read-from-minibuffer "Socket: "
-			      (car jdee-bug-server-socket-history)
-			      nil nil
-			      'jdee-bug-server-socket-history)
+        (read-from-minibuffer "Socket: "
+                              (car jdee-bug-server-socket-history)
+                              nil nil
+                              'jdee-bug-server-socket-history)
       (cdr jdee-bug-server-socket))))
   (let* ((process
-	  (jdee-dbs-proc (format "process%d"
-				(setq jdee-dbs-proc-counter
-				      (1+ jdee-dbs-proc-counter)))
-			:id jdee-dbs-proc-counter :main-class socket))
-	     (old-target (jdee-dbs-get-target-process))
-	     (listen (jdee-dbs-listen-for-process
-		      (format "Listen %s" socket)
-		      :process process
-		      :address socket
-		      :transport "socket")))
+          (jdee-dbs-proc (format "process%d"
+                                (setq jdee-dbs-proc-counter
+                                      (1+ jdee-dbs-proc-counter)))
+                        :id jdee-dbs-proc-counter :main-class socket))
+             (old-target (jdee-dbs-get-target-process))
+             (listen (jdee-dbs-listen-for-process
+                      (format "Listen %s" socket)
+                      :process process
+                      :address socket
+                      :transport "socket")))
     (jdee-dbs-proc-set-add jdee-dbs-the-process-registry process)
     (oset jdee-dbs-the-process-registry :target-process process)
     (when (not (jdee-dbs-cmd-exec listen))
       (jdee-dbs-proc-move-to-morgue process)
       (if old-target
-	  (oset jdee-dbs-the-process-registry :target-process old-target))
+          (oset jdee-dbs-the-process-registry :target-process old-target))
       (jdee-dbs-proc-set-state process "unknown")
       (jdee-dbs-proc-set-state-reason process "Error listening for process.")
       (jdee-dbs-proc-set-add jdee-dbs-the-process-morgue process)
@@ -2272,8 +2272,8 @@ to run."
 use JDEbug->Threads->Suspend Thread (`jdee-bug-suspend-thread')."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (suspend-command
-	  (jdee-dbs-suspend-thread "suspend process" :process process)))
+         (suspend-command
+          (jdee-dbs-suspend-thread "suspend process" :process process)))
     (jdee-dbs-cmd-exec suspend-command)))
 
 
@@ -2282,8 +2282,8 @@ use JDEbug->Threads->Suspend Thread (`jdee-bug-suspend-thread')."
 use JDEbug->Threads->Resume Thread (`jdee-bug-resume-thread')."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (resume-command
-	  (jdee-dbs-resume-thread "resume process" :process process)))
+         (resume-command
+          (jdee-dbs-resume-thread "resume process" :process process)))
     (jdee-dbs-cmd-exec resume-command)))
 
 
@@ -2291,10 +2291,10 @@ use JDEbug->Threads->Resume Thread (`jdee-bug-resume-thread')."
   "Terminates the target process."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	 (finish (jdee-dbs-finish-process
-		  (format "finish %d" (oref process id))
-		  :process process))
-	 (result (jdee-dbs-cmd-exec finish)))
+         (finish (jdee-dbs-finish-process
+                  (format "finish %d" (oref process id))
+                  :process process))
+         (result (jdee-dbs-cmd-exec finish)))
     (jdee-dbs-proc-move-to-morgue process)
     (slot-makeunbound jdee-dbs-the-process-registry :target-process)
     (jdee-dbs-proc-set-state-reason process "finish")))
@@ -2326,17 +2326,17 @@ This command splits the window and shows the locals buffer."
   (interactive)
   (if (not jdee-bug-local-variables)
       (progn
-	(jdee-bug-toggle-local-variables)
-	(sleep-for 0 100)))
+        (jdee-bug-toggle-local-variables)
+        (sleep-for 0 100)))
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (locals-buf (oref process locals-buf))
-	 (source-window (selected-window))
-	 locals-window)
+         (locals-buf (oref process locals-buf))
+         (source-window (selected-window))
+         locals-window)
     (if (one-window-p)
-	(progn
-	  (setq locals-window (split-window source-window))
-	  (set-window-buffer locals-window locals-buf)))
+        (progn
+          (setq locals-window (split-window source-window))
+          (set-window-buffer locals-window locals-buf)))
     (set-window-buffer (next-window source-window) locals-buf)
     (select-window source-window)))
 
@@ -2344,13 +2344,13 @@ This command splits the window and shows the locals buffer."
   "Show the command-line interface (CLI) buffer of the target process."
   (interactive)
   (let* ((process (jdee-dbs-get-target-process))
-	(cli-buf (oref process cli-buf))
-	(source-window (selected-window))
-	cli-window)
+        (cli-buf (oref process cli-buf))
+        (source-window (selected-window))
+        cli-window)
     (if (one-window-p)
-	(progn
-	  (setq cli-window (split-window source-window))
-	  (set-window-buffer cli-window cli-buf)))
+        (progn
+          (setq cli-window (split-window source-window))
+          (set-window-buffer cli-window cli-buf)))
     (set-window-buffer (next-window source-window) cli-buf)
     (select-window source-window)))
 
@@ -2363,13 +2363,13 @@ This command splits the window and shows the locals buffer."
   (jdee-bug-show-threads)
 
   (let* ((process (jdee-dbs-get-target-process))
-	 (threads-buf (oref process threads-buf))
-	 (source-window (selected-window))
-	 threads-window)
+         (threads-buf (oref process threads-buf))
+         (source-window (selected-window))
+         threads-window)
     (if (one-window-p)
-	(progn
-	  (setq threads-window (split-window source-window))
-	  (set-window-buffer threads-window threads-buf)))
+        (progn
+          (setq threads-window (split-window source-window))
+          (set-window-buffer threads-window threads-buf)))
     (set-window-buffer (next-window source-window) threads-buf)
     (select-window source-window)))
 
@@ -2384,12 +2384,12 @@ This command splits the window and shows the locals buffer."
   (mapc
    (lambda (assoc-x)
      (let* ((breakpoint (cdr assoc-x))
-	    (set-breakpoint (jdee-dbs-set-breakpoint
-			     (format "set breakpoint%d"
-				     (oref breakpoint id))
-			     :process process
-			     :breakpoint breakpoint))
-	    (result (jdee-dbs-cmd-exec set-breakpoint)))))
+            (set-breakpoint (jdee-dbs-set-breakpoint
+                             (format "set breakpoint%d"
+                                     (oref breakpoint id))
+                             :process process
+                             :breakpoint breakpoint))
+            (result (jdee-dbs-cmd-exec set-breakpoint)))))
    breakpoints))
 
 ;;;###autoload
@@ -2402,22 +2402,22 @@ This command splits the window and shows the locals buffer."
       (jdee-dbs-debugger-start jdee-dbs-the-debugger))
   (if (jdee-dbs-debugger-running-p)
       (let ((result (jdee-bug-launch-process)))
-	(if result
-	    (let ((process (oref jdee-dbs-the-process-registry :target-process)))
-	      (jdee-bug-set-breakpoints process jdee-db-breakpoints)
-	      (setq result (jdee-bug-continue)))))))
+        (if result
+            (let ((process (oref jdee-dbs-the-process-registry :target-process)))
+              (jdee-bug-set-breakpoints process jdee-db-breakpoints)
+              (setq result (jdee-bug-continue)))))))
 
 (defun jdee-bug-help ()
   "Displays the JDEbug User's Guide."
   (interactive)
   (let* ((jdee-dir (jdee-find-jdee-doc-directory))
-	 (jdebug-help
-	  (if jdee-dir
-	      (expand-file-name "doc/html/jdebug-ug/jdebug-ug.html" jdee-dir))))
+         (jdebug-help
+          (if jdee-dir
+              (expand-file-name "doc/html/jdebug-ug/jdebug-ug.html" jdee-dir))))
     (if (and
-	 jdebug-help
-	 (file-exists-p jdebug-help))
-	(browse-url (concat "file://" (jdee-convert-cygwin-path jdebug-help)))
+         jdebug-help
+         (file-exists-p jdebug-help))
+        (browse-url (concat "file://" (jdee-convert-cygwin-path jdebug-help)))
       (signal 'error '("Cannot find JDEbug User's Guide.")))))
 
 (defun jdee-bug-keys ()
@@ -2431,15 +2431,15 @@ the value of the variable `jdee-bug-local-variables'"
   (interactive)
   (setq jdee-bug-local-variables (not jdee-bug-local-variables))
   (if (and jdee-dbo-current-process
-	   jdee-dbo-current-thread-id
-	   jdee-bug-local-variables)
+           jdee-dbo-current-thread-id
+           jdee-bug-local-variables)
       (jdee-dbo-update-locals-buf jdee-dbo-current-process
-				 jdee-dbo-current-thread-id 0)
+                                 jdee-dbo-current-thread-id 0)
     (save-excursion
       (if jdee-dbo-current-process
-	  (progn
-	    (set-buffer (oref jdee-dbo-current-process locals-buf))
-	    (kill-all-local-variables))))))
+          (progn
+            (set-buffer (oref jdee-dbo-current-process locals-buf))
+            (kill-all-local-variables))))))
 
 (defun jdee-bug-toggle-stack-info ()
   "Enables and disables the retrieval of stack info. It toggles the value
@@ -2447,16 +2447,16 @@ of the variable `jdee-bug-stack-info'"
   (interactive)
   (setq jdee-bug-stack-info (not jdee-bug-stack-info))
   (if (and jdee-dbo-current-process
-	   jdee-dbo-current-thread-id
-	   jdee-bug-stack-info)
+           jdee-dbo-current-thread-id
+           jdee-bug-stack-info)
       (jdee-dbo-update-stack jdee-dbo-current-process
-			    jdee-dbo-current-thread-id)
+                            jdee-dbo-current-thread-id)
     (save-excursion
       (if jdee-dbo-current-process
-	  (progn
-	    (set-buffer (oref jdee-dbo-current-process threads-buf))
-	    (kill-all-local-variables)
-	    (erase-buffer))))))
+          (progn
+            (set-buffer (oref jdee-dbo-current-process threads-buf))
+            (kill-all-local-variables)
+            (erase-buffer))))))
 
 (provide 'jdee-bug)
 

--- a/jdee-bytecode.el
+++ b/jdee-bytecode.el
@@ -66,7 +66,7 @@
 
 (defsubst jdee-bytecode-get-next-const-val (constants)
   (cadr (jdee-bytecode-lookup-constant
-	 (jdee-bytecode-get-next-2-bytes) constants)))
+         (jdee-bytecode-get-next-2-bytes) constants)))
 
 (setq jdee-bytecode-encoding 'utf-8)
 
@@ -83,64 +83,64 @@ keys: version, this-class, interfaces, fields, and methods."
   (let ((buf (find-file-noselect class-file nil t)))
     (set-buffer buf)
     (let* ((version (jdee-bytecode-get-version)) ;do first to validate class file version early
-	   (constants (jdee-bytecode-get-constants))
-	   (access (jdee-bytecode-get-class-access-flags))
-	   (this-class
-	     (subst-char-in-string
-	      ?/ ?. (cadr (jdee-bytecode-lookup-constant
-			     (jdee-bytecode-get-next-const-val constants)
-			      constants))))
-	   (superclass (jdee-bytecode-slash-to-dot
-			(do-and-advance-chars 2
-			  (let ((val (jdee-bytecode-get-const-ref
-				      (point) constants)))
-			    (if (eq (cadr val) 0)
-			      nil ;; only Object can have no superclass
-			      (cadr (jdee-bytecode-lookup-constant
-				     (cadr val) constants)))))))
-	   (interfaces (jdee-bytecode-get-interfaces constants))
-	   (fields (jdee-bytecode-get-fields constants))
-	   (methods (jdee-bytecode-get-methods constants))
-	   (attributes (jdee-bytecode-get-attributes constants)))
+           (constants (jdee-bytecode-get-constants))
+           (access (jdee-bytecode-get-class-access-flags))
+           (this-class
+             (subst-char-in-string
+              ?/ ?. (cadr (jdee-bytecode-lookup-constant
+                             (jdee-bytecode-get-next-const-val constants)
+                              constants))))
+           (superclass (jdee-bytecode-slash-to-dot
+                        (do-and-advance-chars 2
+                          (let ((val (jdee-bytecode-get-const-ref
+                                      (point) constants)))
+                            (if (eq (cadr val) 0)
+                              nil ;; only Object can have no superclass
+                              (cadr (jdee-bytecode-lookup-constant
+                                     (cadr val) constants)))))))
+           (interfaces (jdee-bytecode-get-interfaces constants))
+           (fields (jdee-bytecode-get-fields constants))
+           (methods (jdee-bytecode-get-methods constants))
+           (attributes (jdee-bytecode-get-attributes constants)))
       (kill-buffer buf)
       `((version . ,version) (access . ,access)
-	(this-class . ,this-class) (superclass . ,superclass)
-	(interfaces . ,interfaces)
-	(fields . ,fields)
-	(methods . ,methods)
-	(attributes . ,attributes)))))
+        (this-class . ,this-class) (superclass . ,superclass)
+        (interfaces . ,interfaces)
+        (fields . ,fields)
+        (methods . ,methods)
+        (attributes . ,attributes)))))
 
 (defun jdee-bytecode-extract-caught-exception-types (info)
   "Returns a list of a two-element of list of method signatures to
   caught exception types for each method"
   (mapcar (lambda (method)
-	    (list `(,(cdr (nth 2 info))
-		      ,(cdr (assoc 'name method))
-		      ,@(cdr (assoc 'descriptor method)))
-		  (mapcar (lambda (class) (when class
-					    (jdee-bytecode-slash-to-dot class)))
-			  (cdr (assoc
-				'catch-types
-				(cdr
-				 (assoc 'code
-					(cdr
-					 (assoc 'attributes
-						method)))))))))
-	  (cdr (assoc 'methods info))))
+            (list `(,(cdr (nth 2 info))
+                      ,(cdr (assoc 'name method))
+                      ,@(cdr (assoc 'descriptor method)))
+                  (mapcar (lambda (class) (when class
+                                            (jdee-bytecode-slash-to-dot class)))
+                          (cdr (assoc
+                                'catch-types
+                                (cdr
+                                 (assoc 'code
+                                        (cdr
+                                         (assoc 'attributes
+                                                method)))))))))
+          (cdr (assoc 'methods info))))
 
 (defun jdee-bytecode-extract-thrown-exception-types (info)
   "Returns a two element list of method signatures to thrown exception
   types for each method"
   (mapcar (lambda (method)
-	    (list `(,(cdr (nth 2 info))
-		      ,(cdr (assoc 'name method))
-		      ,@(cdr (assoc 'descriptor method)))
-		  (cdr
-		   (assoc 'exceptions
-			  (cdr
-			   (assoc 'attributes
-				  method))))))
-	  (cdr (assoc 'methods info))))
+            (list `(,(cdr (nth 2 info))
+                      ,(cdr (assoc 'name method))
+                      ,@(cdr (assoc 'descriptor method)))
+                  (cdr
+                   (assoc 'exceptions
+                          (cdr
+                           (assoc 'attributes
+                                  method))))))
+          (cdr (assoc 'methods info))))
 
 (defun jdee-bytecode-extract-method-calls (info)
   "Return a cons of a method signature, and a list of the methods it
@@ -150,25 +150,25 @@ arguments.  INFO is the result of `jdee-bytecode'"
   (cl-mapcan
    (lambda (method)
      (mapcar (lambda (attr)
-	       (list
-		`(,(cdr (nth 2 info))
-		  ,(cdr (assoc 'name method))
-		  ,@(cdr (assoc 'descriptor method))
-		  ,(car attr)) (cdr attr)))
-	     (cdr (assoc
-		   'calls
-		   (cdr
-		    (assoc 'code
-			   (cdr
-			    (assoc 'attributes
-				   method))))))))
+               (list
+                `(,(cdr (nth 2 info))
+                  ,(cdr (assoc 'name method))
+                  ,@(cdr (assoc 'descriptor method))
+                  ,(car attr)) (cdr attr)))
+             (cdr (assoc
+                   'calls
+                   (cdr
+                    (assoc 'code
+                           (cdr
+                            (assoc 'attributes
+                                   method))))))))
    (cdr (assoc 'methods info))))
 
 (defun jdee-bytecode-extract-interfaces (info)
   "Returns a list of fully qualified interface names that the class
   implements.  INFO is the result of `jdee-bytecode'"
   (mapcar 'jdee-bytecode-slash-to-dot
-	  (cdr (assoc 'interfaces info))))
+          (cdr (assoc 'interfaces info))))
 
 (defun jdee-bytecode-extract-superclass (info)
   "Returns a list of fully qualified class names that are superclasses
@@ -178,15 +178,15 @@ arguments.  INFO is the result of `jdee-bytecode'"
 (defun jdee-bytecode-extract-method-signatures (info)
   "Returns a list of method names that the class implements"
   (mapcar (lambda (method-info) (cons (cdr (assoc 'name method-info))
-				      (cdr (assoc 'descriptor method-info))))
-	  (cdr (assoc 'methods info))))
+                                      (cdr (assoc 'descriptor method-info))))
+          (cdr (assoc 'methods info))))
 
 (defun jdee-bytecode-extract-field-signatures (info)
   "Return a list of field names that the class defines"
   (mapcar (lambda (field-info)
-	    (list (cdr (assoc 'name field-info))
-		  (cdr (assoc 'descriptor field-info))))
-	  (cdr (assoc 'fields info))))
+            (list (cdr (assoc 'name field-info))
+                  (cdr (assoc 'descriptor field-info))))
+          (cdr (assoc 'fields info))))
 
 (defun jdee-bytecode-extract-classname (info)
   "Returns the fully qualified classname that the class implements.
@@ -202,7 +202,7 @@ Returns the constant information contained at the reference"
   ;; we have to subtract one since the array index starts at 1
   ;; (according to the class file, not us
   (jdee-bytecode-lookup-constant (jdee-bytecode-get-2byte point)
-				   constants))
+                                   constants))
 
 (defun jdee-bytecode-lookup-constant (num constants)
   "From an index value, get the constant for that index"
@@ -213,224 +213,224 @@ Returns the constant information contained at the reference"
 
 (defun jdee-bytecode-get-interfaces (constants)
   (let ((num (jdee-bytecode-get-next-length-val))
-	(interfaces '()))
+        (interfaces '()))
     (dotimes (i num interfaces)
       (add-to-list 'interfaces (cadr (jdee-bytecode-lookup-constant
-				     (jdee-bytecode-get-next-const-val
-				      constants) constants))))))
+                                     (jdee-bytecode-get-next-const-val
+                                      constants) constants))))))
 
 (defun jdee-bytecode-get-methods (constants)
   (let ((num (jdee-bytecode-get-next-length-val))
-	(methods '()))
+        (methods '()))
     (dotimes (i num (nreverse methods))
       (add-to-list 'methods (jdee-bytecode-get-method constants)))))
 
 (defun jdee-bytecode-get-method (constants)
   (list (cons 'access-flags (jdee-bytecode-get-method-access-flags))
         (cons 'name (jdee-bytecode-get-next-const-val constants))
-	(cons 'descriptor (jdee-bytecode-parse-complete-arg-signature
-			   (jdee-bytecode-get-next-const-val constants)))
-	(cons 'attributes (jdee-bytecode-get-attributes constants))))
+        (cons 'descriptor (jdee-bytecode-parse-complete-arg-signature
+                           (jdee-bytecode-get-next-const-val constants)))
+        (cons 'attributes (jdee-bytecode-get-attributes constants))))
 
 (defun jdee-bytecode-get-fields (constants)
   (let ((num (jdee-bytecode-get-next-length-val))
-	(fields '()))
+        (fields '()))
     (dotimes (i num (nreverse fields))
       (add-to-list 'fields (jdee-bytecode-get-field constants)))))
 
 (defun jdee-bytecode-get-field (constants)
   (list (cons 'access-flags (jdee-bytecode-get-field-access-flags))
         (cons 'name (jdee-bytecode-get-next-const-val constants))
-	(cons 'descriptor (car (jdee-bytecode-parse-first-arg
-			   (jdee-bytecode-get-next-const-val constants))))
-	(cons 'attributes (jdee-bytecode-get-attributes constants))))
+        (cons 'descriptor (car (jdee-bytecode-parse-first-arg
+                           (jdee-bytecode-get-next-const-val constants))))
+        (cons 'attributes (jdee-bytecode-get-attributes constants))))
 
 (defun jdee-bytecode-get-attributes (constants)
   (let ((num (jdee-bytecode-get-next-length-val))
-	(attributes '()))
+        (attributes '()))
     (dotimes (i num attributes)
       (add-to-list 'attributes (jdee-bytecode-get-attribute constants)))))
 
 (defun jdee-bytecode-get-attribute (constants)
   (let ((attribute-type (jdee-bytecode-get-next-const-val constants))
-	(numbytes (jdee-bytecode-get-next-4-bytes (point))))
+        (numbytes (jdee-bytecode-get-next-4-bytes (point))))
     ;; TODO: implement the rest of the common attribute types
     (cond ((equal attribute-type "Code")
-	    (cons 'code
-		  (jdee-bytecode-get-code-attribute numbytes constants)))
-	  ((equal attribute-type "LineNumberTable")
-	    (cons 'line-number-table
-		  (jdee-bytecode-get-line-number-attribute)))
-	  ((equal attribute-type "Exceptions")
-	    (cons 'throws
-		  (jdee-bytecode-get-exception-attribute constants)))
-	  ((equal attribute-type "SourceFile")
-	    (cons 'source-file
-		  (jdee-bytecode-get-source-file-attribute constants)))
-	  (t (forward-char numbytes)))))
+            (cons 'code
+                  (jdee-bytecode-get-code-attribute numbytes constants)))
+          ((equal attribute-type "LineNumberTable")
+            (cons 'line-number-table
+                  (jdee-bytecode-get-line-number-attribute)))
+          ((equal attribute-type "Exceptions")
+            (cons 'throws
+                  (jdee-bytecode-get-exception-attribute constants)))
+          ((equal attribute-type "SourceFile")
+            (cons 'source-file
+                  (jdee-bytecode-get-source-file-attribute constants)))
+          (t (forward-char numbytes)))))
 
 (defun jdee-bytecode-get-source-file-attribute (constants)
   (jdee-bytecode-get-next-const-val constants))
 
 (defun jdee-bytecode-get-exception-attribute (constants)
   (let ((num (jdee-bytecode-get-next-length-val))
-	(classes '()))
+        (classes '()))
     (dotimes (i num classes)
       (add-to-list 'classes
-		   (cadr (jdee-bytecode-lookup-constant
-			  (jdee-bytecode-get-next-const-val constants)
-			  constants))))))
+                   (cadr (jdee-bytecode-lookup-constant
+                          (jdee-bytecode-get-next-const-val constants)
+                          constants))))))
 
 (defun jdee-bytecode-get-line-number-attribute ()
   (let ((num (jdee-bytecode-get-next-length-val))
-	(line-number-infos '()))
+        (line-number-infos '()))
     (dotimes (i num (nreverse line-number-infos))
       (add-to-list
        'line-number-infos
        (cons (jdee-bytecode-get-next-2-bytes)
-	     (jdee-bytecode-get-next-2-bytes))))))
+             (jdee-bytecode-get-next-2-bytes))))))
 
 (defun jdee-bytecode-get-code-attribute (numbytes constants)
   (goto-char (+ (point) 4)) ;; no one cares about max_stack and max_locals, right?
   (let* ((code-numbytes (jdee-bytecode-get-next-4-bytes (point)))
-	 (end-point (+ (point) code-numbytes))
-	 (begin-point (point))
-	 (calls '())
-	 (catch-types '()))
+         (end-point (+ (point) code-numbytes))
+         (begin-point (point))
+         (calls '())
+         (catch-types '()))
     (while (< (point) end-point)
       (let* ((opcode-info (aref jdee-bytecode-opcode-vec
-				(char-int (char-after))))
-	     (opcode-val (car opcode-info))
-	     (opcode-length (cdr opcode-info)))
-	(forward-char)
-	(cond ((member opcode-val '(invokevirtual invokestatic invokespecial
-				    invokeinterface getstatic putstatic
-				    getfield putfield))
-		(do-and-advance-chars (- opcode-length 1)
-		  (add-to-list
-		   'calls
-		   (cons (- (point) begin-point)
-			 (jdee-bytecode-parse-method-signature
-			  (jdee-bytecode-lookup-method
-			   (jdee-bytecode-get-const-ref (point) constants)
-			   constants))))))
+                                (char-int (char-after))))
+             (opcode-val (car opcode-info))
+             (opcode-length (cdr opcode-info)))
+        (forward-char)
+        (cond ((member opcode-val '(invokevirtual invokestatic invokespecial
+                                    invokeinterface getstatic putstatic
+                                    getfield putfield))
+                (do-and-advance-chars (- opcode-length 1)
+                  (add-to-list
+                   'calls
+                   (cons (- (point) begin-point)
+                         (jdee-bytecode-parse-method-signature
+                          (jdee-bytecode-lookup-method
+                           (jdee-bytecode-get-const-ref (point) constants)
+                           constants))))))
               ((eq opcode-val 'invokedynamic)
                ;; TODO -- possible to parse out a call?
                (forward-char (- opcode-length 1)))
-	      ((eq opcode-val 'tableswitch)
-		;; skip padding to go to a multiple of 4 from the begin-point.
-		;; The second mod is to make sure on an offset of 4 we really don't skip anything
-		(forward-char (mod (- 4 (mod (- (point) begin-point) 4)) 4))
-		(forward-char 4)  ;; we don't care about default
-		(let ((diff (jdee-bytecode-diff-next-two-4-bytes-as-signed)))
-		  (forward-char (* 4 (+ diff 1)))))
-	      ((eq opcode-val 'lookupswitch)
-		(forward-char (mod (- 4 (mod (- (point) begin-point) 4)) 4))
-		(forward-char 4)
-		(forward-char (* 8 (jdee-bytecode-get-next-4-bytes-as-signed))))
-	      ((eq opcode-val 'wide)
-		(let ((opcode2 (char-int (char-after))))
-		  (if (eq opcode2 'iinc)
-		    (forward-char 5)
-		    (forward-char 2))))
+              ((eq opcode-val 'tableswitch)
+                ;; skip padding to go to a multiple of 4 from the begin-point.
+                ;; The second mod is to make sure on an offset of 4 we really don't skip anything
+                (forward-char (mod (- 4 (mod (- (point) begin-point) 4)) 4))
+                (forward-char 4)  ;; we don't care about default
+                (let ((diff (jdee-bytecode-diff-next-two-4-bytes-as-signed)))
+                  (forward-char (* 4 (+ diff 1)))))
+              ((eq opcode-val 'lookupswitch)
+                (forward-char (mod (- 4 (mod (- (point) begin-point) 4)) 4))
+                (forward-char 4)
+                (forward-char (* 8 (jdee-bytecode-get-next-4-bytes-as-signed))))
+              ((eq opcode-val 'wide)
+                (let ((opcode2 (char-int (char-after))))
+                  (if (eq opcode2 'iinc)
+                    (forward-char 5)
+                    (forward-char 2))))
               ((< opcode-length 0)
                (error "Invalid opcode-length %s" opcode-info))
-	      (t (forward-char (- opcode-length 1))))))
+              (t (forward-char (- opcode-length 1))))))
     (let ((num-exceptions (jdee-bytecode-get-next-length-val)))
       (dotimes (i num-exceptions)
-	(let ((type (cdr (assoc 'catch-type
-				 (jdee-bytecode-get-exception-handler
-				  constants)))))
-	  (when type
-	    (add-to-list 'catch-types type)))))
+        (let ((type (cdr (assoc 'catch-type
+                                 (jdee-bytecode-get-exception-handler
+                                  constants)))))
+          (when type
+            (add-to-list 'catch-types type)))))
     (let ((attributes (jdee-bytecode-get-attributes constants)))
       ;; Get the line numbers if there, if not use -1's to iondicate no line number
       (let ((table (when (assoc 'line-number-table attributes)
-		     (cdr (assoc 'line-number-table attributes)))))
-	(list (cons
-	       'calls
-	       (mapcar (lambda (call)
-		  (if table
-		    ;; The line numbers describe the instruction at
-		    ;; the start of the line, not every instruction
+                     (cdr (assoc 'line-number-table attributes)))))
+        (list (cons
+               'calls
+               (mapcar (lambda (call)
+                  (if table
+                    ;; The line numbers describe the instruction at
+                    ;; the start of the line, not every instruction
 
-		    ;; Advance in the table when the next byte
-		    ;; described is higher than the current one
-		    (progn (while (and (cadr table)
-				       (>= (car call) (caadr table)))
-			     (setq table (cdr table)))
-			   (cons (cdar table) (cdr call)))
-		    (cons -1 (cdr call)))) (nreverse calls)))
-	      (cons 'catch-types catch-types))))))
+                    ;; Advance in the table when the next byte
+                    ;; described is higher than the current one
+                    (progn (while (and (cadr table)
+                                       (>= (car call) (caadr table)))
+                             (setq table (cdr table)))
+                           (cons (cdar table) (cdr call)))
+                    (cons -1 (cdr call)))) (nreverse calls)))
+              (cons 'catch-types catch-types))))))
 
 (defun jdee-bytecode-get-exception-handler (constants)
   (list (cons 'start-pc (jdee-bytecode-get-next-2-bytes))
     (cons 'end-pc (jdee-bytecode-get-next-2-bytes))
     (cons 'handler-pc (jdee-bytecode-get-next-2-bytes))
     (cons 'catch-type (let ((val (jdee-bytecode-get-next-2-bytes)))
-			(when (> val 0)
-			  (cadr (jdee-bytecode-lookup-constant
-				 (cadr (jdee-bytecode-lookup-constant val constants))
-			      constants)))))))
+                        (when (> val 0)
+                          (cadr (jdee-bytecode-lookup-constant
+                                 (cadr (jdee-bytecode-lookup-constant val constants))
+                              constants)))))))
 
 (defun jdee-bytecode-parse-first-arg (sig)
   (let ((char (char-to-string (string-to-char sig))))
     (cond ((equal char "B") `("byte" . 1))
-	  ((equal char "C") `("char" . 1))
-	  ((equal char "D") `("double" . 1))
-	  ((equal char "F") `("float" . 1))
-	  ((equal char "I") `("int" . 1))
-	  ((equal char "J") `("long" . 1))
-	  ((equal char "L") (let ((endpos (string-match ";" sig)))
-			      (cons (jdee-bytecode-slash-to-dot
-				     (substring sig 1
-						endpos))
-				    (+ 1 endpos))))
-	  ((equal char "S") `("short" . 1))
-	  ((equal char "Z") `("boolean" . 1))
-	  ((equal char "[") (let ((rest (jdee-bytecode-parse-first-arg
-					 (substring sig 1))))
-			      (cons (concat (car rest) "[]") (+ (cdr rest) 1))))
+          ((equal char "C") `("char" . 1))
+          ((equal char "D") `("double" . 1))
+          ((equal char "F") `("float" . 1))
+          ((equal char "I") `("int" . 1))
+          ((equal char "J") `("long" . 1))
+          ((equal char "L") (let ((endpos (string-match ";" sig)))
+                              (cons (jdee-bytecode-slash-to-dot
+                                     (substring sig 1
+                                                endpos))
+                                    (+ 1 endpos))))
+          ((equal char "S") `("short" . 1))
+          ((equal char "Z") `("boolean" . 1))
+          ((equal char "[") (let ((rest (jdee-bytecode-parse-first-arg
+                                         (substring sig 1))))
+                              (cons (concat (car rest) "[]") (+ (cdr rest) 1))))
           (t (error (concat "Could not find char " char))))))
 
 (defun jdee-bytecode-parse-arg-signature (sig)
   (when (> (length sig) 0)
     (let ((arg (jdee-bytecode-parse-first-arg sig)))
       (if (> (cdr arg) (length sig))
-	(list (car arg))
-	(cons (car arg) (jdee-bytecode-parse-arg-signature
-			 (substring sig (cdr arg))))))))
+        (list (car arg))
+        (cons (car arg) (jdee-bytecode-parse-arg-signature
+                         (substring sig (cdr arg))))))))
 
 
 (defun jdee-bytecode-parse-complete-arg-signature (sig)
   (let* ((match (string-match "(\\(.*\\))\\(.*\\)" sig)))
     (if match
       (let ((args (match-string 1 sig))
-	    (return-val (match-string 2 sig)))
-	(list (unless (equal "V" return-val)
-		(car (jdee-bytecode-parse-arg-signature return-val)))
-	      (jdee-bytecode-parse-arg-signature args)))
+            (return-val (match-string 2 sig)))
+        (list (unless (equal "V" return-val)
+                (car (jdee-bytecode-parse-arg-signature return-val)))
+              (jdee-bytecode-parse-arg-signature args)))
       (list nil (jdee-bytecode-parse-arg-signature sig)))))
 
 
 (defun jdee-bytecode-parse-method-signature (siglist)
   `(,(jdee-bytecode-slash-to-dot (car siglist))
     ,(cadr siglist) ,@(jdee-bytecode-parse-complete-arg-signature
-		      (nth 2 siglist))))
+                      (nth 2 siglist))))
 
 (defun jdee-bytecode-lookup-method (method constants)
   (list (cadr (jdee-bytecode-lookup-constant
-	       (cadr (jdee-bytecode-lookup-constant
-		       (cadr method) constants))
-	       constants))
-	(cadr (jdee-bytecode-lookup-constant
-	       (cadr
-		(jdee-bytecode-lookup-constant (nth 2 method) constants))
-	       constants))
-	(cadr (jdee-bytecode-lookup-constant
-	       (nth 2
-		(jdee-bytecode-lookup-constant (nth 2 method) constants))
-	       constants))))
+               (cadr (jdee-bytecode-lookup-constant
+                       (cadr method) constants))
+               constants))
+        (cadr (jdee-bytecode-lookup-constant
+               (cadr
+                (jdee-bytecode-lookup-constant (nth 2 method) constants))
+               constants))
+        (cadr (jdee-bytecode-lookup-constant
+               (nth 2
+                (jdee-bytecode-lookup-constant (nth 2 method) constants))
+               constants))))
 
 (defun get-bit-flags-for-byte (byte flag-vec)
   "Gets the bit flags for BYTE, given the flags that apply to each bit,
@@ -443,14 +443,14 @@ returns ('f 'g)"
   (let ((flags '()))
     (dotimes (i 8 flags)
       (when (and (aref flag-vec (- 7 i))
-		 (> (logand (expt 2 i)  byte) 0))
-	(add-to-list 'flags (aref flag-vec (- 7 i)))))
+                 (> (logand (expt 2 i)  byte) 0))
+        (add-to-list 'flags (aref flag-vec (- 7 i)))))
     flags))
 
 (defun jdee-bytecode-get-access-flags (bits0 bits1)
   (do-and-advance-chars 2
     (let ((raw0 (char-int (char-after (point))))
-	  (raw1 (char-int (char-after (+ (point) 1)))))
+          (raw1 (char-int (char-after (+ (point) 1)))))
       (append
        (get-bit-flags-for-byte raw0 bits0)
        (get-bit-flags-for-byte raw1 bits1)))))
@@ -490,7 +490,7 @@ returns ('f 'g)"
 (defun jdee-bytecode-get-2byte (point)
   "Gets the value of two bytes (0 - 65535) as an int"
   (let ((b1 (char-int (char-after point)))
-	(b2 (char-int (char-after (+ 1 point)))))
+        (b2 (char-int (char-after (+ 1 point)))))
     (+ (* b1 256) b2)))
 
 (defun jdee-bytecode-get-next-2-bytes ()
@@ -499,23 +499,23 @@ returns ('f 'g)"
 
 (defun jdee-bytecode-get-4byte (point &optional ignore-large-val)
   (let ((db1 (jdee-bytecode-get-2byte point))
-	(db2 (jdee-bytecode-get-2byte (+ 2 point))))
+        (db2 (jdee-bytecode-get-2byte (+ 2 point))))
     (if (< db1 2047)
       ;; don't go over the maxint in elisp (2047, since we have 1 more db1 could be 65536)
       (+ (* 65536 db1) db2)
       (if ignore-large-val
-	0
-	(error "Class file has a larger 4 byte value then emacs can handle")))))
+        0
+        (error "Class file has a larger 4 byte value then emacs can handle")))))
 
 (defun jdee-bytecode-get-next-4-bytes-as-signed (&optional ignore-large-val)
   (let ((db1 (jdee-bytecode-get-next-2-bytes))
-	(db2 (jdee-bytecode-get-next-2-bytes)))
+        (db2 (jdee-bytecode-get-next-2-bytes)))
     (if (> (logand 32768 db1) 0)  ;; if its high-bit is set, then it's negative.
       (if (> db1 63488)
-	(- (+ 1 (+ (* (- 65535 db1) 65536) (- 65535 db2))))
-	(if ignore-large-val
-	  0
-	  (error "Class file has an unsigned int who is smaller than emacs can handle")))
+        (- (+ 1 (+ (* (- 65535 db1) 65536) (- 65535 db2))))
+        (if ignore-large-val
+          0
+          (error "Class file has an unsigned int who is smaller than emacs can handle")))
       (jdee-bytecode-get-4byte (- (point) 4)))))
 
 (defun jdee-bytecode-diff-next-two-4-bytes-as-signed ()
@@ -536,24 +536,24 @@ returns ('f 'g)"
   "Returns a list of the constant ending location (not inclusive of
 of the constants) and a vector of all constants"
   (let* ((count (- (jdee-bytecode-get-2byte 9) 1))
-	 (const-vec (make-vector count '())))
+         (const-vec (make-vector count '())))
     (goto-char 11) ;; start of constants
     (dotimes (i count const-vec)
       (let ((const (jdee-bytecode-get-next-constant)))
-	(aset const-vec i const)
-	;; doubles and longs take up two places on the const table.
-	(when (or (eq (car const) 'double)
-		  (eq (car const) 'long))
-	  (aset const-vec (+ 1 i) nil)
-	  (setq i (+ 1 i)))))))
+        (aset const-vec i const)
+        ;; doubles and longs take up two places on the const table.
+        (when (or (eq (car const) 'double)
+                  (eq (car const) 'long))
+          (aset const-vec (+ 1 i) nil)
+          (setq i (+ 1 i)))))))
 
 (defsubst jdee-bytecode-get-long-constant (&optional ignore-large-val)
   (let ((qb1 (jdee-bytecode-get-next-4-bytes ignore-large-val))
-	(qb2 (jdee-bytecode-get-next-4-bytes ignore-large-val)))
+        (qb2 (jdee-bytecode-get-next-4-bytes ignore-large-val)))
     (if (> qb2 0)
       (if ignore-large-val
-	0
-	(error "Class file has a large 8 byte value than emacs can handle"))
+        0
+        (error "Class file has a large 8 byte value than emacs can handle"))
       qb1)))
 
 (defsubst jdee-bytecode-get-double-constant ()
@@ -574,9 +574,9 @@ of the constants) and a vector of all constants"
 
 (defsubst jdee-bytecode-get-utf8-constant ()
   (let* ((len (jdee-bytecode-get-next-2-bytes))
-	 (result (encode-coding-string (buffer-substring (point)
-							(+ len (point)))
-				       jdee-bytecode-encoding)))
+         (result (encode-coding-string (buffer-substring (point)
+                                                        (+ len (point)))
+                                       jdee-bytecode-encoding)))
     (goto-char (+ len (point)))
     result))
 
@@ -608,25 +608,25 @@ of the constants) and a vector of all constants"
     (forward-char)
     (cond ((eq const-type 7)
            `(class ,(jdee-bytecode-get-next-2-bytes)))
-	  ((eq const-type 9)
+          ((eq const-type 9)
            `(field ,@(jdee-bytecode-get-ref-constant)))
-	  ((eq const-type 10)
+          ((eq const-type 10)
            `(method ,@(jdee-bytecode-get-ref-constant)))
-	  ((eq const-type 11)
+          ((eq const-type 11)
            `(interface-method ,@(jdee-bytecode-get-ref-constant)))
-	  ((eq const-type 8)
+          ((eq const-type 8)
            `(string ,(jdee-bytecode-get-next-2-bytes)))
-	  ((eq const-type 3)
+          ((eq const-type 3)
            `(integer ,(jdee-bytecode-get-next-4-bytes t)))
-	  ((eq const-type 4)
+          ((eq const-type 4)
            `(float ,(jdee-bytecode-get-float-constant)))
-	  ((eq const-type 5)
+          ((eq const-type 5)
            `(long ,(jdee-bytecode-get-long-constant t)))
-	  ((eq const-type 6)
+          ((eq const-type 6)
            `(double ,(jdee-bytecode-get-double-constant)))
-	  ((eq const-type 12)
+          ((eq const-type 12)
            `(name-and-type ,@(jdee-bytecode-get-nameandtype-constant)))
-	  ((eq const-type 1)
+          ((eq const-type 1)
            `(utf8 ,(jdee-bytecode-get-utf8-constant)))
           ((eq const-type 15)
            `(method-handle ,@(jdee-bytecode-get-method-handle)))

--- a/jdee-checkstyle.el
+++ b/jdee-checkstyle.el
@@ -108,7 +108,7 @@ documentation for information on configuration files). Use
 the configuration file reads from the CheckStyle command line."
   :group 'jdee-checkstyle
   :type '(choice (const :tag "Sun" :value nil)
-		 (file :menu-tag "Custom" :tag "Config. File")))
+                 (file :menu-tag "Custom" :tag "Config. File")))
 
 
 (defcustom jdee-checkstyle-expanded-properties nil
@@ -125,8 +125,8 @@ this way.  To delete a property, select the DEL button next
 to the property."
   :group 'jdee-checkstyle
   :type '(repeat (cons
-		  (string :tag "Property Name")
-		  (string :tag "Property Value"))))
+                  (string :tag "Property Name")
+                  (string :tag "Property Value"))))
 
 ;; (makunbound 'jdee-checkstyle-expanded-properties-file)
 (defcustom jdee-checkstyle-expanded-properties-file nil
@@ -159,7 +159,7 @@ custom style checking modules used by this project."
 Options are plain or XML."
   :group 'jdee-checkstyle
   :type '(choice (const :tag "Plain" :value nil)
-		 (const :tag "XML" :value "xml")))
+                 (const :tag "XML" :value "xml")))
 
 
 ;; (makunbound 'jdee-checkstyle-source-dir)
@@ -187,7 +187,7 @@ string describing how the compilation finished."
   "Extension of Java source files (if not java)."
   :group 'jdee-checkstyle
   :type '(choice (const :tag "java" :value nil)
-		 (string :menu-tag "other" :tag "Extension")))
+                 (string :menu-tag "other" :tag "Extension")))
 
 
 (defmethod jdee-checkstyle-get-property-args ((this jdee-run-vm))
@@ -207,34 +207,34 @@ string describing how the compilation finished."
 
 (defclass jdee-checkstyle-checker ()
   ((buffer           :initarg :buffer
-		     :type buffer
-		     :documentation
-		     "Compilation buffer")
+                     :type buffer
+                     :documentation
+                     "Compilation buffer")
    (window           :initarg :window
-		     :type window
-		     :documentation
-		     "Window that displays the compilation buffer.")
+                     :type window
+                     :documentation
+                     "Window that displays the compilation buffer.")
    (interactive-args :initarg :interactive-args
                      :initform: nil
-		     :type list
-		     :documentation
-		     "Arguments entered in the minibuffer."))
+                     :type list
+                     :documentation
+                     "Arguments entered in the minibuffer."))
   "Class of Java style checkers.")
 
 (defmethod jdee-checkstyle-create-checker-buffer ((this jdee-checkstyle-checker))
   (save-excursion
     (let ((buf (get-buffer-create "*check style*"))
-	  (error-regexp-alist compilation-error-regexp-alist)
-	  (enter-regexp-alist (if (boundp 'compilation-enter-directory-regexp-alist)
-				  compilation-enter-directory-regexp-alist))
-	  (leave-regexp-alist (if (boundp 'compilation-leave-directory-regexp-alist)
-				  compilation-leave-directory-regexp-alist))
-	  (file-regexp-alist (if (boundp 'compilation-file-regexp-alist)
-				 compilation-file-regexp-alist))
-	  (nomessage-regexp-alist (if (boundp 'compilation-nomessage-regexp-alist)
-				      compilation-nomessage-regexp-alist))
-	  (error-message "No further errors")
-	  (thisdir default-directory))
+          (error-regexp-alist compilation-error-regexp-alist)
+          (enter-regexp-alist (if (boundp 'compilation-enter-directory-regexp-alist)
+                                  compilation-enter-directory-regexp-alist))
+          (leave-regexp-alist (if (boundp 'compilation-leave-directory-regexp-alist)
+                                  compilation-leave-directory-regexp-alist))
+          (file-regexp-alist (if (boundp 'compilation-file-regexp-alist)
+                                 compilation-file-regexp-alist))
+          (nomessage-regexp-alist (if (boundp 'compilation-nomessage-regexp-alist)
+                                      compilation-nomessage-regexp-alist))
+          (error-message "No further errors")
+          (thisdir default-directory))
 
       (oset this :buffer buf)
 
@@ -243,17 +243,17 @@ string describing how the compilation finished."
       ;; Make sure a style checker process is not
       ;; already running.
       (let ((check-proc (get-buffer-process (current-buffer))))
-	(if check-proc
-	    (if (or (not (eq (process-status check-proc) 'run))
-		    (yes-or-no-p
+        (if check-proc
+            (if (or (not (eq (process-status check-proc) 'run))
+                    (yes-or-no-p
                      "A check style process is running; kill it?"))
-		(condition-case ()
-		    (progn
-		      (interrupt-process check-proc)
-		      (sit-for 1)
-		      (delete-process check-proc))
-		  (error nil))
-	      (error "Cannot have two processes in `%s' at once"
+                (condition-case ()
+                    (progn
+                      (interrupt-process check-proc)
+                      (sit-for 1)
+                      (delete-process check-proc))
+                  (error nil))
+              (error "Cannot have two processes in `%s' at once"
                      (buffer-name)))))
 
       ;; In case the checker buffer is current, make sure we get the global
@@ -269,11 +269,11 @@ string describing how the compilation finished."
       (setq buffer-read-only nil)
 
       (set (make-local-variable 'compilation-finish-functions)
-	   (lambda (buf msg)
-	     (run-hook-with-args 'jdee-checkstyle-finish-hook buf msg)
-	     (setq compilation-finish-functions nil)))
+           (lambda (buf msg)
+             (run-hook-with-args 'jdee-checkstyle-finish-hook buf msg)
+             (setq compilation-finish-functions nil)))
       (if (boundp 'compilation-error-message)
-	  (set (make-local-variable 'compilation-error-message) error-message))
+          (set (make-local-variable 'compilation-error-message) error-message))
       (set (make-local-variable 'compilation-error-regexp-alist)
            error-regexp-alist)
       (dolist (elt `((compilation-enter-directory-regexp-alist
@@ -288,8 +288,8 @@ string describing how the compilation finished."
             (set (make-local-variable (car elt)) (second elt))))
 
       (if (boundp 'compilation-directory-stack)
-	  (setq default-directory thisdir
-		compilation-directory-stack (list default-directory))))))
+          (setq default-directory thisdir
+                compilation-directory-stack (list default-directory))))))
 
 (defmethod jdee-checkstyle-get-property-args ((this jdee-checkstyle-checker))
     "Get property arguments."
@@ -311,64 +311,64 @@ string describing how the compilation finished."
       (funcall compilation-process-setup-function))
 
   (let* ((outbuf (oref this :buffer))
-	 (vm-path (oref (jdee-run-get-vm) :path))
-	 (source-file
-	  (concat "./" (file-name-nondirectory buffer-file-name)))
-	 (jdee-java-directory
-	  (concat
-	   (jdee-find-jdee-data-directory)
-	   "java/"))
-	 (args (append
-		(unless jdee-checkstyle-expanded-properties-file
-		  (jdee-checkstyle-get-property-args this))
-		(oref this :interactive-args)
-		(list "-classpath"
-		      (if jdee-checkstyle-classpath
-			  (jdee-build-classpath jdee-checkstyle-classpath)
-			(jdee-normalize-path
-			 (expand-file-name "lib/checkstyle-all.jar" jdee-java-directory))))
-		(list jdee-checkstyle-class)
-		(list "-c"
-		      (if jdee-checkstyle-style
-			  (jdee-normalize-path jdee-checkstyle-style)
-			(concat (jdee-find-jdee-data-directory) "java/lib/sun_checks.xml")))
-		(if jdee-checkstyle-expanded-properties-file
-		    (list "-p" (jdee-normalize-path jdee-checkstyle-expanded-properties-file)))
-		(if jdee-checkstyle-module-package-names-file
-		    (list "-n" (jdee-normalize-path jdee-checkstyle-module-package-names-file)))
-		(if jdee-checkstyle-output-format
-		    (list "-f" jdee-checkstyle-output-format))
-		(if jdee-checkstyle-output-file
-		    (list "-o" (jdee-normalize-path jdee-checkstyle-output-file)))
-		(if jdee-checkstyle-source-file-extension
-		    (list "-e" jdee-checkstyle-source-file-extension))
-		(if jdee-checkstyle-source-dir
-		    (list "-r" (jdee-normalize-path jdee-checkstyle-source-dir))
-		  (list source-file)))))
+         (vm-path (oref (jdee-run-get-vm) :path))
+         (source-file
+          (concat "./" (file-name-nondirectory buffer-file-name)))
+         (jdee-java-directory
+          (concat
+           (jdee-find-jdee-data-directory)
+           "java/"))
+         (args (append
+                (unless jdee-checkstyle-expanded-properties-file
+                  (jdee-checkstyle-get-property-args this))
+                (oref this :interactive-args)
+                (list "-classpath"
+                      (if jdee-checkstyle-classpath
+                          (jdee-build-classpath jdee-checkstyle-classpath)
+                        (jdee-normalize-path
+                         (expand-file-name "lib/checkstyle-all.jar" jdee-java-directory))))
+                (list jdee-checkstyle-class)
+                (list "-c"
+                      (if jdee-checkstyle-style
+                          (jdee-normalize-path jdee-checkstyle-style)
+                        (concat (jdee-find-jdee-data-directory) "java/lib/sun_checks.xml")))
+                (if jdee-checkstyle-expanded-properties-file
+                    (list "-p" (jdee-normalize-path jdee-checkstyle-expanded-properties-file)))
+                (if jdee-checkstyle-module-package-names-file
+                    (list "-n" (jdee-normalize-path jdee-checkstyle-module-package-names-file)))
+                (if jdee-checkstyle-output-format
+                    (list "-f" jdee-checkstyle-output-format))
+                (if jdee-checkstyle-output-file
+                    (list "-o" (jdee-normalize-path jdee-checkstyle-output-file)))
+                (if jdee-checkstyle-source-file-extension
+                    (list "-e" jdee-checkstyle-source-file-extension))
+                (if jdee-checkstyle-source-dir
+                    (list "-r" (jdee-normalize-path jdee-checkstyle-source-dir))
+                  (list source-file)))))
 
     (with-current-buffer outbuf
 
       (insert (format "cd %s\n" default-directory))
 
       (insert (concat
-	       vm-path
-	       " "
-	       (mapconcat 'identity args " ")
-	       "\n\n"))
+               vm-path
+               " "
+               (mapconcat 'identity args " ")
+               "\n\n"))
 
       (let* ((process-environment (cons "EMACS=t" process-environment))
-	     (w32-quote-process-args ?\")
-	     (win32-quote-process-args ?\") ;; XEmacs
-	     (proc (apply 'start-process
-			  (downcase mode-name)
-			  outbuf
-			  vm-path
-			  args)))
-	(set-process-sentinel proc 'compilation-sentinel)
-	(set-process-filter proc 'compilation-filter)
-	(set-marker (process-mark proc) (point) outbuf)
-	(setq compilation-in-progress
-	      (cons proc compilation-in-progress)))
+             (w32-quote-process-args ?\")
+             (win32-quote-process-args ?\") ;; XEmacs
+             (proc (apply 'start-process
+                          (downcase mode-name)
+                          outbuf
+                          vm-path
+                          args)))
+        (set-process-sentinel proc 'compilation-sentinel)
+        (set-process-filter proc 'compilation-filter)
+        (set-marker (process-mark proc) (point) outbuf)
+        (setq compilation-in-progress
+              (cons proc compilation-in-progress)))
 
       (set-buffer-modified-p nil)
       (setq compilation-last-buffer (oref this :buffer)))))
@@ -388,16 +388,16 @@ history enabled."
 
   (if jdee-checkstyle-read-args
       (setq jdee-checkstyle-interactive-args
-	    (read-from-minibuffer
-	     "Check args: "
-	     jdee-checkstyle-interactive-args
-	     nil nil
-	     '(jdee-checkstyle-interactive-arg-history . 1))))
+            (read-from-minibuffer
+             "Check args: "
+             jdee-checkstyle-interactive-args
+             nil nil
+             '(jdee-checkstyle-interactive-arg-history . 1))))
 
   (let ((checker (jdee-checkstyle-checker
-		  "checker"
-		  :interactive-args (if jdee-checkstyle-read-args
-					jdee-checkstyle-interactive-args))))
+                  "checker"
+                  :interactive-args (if jdee-checkstyle-read-args
+                                        jdee-checkstyle-interactive-args))))
 
     ;; Force save-some-buffers to use the minibuffer
     ;; to query user about whether to save modified buffers.
@@ -406,13 +406,13 @@ history enabled."
     ;; which seems not to be supported--at least on
     ;; the PC.
     (if (eq system-type 'windows-nt)
-	(let ((temp last-nonmenu-event))
-	  ;; The next line makes emacs think that jdee-checkstyle
-	  ;; was invoked from the minibuffer, even when it
-	  ;; is actually invoked from the menu-bar.
-	  (setq last-nonmenu-event t)
-	  (save-some-buffers (not compilation-ask-about-save) nil)
-	  (setq last-nonmenu-event temp))
+        (let ((temp last-nonmenu-event))
+          ;; The next line makes emacs think that jdee-checkstyle
+          ;; was invoked from the minibuffer, even when it
+          ;; is actually invoked from the menu-bar.
+          (setq last-nonmenu-event t)
+          (save-some-buffers (not compilation-ask-about-save) nil)
+          (setq last-nonmenu-event temp))
       (save-some-buffers (not compilation-ask-about-save) nil))
 
     (jdee-checkstyle-exec checker)))

--- a/jdee-class.el
+++ b/jdee-class.el
@@ -64,17 +64,17 @@ argument in the SPEC is the package to restrict processing to.
 \(fn (VAR [RESULT] [PACKAGE]) BODY...)"
 
   (let ((class-var-sym (car spec))
-	(old-dir-sym (cl-gensym "--with-all-class-files-old-dir"))
-	(normalized-path-sym (cl-gensym "--with-all-class-files-npath"))
-	(dir-sym (cl-gensym "--with-all-class-files-dir-sym"))
-	(dir2-sym (cl-gensym "--with-all-class-files-dir2-sym"))
-	(path-sym (cl-gensym "--with-all-class-files-path"))
-	(buf-sym (cl-gensym "--with-all-class-files-buf"))
-	(rec-descend (cl-gensym "--with-all-class-files-rec-descend"))
-	(process-files (cl-gensym "--with-all-class-files-process-files"))
-	(process-class (cl-gensym "--with-all-class-files-process-class"))
-	(child-path (cl-gensym "--with-all-class-files-child-path"))
-	(package (nth 2 spec)))
+        (old-dir-sym (cl-gensym "--with-all-class-files-old-dir"))
+        (normalized-path-sym (cl-gensym "--with-all-class-files-npath"))
+        (dir-sym (cl-gensym "--with-all-class-files-dir-sym"))
+        (dir2-sym (cl-gensym "--with-all-class-files-dir2-sym"))
+        (path-sym (cl-gensym "--with-all-class-files-path"))
+        (buf-sym (cl-gensym "--with-all-class-files-buf"))
+        (rec-descend (cl-gensym "--with-all-class-files-rec-descend"))
+        (process-files (cl-gensym "--with-all-class-files-process-files"))
+        (process-class (cl-gensym "--with-all-class-files-process-class"))
+        (child-path (cl-gensym "--with-all-class-files-child-path"))
+        (package (nth 2 spec)))
     `(labels ((,process-class (,class-var-sym)
                               (when (string-match "\.[Cc][Ll][Aa][Ss][Ss]$" ,class-var-sym)
                                 ,@body))
@@ -140,16 +140,16 @@ Example:(with-all-class-infos-when (info) (lambda (x)
  (some-pred-p x)) (do-stuff info))"
 
   (let ((parsed-class-sym (cl-gensym "--with-all-class-infos-pclasses"))
-	(class-file-sym (cl-gensym "--with-all-class-infos-cfile"))
-	(var-sym (car spec)))
+        (class-file-sym (cl-gensym "--with-all-class-infos-cfile"))
+        (var-sym (car spec)))
     `(let ((,parsed-class-sym '()))
        (with-all-class-files (,class-file-sym ,@(cdr spec))
-			     (when (and (not (jdee-class-path-in-classes-p ,class-file-sym ,parsed-class-sym))
-					(funcall ,pred ,class-file-sym))
-			       (let ((,var-sym (jdee-bytecode ,class-file-sym)))
-				 ,@body
-				 (add-to-list (quote ,parsed-class-sym)
-					      (jdee-bytecode-extract-classname info)))))
+                             (when (and (not (jdee-class-path-in-classes-p ,class-file-sym ,parsed-class-sym))
+                                        (funcall ,pred ,class-file-sym))
+                               (let ((,var-sym (jdee-bytecode ,class-file-sym)))
+                                 ,@body
+                                 (add-to-list (quote ,parsed-class-sym)
+                                              (jdee-bytecode-extract-classname info)))))
        ,(cadr spec))))
 
 (defmacro with-all-corresponding-class-infos (spec &rest body)
@@ -168,7 +168,7 @@ info, the package name of the source file, the source name of the source file, a
   "Returns true if the PATH looks like it represents a class in CLASSES"
   (jdee-class-partial-match-member
    (replace-regexp-in-string "\\.[Cc][Ll][Aa][Ss][Ss]$" ""
-			     (replace-regexp-in-string "/\\|\\$" "." path))
+                             (replace-regexp-in-string "/\\|\\$" "." path))
    classes))
 
 (defun jdee-class-partial-match-member (str list)
@@ -188,33 +188,33 @@ will not be."
 
 (defun jdee-class-get-all-classes-used-by-source (package source-file)
   (let ((primitives '("boolean" "int" "void" "float" "double"))
-	(classes '()))
+        (classes '()))
     (with-all-corresponding-class-infos (info package source-file classes)
-					;;a. super class type
-					(add-to-list 'classes (jdee-bytecode-extract-superclass info))
-					;;b. super interfaces type
-					(append-to-list 'classes (jdee-bytecode-extract-interfaces info))
-					;;c. types of declared fields
-					;;d. local variable types
-					;; (all called types should wrk for this...)
-					(append-to-list 'classes (mapcar (lambda(item) (caadr item))
-									 (jdee-bytecode-extract-method-calls info)))
-					;;e. method return type
-					;;f. method parameter type
-					(dolist (sig (jdee-bytecode-extract-method-signatures info))
-					  (when (and (nth 1 sig) (not (member (nth 1 sig) primitives)))
-					    (add-to-list 'classes (nth 1 sig)))
-					  (append-to-list 'classes
-							  (mapcar (lambda (c) (when (and c (not (member c primitives)) c)))
-								  (nth 2 sig))))
-					;;g. method exception types
-					(dolist (exceptions (mapcar (lambda (method-exceptions) (nth 1 method-exceptions))
-								    (jdee-bytecode-extract-thrown-exception-types info)))
-					  (append-to-list 'classes exceptions))
-					;;h. type of exceptions in 'catch' statements.
-					(dolist (exceptions (mapcar (lambda (method-exceptions) (nth 1 method-exceptions))
-								    (jdee-bytecode-extract-caught-exception-types info)))
-					  (append-to-list 'classes exceptions)))))
+                                        ;;a. super class type
+                                        (add-to-list 'classes (jdee-bytecode-extract-superclass info))
+                                        ;;b. super interfaces type
+                                        (append-to-list 'classes (jdee-bytecode-extract-interfaces info))
+                                        ;;c. types of declared fields
+                                        ;;d. local variable types
+                                        ;; (all called types should wrk for this...)
+                                        (append-to-list 'classes (mapcar (lambda(item) (caadr item))
+                                                                         (jdee-bytecode-extract-method-calls info)))
+                                        ;;e. method return type
+                                        ;;f. method parameter type
+                                        (dolist (sig (jdee-bytecode-extract-method-signatures info))
+                                          (when (and (nth 1 sig) (not (member (nth 1 sig) primitives)))
+                                            (add-to-list 'classes (nth 1 sig)))
+                                          (append-to-list 'classes
+                                                          (mapcar (lambda (c) (when (and c (not (member c primitives)) c)))
+                                                                  (nth 2 sig))))
+                                        ;;g. method exception types
+                                        (dolist (exceptions (mapcar (lambda (method-exceptions) (nth 1 method-exceptions))
+                                                                    (jdee-bytecode-extract-thrown-exception-types info)))
+                                          (append-to-list 'classes exceptions))
+                                        ;;h. type of exceptions in 'catch' statements.
+                                        (dolist (exceptions (mapcar (lambda (method-exceptions) (nth 1 method-exceptions))
+                                                                    (jdee-bytecode-extract-caught-exception-types info)))
+                                          (append-to-list 'classes exceptions)))))
 
 (provide 'jdee-class)
 

--- a/jdee-compile.el
+++ b/jdee-compile.el
@@ -89,12 +89,12 @@ JDK for the current project. Similarly, to use ecj, select \"eclipse java compil
 and specify the path of the eclipse compiler ecj.jar."
   :group 'jdee-project
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Compiler type"
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Compiler type"
            (item "javac")
-	   (item "javac server")
-	   (list :format "%v"
+           (item "javac server")
+           (list :format "%v"
                  (const "eclipse java compiler server")
                  (file :tag "Path to  ecj.jar (or jdt core jar)"))
            ))
@@ -160,11 +160,11 @@ and a string describing how the compilation finished."
 
 (defun jdee-compile-update-class-list ()
   (let ((class-dir
-	 (if (string= jdee-compile-option-directory "")
-	     (expand-file-name ".")
-	   (jdee-normalize-path
-	    jdee-compile-option-directory
-	    'jdee-compile-option-directory))))
+         (if (string= jdee-compile-option-directory "")
+             (expand-file-name ".")
+           (jdee-normalize-path
+            jdee-compile-option-directory
+            'jdee-compile-option-directory))))
     (unless jdee-compile-mute
       (message (concat "Updating class list for " class-dir)))
     (jdee-backend-update-class-list class-dir)
@@ -178,24 +178,24 @@ don't know which classes were recompiled."
   ;;Setting the last java buffer as the current buffer
   (condition-case nil
       (progn
-	(set-buffer (car (buffer-list)))
-	(if (eq major-mode 'jdee-mode)
-	    (progn
+        (set-buffer (car (buffer-list)))
+        (if (eq major-mode 'jdee-mode)
+            (progn
               ;;; TODO: replace with observer/event
-	      (setq jdee-complete-last-compiled-class (jdee-parse-get-buffer-class))
-	      (jdee-complete-flush-classes-in-cache (list jdee-complete-last-compiled-class))
+              (setq jdee-complete-last-compiled-class (jdee-parse-get-buffer-class))
+              (jdee-complete-flush-classes-in-cache (list jdee-complete-last-compiled-class))
               (unless jdee-compile-mute
                 (message "Flushed completion cache."))
-	      (setq jdee-complete-last-compiled-class nil)
-	      (jdee-compile-update-class-list))))
+              (setq jdee-complete-last-compiled-class nil)
+              (jdee-compile-update-class-list))))
     (error nil)))
 
 ;;; TODO: remove from here and add observer
 (defun jdee-compile-finish-refresh-speedbar (buf msg)
   "Refresh speedbar at the end of a compilation."
   (if (and (boundp 'speedbar-frame)
-	   (frame-live-p speedbar-frame)
-	   (frame-visible-p speedbar-frame))
+           (frame-live-p speedbar-frame)
+           (frame-visible-p speedbar-frame))
       (speedbar-refresh)))
 
 (defcustom jdee-compile-jump-to-first-error t
@@ -326,21 +326,21 @@ The JDK 1.1.x versions of javac do not support inclusion of selected
 debug information."
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Debug info to include in class:"
-	   (const "all")
-	   (const "none")
-	   (const "selected"))
-	  (list
-	   :tag "    info"
-	   :indent 4
-	   (checkbox :format "%[%v%] %t \n"
-		     :tag "Line Numbers")
-	   (checkbox :format "%[%v%] %t \n"
-		     :tag "Variables")
-	   (checkbox :format "%[%v%] %t \n"
-		     :tag "Source")))
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Debug info to include in class:"
+           (const "all")
+           (const "none")
+           (const "selected"))
+          (list
+           :tag "    info"
+           :indent 4
+           (checkbox :format "%[%v%] %t \n"
+                     :tag "Line Numbers")
+           (checkbox :format "%[%v%] %t \n"
+                     :tag "Variables")
+           (checkbox :format "%[%v%] %t \n"
+                     :tag "Source")))
 
 )
 
@@ -387,11 +387,11 @@ from the following options:
   -depend   Full dependency checking (pre-JDK 1.1.6)"
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Select -Xdepend (javac) or -depend (pre-JDK 1.1.6):"
-	   (const "-Xdepend")
-	   (const "-depend"))))
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Select -Xdepend (javac) or -depend (pre-JDK 1.1.6):"
+           (const "-Xdepend")
+           (const "-depend"))))
 
 (defcustom jdee-compile-option-vm-args nil
 "*Specify command-line arguments for Java interpreter.
@@ -428,12 +428,12 @@ warnings."
 "*Controls whether annotation processing and/or compilation is done."
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Processing:"
-	   (const "compile and process annotations")
-	   (const "compile only")
-	   (const "process annotations only"))))
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Processing:"
+           (const "compile and process annotations")
+           (const "compile only")
+           (const "process annotations only"))))
 
 ;;(makunbound 'jdee-compile-option-annotation-processor-options)
 (defcustom jdee-compile-option-annotation-processor-options nil
@@ -443,9 +443,9 @@ individual processors. key should be one or more identifiers
 separated by \".\"."
   :group 'jdee-compile-options
   :type '(repeat
-	  (cons :tag "Option"
-	   (string :tag "Key")
-	   (string :tag "Value"))))
+          (cons :tag "Option"
+           (string :tag "Key")
+           (string :tag "Value"))))
 
 (defcustom jdee-compile-option-encoding ""
 "*Specify the source file encoding name, such as EUCJIS\\SJIS.
@@ -479,12 +479,12 @@ annotations in other files. Options are:
 "
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Processing:"
-	   (const "Generate and warn")
-	   (const "Generate and do not warn")
-	   (const "Do not generate"))))
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Processing:"
+           (const "Generate and warn")
+           (const "Generate and do not warn")
+           (const "Do not generate"))))
 
 
 ;;(makunbound 'jdee-compile-option-source)
@@ -492,7 +492,7 @@ annotations in other files. Options are:
   "*Enables JDK version-specific features to be used in
 source files.
 
-  1.3	  The compiler does not support assertions
+  1.3          The compiler does not support assertions
 
   1.4     The compiler accepts code containing assertions.
 
@@ -518,16 +518,16 @@ source files.
    starting with J2SDK 1.4."
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Source release:"
-	   (const "default")
-	   (const "1.3")
-	   (const "1.4")
-	   (const "1.5")
-	   (const "1.6")
-	   (const "1.7")
-	   (const "1.8")
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Source release:"
+           (const "default")
+           (const "1.3")
+           (const "1.4")
+           (const "1.5")
+           (const "1.6")
+           (const "1.7")
+           (const "1.8")
            (const "1.9"))))
 
 ;;(makunbound 'jdee-compile-option-target)
@@ -535,32 +535,32 @@ source files.
   "*Generate class files that will work on VMs with the specified version.
 
   1.1     Ensure that generated class files will be compatible
-	  with 1.1 and 1.2 VMs.
+          with 1.1 and 1.2 VMs.
 
   1.2     Generate class files that will run on 1.2 VMs, but
-	  not on 1.1 VMs.
+          not on 1.1 VMs.
 
   1.3     Generate class files that will run on VMs in the
-	  Java 2 SDK, v 1.3 and later, but will not run
-	  on 1.1 or 1.2 VMs
+          Java 2 SDK, v 1.3 and later, but will not run
+          on 1.1 or 1.2 VMs
 
   1.4     Generate class files that are compatible only with
-	  1.4 VMs.
+          1.4 VMs.
 
   1.5     Generate class files that are compatible only with
-	  1.5 VMs.
+          1.5 VMs.
 
   1.6     Generate class files that are compatible only with
-	  1.6 VMs.
+          1.6 VMs.
 
   1.7     Generate class files that are compatible only with
-	  1.7 VMs.
+          1.7 VMs.
 
   1.8     Generate class files that are compatible only with
-	  1.8 VMs.
+          1.8 VMs.
 
   1.9     Generate class files that are compatible only with
-	  1.9 VMs.
+          1.9 VMs.
 
 Select \"default\" to use the source features that the compiler
 supports by default, i.e., to not include the -target switch on
@@ -574,18 +574,18 @@ different Java platform implementation. It is important to use
 cross-compiling."
   :group 'jdee-compile-options
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Target VM:"
-	   (const "default")
-	   (const "1.1")
-	   (const "1.2")
-	   (const "1.3")
-	   (const "1.4")
-	   (const "1.5")
-	   (const "1.6")
-	   (const "1.7")
-	   (const "1.8")
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Target VM:"
+           (const "default")
+           (const "1.1")
+           (const "1.2")
+           (const "1.3")
+           (const "1.4")
+           (const "1.5")
+           (const "1.6")
+           (const "1.7")
+           (const "1.8")
            (const "1.9"))))
 
 (defcustom jdee-compile-option-bootclasspath nil
@@ -657,16 +657,16 @@ If t (or other non-nil non-number) then kill in 2 secs."
   ;; already running.
   (if (oref this process)
       (if (or (not (eq (process-status (oref this process)) 'run))
-	      (yes-or-no-p
-	       "A compilation process is running; kill it?"))
-	  (condition-case ()
-	      (progn
-		(interrupt-process (oref this process))
-		(sit-for 1)
-		(delete-process (oref this process)))
-	    (error nil))
-	(error "Cannot have two processes in `%s' at once"
-	       (oref this buffer-name))))
+              (yes-or-no-p
+               "A compilation process is running; kill it?"))
+          (condition-case ()
+              (progn
+                (interrupt-process (oref this process))
+                (sit-for 1)
+                (delete-process (oref this process)))
+            (error nil))
+        (error "Cannot have two processes in `%s' at once"
+               (oref this buffer-name))))
 
   (bsh-compilation-buffer-set-mode this))
 
@@ -678,62 +678,62 @@ If t (or other non-nil non-number) then kill in 2 secs."
 
 (defclass jdee-compile-compiler ()
   ((name             :initarg :name
-		     :type string
-		     :documentation
-		     "Name of compiler")
+                     :type string
+                     :documentation
+                     "Name of compiler")
    (version          :initarg :version
-		     :type string
-		     :documentation
-		     "Compiler version.")
+                     :type string
+                     :documentation
+                     "Compiler version.")
    (path             :initarg :path
-		     :type string
-		     :documentation
-		     "Path of the compiler executable.")
+                     :type string
+                     :documentation
+                     "Path of the compiler executable.")
    (buffer           :initarg :buffer
-		     :type bsh-compilation-buffer
-		     :documentation
-		     "Compilation buffer")
+                     :type bsh-compilation-buffer
+                     :documentation
+                     "Compilation buffer")
    (window           :initarg :window
-		     :type window
-		     :documentation
-		     "Window that displays the compilation buffer.")
+                     :type window
+                     :documentation
+                     "Window that displays the compilation buffer.")
    (interactive-args :initarg :interactive-args
                      :initform nil
-		     :type list
-		     :documentation
-		     "Arguments entered in the minibuffer.")
+                     :type list
+                     :documentation
+                     "Arguments entered in the minibuffer.")
    (use-server-p     :initarg :use-server-p
-		     :type boolean
-		     :documentation
-		     "Run as a compile server in the Beanshell."))
+                     :type boolean
+                     :documentation
+                     "Run as a compile server in the Beanshell."))
   "Class of Java compilers.")
 
 (defmethod jdee-compile-classpath-arg ((this jdee-compile-compiler))
   "Returns the classpath argument for this compiler."
   (let ((classpath
-	 (if jdee-compile-option-classpath
-	     jdee-compile-option-classpath
-	   (jdee-get-global-classpath)))
-	(symbol
-	 (if jdee-compile-option-classpath
-	     'jdee-compile-option-classpath
-	   'jdee-global-classpath)))
+         (if jdee-compile-option-classpath
+             jdee-compile-option-classpath
+           (jdee-get-global-classpath)))
+        (symbol
+         (if jdee-compile-option-classpath
+             'jdee-compile-option-classpath
+           'jdee-global-classpath)))
     (if classpath
-	(list
-	 "-classpath"
-	 (jdee-build-classpath
-	  classpath
-	  symbol)
-	 ))))
+        (list
+         "-classpath"
+         (jdee-build-classpath
+          classpath
+          symbol)
+         ))))
 
 (defmethod jdee-compile-sourcepath-arg ((this jdee-compile-compiler))
   "Get the source path argument for this compiler."
     (if jdee-compile-option-sourcepath
-	(list
-	 "-sourcepath"
-	 (jdee-build-classpath
-	  jdee-compile-option-sourcepath
-	  'jdee-compile-option-sourcepath))))
+        (list
+         "-sourcepath"
+         (jdee-build-classpath
+          jdee-compile-option-sourcepath
+          'jdee-compile-option-sourcepath))))
 
 (defmethod jdee-compile-bootclasspath-arg ((this jdee-compile-compiler))
   "Get the boot classpath argument for this compiler."
@@ -741,7 +741,7 @@ If t (or other non-nil non-number) then kill in 2 secs."
       (list
        "-bootclasspath"
        (jdee-build-classpath jdee-compile-option-bootclasspath
-			    'jdee-compile-option-bootclasspath))))
+                            'jdee-compile-option-bootclasspath))))
 
 (defmethod jdee-compile-extdirs-arg ((this jdee-compile-compiler))
   "Get the extdirs argument for this compiler."
@@ -749,8 +749,8 @@ If t (or other non-nil non-number) then kill in 2 secs."
       (list
        "-extdirs"
        (jdee-build-classpath
-	jdee-compile-option-extdirs
-	'jdee-compile-option-extdirs))))
+        jdee-compile-option-extdirs
+        'jdee-compile-option-extdirs))))
 
 
 (defmethod jdee-compile-encoding-arg ((this jdee-compile-compiler))
@@ -762,10 +762,10 @@ If t (or other non-nil non-number) then kill in 2 secs."
 (defmethod jdee-compile-debug-arg ((this jdee-compile-compiler))
   "Get the debug arg for this compiler."
   (let* ((include-option (nth 0 jdee-compile-option-debug))
-	 (selected (nth 1 jdee-compile-option-debug))
-	 (lines (nth 0 selected))
-	 (vars (nth 1 selected))
-	 (src (nth 2 selected)))
+         (selected (nth 1 jdee-compile-option-debug))
+         (lines (nth 0 selected))
+         (vars (nth 1 selected))
+         (src (nth 2 selected)))
     (cond
      ((and
        (string= include-option "selected")
@@ -782,31 +782,31 @@ If t (or other non-nil non-number) then kill in 2 secs."
        (or lines vars src))
       (list
        (concat
-	"-g:"
-	(if lines
-	    (if (or vars src) "lines,"
-	      "lines"))
-	(if vars
-	    (if vars
-		(if src "vars," "vars")))
-	(if src "source")))))))
+        "-g:"
+        (if lines
+            (if (or vars src) "lines,"
+              "lines"))
+        (if vars
+            (if vars
+                (if src "vars," "vars")))
+        (if src "source")))))))
 
 (defmethod jdee-compile-output-dir-arg ((this jdee-compile-compiler))
   "Get the ouput directory arg for this compiler."
     (if (not (string= jdee-compile-option-directory ""))
-	(list
-	 "-d"
-	 (jdee-normalize-path 'jdee-compile-option-directory))))
+        (list
+         "-d"
+         (jdee-normalize-path 'jdee-compile-option-directory))))
 
 (defmethod jdee-compile-deprecation-arg ((this jdee-compile-compiler))
   "Get deprecation argument for this compiler."
     (if jdee-compile-option-deprecation
-	(list "-deprecation")))
+        (list "-deprecation")))
 
 (defmethod jdee-compile-optimize-arg ((this jdee-compile-compiler))
   "Get optimization argument for this compiler."
     (if jdee-compile-option-optimize
-	(list "-O")))
+        (list "-O")))
 
 (defmethod jdee-compile-depend-arg ((this jdee-compile-compiler))
   "Get dependency-checking argument for this compiler."
@@ -816,41 +816,41 @@ If t (or other non-nil non-number) then kill in 2 secs."
 (defmethod jdee-compile-vm-args ((this jdee-compile-compiler))
   "Get arguments to pass to the vm used to run this compiler."
     (if jdee-compile-option-vm-args
-	(cl-mapcan
-	 (lambda (arg)
-	   (list (concat "-J" arg)))
-	 jdee-compile-option-vm-args)))
+        (cl-mapcan
+         (lambda (arg)
+           (list (concat "-J" arg)))
+         jdee-compile-option-vm-args)))
 
 (defmethod jdee-compile-verbose-arg ((this jdee-compile-compiler))
   "Get verbosity level argument for this compiler."
     (if jdee-compile-option-verbose
-	(list "-verbose")))
+        (list "-verbose")))
 
 (defmethod jdee-compile-verbose-path-arg ((this jdee-compile-compiler))
   "Get verbose path argument for this compiler."
     (if jdee-compile-option-verbose-path
-	(list "-Xverbosepath")))
+        (list "-Xverbosepath")))
 
 (defmethod jdee-compile-nowarn-arg ((this jdee-compile-compiler))
   "Get no warning argument for this compiler."
     (if jdee-compile-option-nowarn
-	(list "-nowarn")))
+        (list "-nowarn")))
 
 (defmethod jdee-compile-command-line-args ((this jdee-compile-compiler))
   "Get additional command line arguments for this compiler."
-	jdee-compile-option-command-line-args)
+        jdee-compile-option-command-line-args)
 
 (defmethod jdee-compile-target-arg ((this jdee-compile-compiler))
   "Get compiler target argument for this compiler."
     (let ((target (car jdee-compile-option-target)))
       (if (not (string= target "default"))
-	  (list "-target" target))))
+          (list "-target" target))))
 
 (defmethod jdee-compile-source-arg ((this jdee-compile-compiler))
   "Get compiler source argument for this compiler."
   (let ((source (car jdee-compile-option-source)))
     (if (not (string= source "default"))
-	(list "-source" source))))
+        (list "-source" source))))
 
 (defmethod jdee-compile-get-args ((this jdee-compile-compiler))
   (append
@@ -875,19 +875,19 @@ If t (or other non-nil non-number) then kill in 2 secs."
 
 (defmethod jdee-compile-run-exec ((this jdee-compile-compiler))
   (let* ((outbuf (oref (oref this buffer) buffer))
-	 (compiler-path (oref this :path))
-	 (source-file (file-name-nondirectory buffer-file-name))
-	 (flag nil)
-	 (args (append
-		(jdee-compile-get-args this)
-		(oref this :interactive-args)
-		(list source-file))))
+         (compiler-path (oref this :path))
+         (source-file (file-name-nondirectory buffer-file-name))
+         (flag nil)
+         (args (append
+                (jdee-compile-get-args this)
+                (oref this :interactive-args)
+                (list source-file))))
 
     (with-current-buffer outbuf
 
       (let ((inhibit-read-only t)) ; make compilation buffer temporarily writable
-	(insert (format "cd %s\n" default-directory))
-	(insert (concat
+        (insert (format "cd %s\n" default-directory))
+        (insert (concat
                  compiler-path
                  " "
                  (mapconcat (lambda (x)
@@ -904,18 +904,18 @@ If t (or other non-nil non-number) then kill in 2 secs."
                  "\n\n")))
 
       (let* ((process-environment (cons "EMACS=t" process-environment))
-	     (w32-quote-process-args ?\")
-	     (win32-quote-process-args ?\") ;; XEmacs
-	     (proc (apply 'start-process
-			  (downcase mode-name)
-			  outbuf
-			  compiler-path
-			  args)))
-	(set-process-sentinel proc 'compilation-sentinel)
-	(set-process-filter proc 'compilation-filter)
-	(set-marker (process-mark proc) (point) outbuf)
-	(setq compilation-in-progress
-	      (cons proc compilation-in-progress))))))
+             (w32-quote-process-args ?\")
+             (win32-quote-process-args ?\") ;; XEmacs
+             (proc (apply 'start-process
+                          (downcase mode-name)
+                          outbuf
+                          compiler-path
+                          args)))
+        (set-process-sentinel proc 'compilation-sentinel)
+        (set-process-filter proc 'compilation-filter)
+        (set-marker (process-mark proc) (point) outbuf)
+        (setq compilation-in-progress
+              (cons proc compilation-in-progress))))))
 
 ;;; TODO: extract code duplicated with EJC version
 (defmethod jdee-compile-run-server ((this jdee-compile-compiler))
@@ -928,15 +928,15 @@ If t (or other non-nil non-number) then kill in 2 secs."
          (arg-array (concat "new String[] {\"" source-path "\"")))
 
     (if args
-	(setq arg-array
-	      (concat
-	       arg-array
-	       ","
-	       (mapconcat
-		(lambda (arg)
-		  (concat "\"" arg "\""))
-		args
-		","))))
+        (setq arg-array
+              (concat
+               arg-array
+               ","
+               (mapconcat
+                (lambda (arg)
+                  (concat "\"" arg "\""))
+                args
+                ","))))
 
     (setq arg-array (concat arg-array "}"))
 
@@ -1154,8 +1154,8 @@ If t (or other non-nil non-number) then kill in 2 secs."
     (list
      "-processor"
      (mapconcat 'identity
-		jdee-compile-option-annotation-processors
-		","))))
+                jdee-compile-option-annotation-processors
+                ","))))
 
 (defmethod jdee-compile-annotation-processing-arg ((this jdee-compile-javac-16))
   (let ((option (car jdee-compile-option-annotation-processing)))
@@ -1172,10 +1172,10 @@ If t (or other non-nil non-number) then kill in 2 secs."
     (mapcar
      (lambda (option)
        (let ((key (car option))
-	     (value (cdr option)))
-	 (if (string= value "")
-	     (format "-A%s" key)
-	   (format "-A%s=%s" key value))))
+             (value (cdr option)))
+         (if (string= value "")
+             (format "-A%s" key)
+           (format "-A%s=%s" key value))))
      jdee-compile-option-annotation-processor-options))
 
 (defmethod jdee-compile-implicit-arg ((this jdee-compile-javac-16))
@@ -1362,46 +1362,46 @@ If t (or other non-nil non-number) then kill in 2 secs."
 (defun jdee-compile-get-javac ()
   "Return Java compiler that matches the current JDK."
   (let* ((jdk-version (jdee-java-version))
-	 (jdk-split-version (split-string jdk-version "[.]"))
-	 (jdk-major-version (nth 0 jdk-split-version))
-	 (jdk-minor-version (nth 1 jdk-split-version))
-	 (compiler
-	  (cl-find-if
-	   (lambda (compiler-x)
-	     (let* ((compiler-split-version (split-string (oref compiler-x :version) "[.]"))
-		    (compiler-major-version (nth 0 compiler-split-version))
-		    (compiler-minor-version (nth 1 compiler-split-version)))
-	       (and
-		(string= jdk-major-version compiler-major-version)
-		(string= jdk-minor-version compiler-minor-version))))
-	   jdee-compile-javac-compilers)))
+         (jdk-split-version (split-string jdk-version "[.]"))
+         (jdk-major-version (nth 0 jdk-split-version))
+         (jdk-minor-version (nth 1 jdk-split-version))
+         (compiler
+          (cl-find-if
+           (lambda (compiler-x)
+             (let* ((compiler-split-version (split-string (oref compiler-x :version) "[.]"))
+                    (compiler-major-version (nth 0 compiler-split-version))
+                    (compiler-minor-version (nth 1 compiler-split-version)))
+               (and
+                (string= jdk-major-version compiler-major-version)
+                (string= jdk-minor-version compiler-minor-version))))
+           jdee-compile-javac-compilers)))
     ;; Suggest to use the latest if not found.
     (unless compiler
       (let ((latest-javac (car (last jdee-compile-javac-compilers))))
-	(if
-	    (and t (yes-or-no-p
-	     (format "The JDE does not recognize JDK %s javac. Assume JDK %s javac?"
-		     jdk-version (oref latest-javac :version))))
-	    (setq compiler latest-javac))))
+        (if
+            (and t (yes-or-no-p
+             (format "The JDE does not recognize JDK %s javac. Assume JDK %s javac?"
+                     jdk-version (oref latest-javac :version))))
+            (setq compiler latest-javac))))
     ;; Initialize the compiler
     (if compiler
-	(if (string= (car jdee-compiler) "javac server")
-	    (oset compiler :use-server-p t)
-	  (progn
-	    (oset compiler :use-server-p nil)
-	    (oset compiler
-		  :path
+        (if (string= (car jdee-compiler) "javac server")
+            (oset compiler :use-server-p t)
+          (progn
+            (oset compiler :use-server-p nil)
+            (oset compiler
+                  :path
                   ;; Discover compiler's path:
-		  (let ((compiler-path
+                  (let ((compiler-path
                          (if (listp (car jdee-compiler))
                              (substitute-in-file-name (nth 1 (car jdee-compiler)))
                            "")))
-		    (if (string= compiler-path "")
-			(setq compiler-path (jdee-get-jdk-prog 'javac))
-		      (if (file-exists-p compiler-path)
-			  compiler-path
-			(error (format "Invalid compiler path %s"
-				       compiler-path)))))))))
+                    (if (string= compiler-path "")
+                        (setq compiler-path (jdee-get-jdk-prog 'javac))
+                      (if (file-exists-p compiler-path)
+                          compiler-path
+                        (error (format "Invalid compiler path %s"
+                                       compiler-path)))))))))
     compiler))
 
 (defun jdee-compile-get-ejc ()

--- a/jdee-complete.el
+++ b/jdee-complete.el
@@ -90,10 +90,10 @@ minibuffer), a buffer(a one line buffer shows the signature and then
 dissapears), or none."
   :group 'jdee-complete
   :type '(list
-	  (radio-button-choice
-	   (const "Eldoc")
-	   (const "Buffer")
-	   (const "None"))))
+          (radio-button-choice
+           (const "Eldoc")
+           (const "Buffer")
+           (const "None"))))
 
 (defcustom jdee-complete-signature-display-time 5
   "Amount of time in seconds to display the method signature
@@ -171,10 +171,10 @@ be an interactive function that can be called by
 `call-interactively'."
   :group 'jdee-project
   :type '(choice
-	   (function-item jdee-complete-menu)
-	   (function-item jdee-complete-minibuf)
-	   (function-item jdee-complete-in-line)
-	   (function :format "%t %v" :tag "Custom:")))
+           (function-item jdee-complete-menu)
+           (function-item jdee-complete-minibuf)
+           (function-item jdee-complete-in-line)
+           (function :format "%t %v" :tag "Custom:")))
 
 (defvar jdee-complete-current-list nil
   "The list of all the completion. Each element of the list is a list
@@ -191,10 +191,10 @@ for the VARNAME variable."
   (save-excursion
     (goto-char point)
     (if (looking-at
-	 (concat "\\([A-Za-z0-9_.\177-\377]+\\)[ \t\n\r]+"
-		 (jdee-complete-double-backquotes varname)
-		 "[ \t\n\r]*[;=]"))
-	(match-string 1)
+         (concat "\\([A-Za-z0-9_.\177-\377]+\\)[ \t\n\r]+"
+                 (jdee-complete-double-backquotes varname)
+                 "[ \t\n\r]*[;=]"))
+        (match-string 1)
       nil)))
 
 (defun jdee-complete-double-backquotes (varname)
@@ -204,8 +204,8 @@ for the VARNAME variable."
     (while (< idx len)
       (setq curcar (elt varname idx))
       (setq result (concat result (if (eq curcar ?\\)
-				      "\\\\"
-				    (make-string 1 curcar))))
+                                      "\\\\"
+                                    (make-string 1 curcar))))
       (setq idx (1+ idx)))
     result))
 
@@ -217,15 +217,15 @@ name, it just returns the type as it is declared."
   (save-excursion
     (let (found res pos orgpt resname)
       (while (and (not found)
-		  (search-backward name nil t))
-	(setq pos (point))
-	(backward-word 1)
-	(setq resname (jdee-complete-valid-java-declaration-at (point) name))
-	(goto-char pos)
-	(forward-char -1)
-	(if resname
-	    (progn (setq res resname)
-		   (setq found t))))
+                  (search-backward name nil t))
+        (setq pos (point))
+        (backward-word 1)
+        (setq resname (jdee-complete-valid-java-declaration-at (point) name))
+        (goto-char pos)
+        (forward-char -1)
+        (if resname
+            (progn (setq res resname)
+                   (setq found t))))
       res)))
 
 (defun jdee-complete-filter-fqn (importlist)
@@ -235,8 +235,8 @@ so that it can stops at the first package import (with a star `*' at
 the end of the declaration)."
   (if importlist
       (if (string= "*" (car (cdr (car importlist))))
-	  importlist
-	(jdee-complete-filter-fqn (cdr importlist)))))
+          importlist
+        (jdee-complete-filter-fqn (cdr importlist)))))
 
 (defun jdee-complete-guess-type-of (name)
   "Guess the fully qualified name of the class NAME, using the import
@@ -249,11 +249,11 @@ packages otherwise."
       (setq fullname (concat (car tmp) name))
       (cond
        ((string= "*" shortname)
-	(setq result importlist))
+        (setq result importlist))
        ((string= name shortname)
-	(setq result fullname))
+        (setq result fullname))
        (t
-	(setq importlist (cdr importlist)))))
+        (setq importlist (cdr importlist)))))
     result))
 
 
@@ -270,18 +270,18 @@ packages otherwise."
 (defun jdee-complete-flush-classes-in-cache (class-list)
   "Flushes all the classes in CLASS-LIST as entries of cache."
   (let ((temp (nth 0 jdee-complete-classinfo-cache))
-	(index -1)
-	(found nil)
-	(class (car class-list)))
+        (index -1)
+        (found nil)
+        (class (car class-list)))
     (while class
       (while (and temp (not found))
-	(setq index (1+ index))
-	(setq temp (nth index jdee-complete-classinfo-cache))
-	(if (string= (car temp) class)
-	    (setq found t)))
+        (setq index (1+ index))
+        (setq temp (nth index jdee-complete-classinfo-cache))
+        (if (string= (car temp) class)
+            (setq found t)))
       (if found
-	  (setq jdee-complete-classinfo-cache
-		(nthcdr (1+ index) jdee-complete-classinfo-cache)))
+          (setq jdee-complete-classinfo-cache
+                (nthcdr (1+ index) jdee-complete-classinfo-cache)))
       (setq class-list (cdr class-list))
       (setq class (car class-list))
       (setq found nil))))
@@ -289,17 +289,17 @@ packages otherwise."
 (defun jdee-complete-add-to-classinfo-cache (name classinfo)
   (let (new-entry new-list)
     (if (nth jdee-complete-classinfo-cache-size jdee-complete-classinfo-cache)
-	(progn
-	  (setq new-entry (list name classinfo))
-	  (setq new-list (list new-entry nil))
-	  (setcdr new-list (cdr jdee-complete-classinfo-cache))
-	  (setq jdee-complete-classinfo-cache new-list)
-	  (message "cache is full"))
+        (progn
+          (setq new-entry (list name classinfo))
+          (setq new-list (list new-entry nil))
+          (setcdr new-list (cdr jdee-complete-classinfo-cache))
+          (setq jdee-complete-classinfo-cache new-list)
+          (message "cache is full"))
       ;;else
       (setq jdee-complete-classinfo-cache
-	    (append
-	     jdee-complete-classinfo-cache
-	     (list (list name classinfo)))))))
+            (append
+             jdee-complete-classinfo-cache
+             (list (list name classinfo)))))))
 
 (defun jdee-complete-get-from-cache (name)
   (let ((temp (nth 0 jdee-complete-classinfo-cache)) (index -1) (found nil))
@@ -307,9 +307,9 @@ packages otherwise."
       (setq index (1+ index))
       (setq temp (nth index jdee-complete-classinfo-cache))
       (if (string= (car temp) name)
-	  (setq found t)))
+          (setq found t)))
     (if found
-	(nth 1 temp)
+        (nth 1 temp)
       nil)))
 
 (defun jdee-complete-get-classinfo (name &optional access-level)
@@ -334,38 +334,38 @@ informations on the completion."
       (setq access-level jdee-complete-public))
 
   (let ((class-info (jdee-complete-get-from-cache name))
-	public-methods protected-methods private-methods
-	package-methods)
+        public-methods protected-methods private-methods
+        package-methods)
     (when (not class-info)
       ;;Getting public class info
       (setq public-methods
-	    (jdee-complete-invoke-get-class-info
-	     name jdee-complete-public))
+            (jdee-complete-invoke-get-class-info
+             name jdee-complete-public))
 
       ;;Getting protected class info
       (setq protected-methods
-	    (jdee-complete-invoke-get-class-info
-	     name jdee-complete-protected))
+            (jdee-complete-invoke-get-class-info
+             name jdee-complete-protected))
 
       ;;Getting package class info
       (setq package-methods
-	    (jdee-complete-invoke-get-class-info
-	     name jdee-complete-package))
+            (jdee-complete-invoke-get-class-info
+             name jdee-complete-package))
 
       ;;Getting private class info
       (setq private-methods
-	    (jdee-complete-invoke-get-class-info
-	     name jdee-complete-private))
+            (jdee-complete-invoke-get-class-info
+             name jdee-complete-private))
       (setq class-info (append public-methods
-			       protected-methods
-			       package-methods
-			       private-methods))
+                               protected-methods
+                               package-methods
+                               private-methods))
       (if class-info
-	  (jdee-complete-add-to-classinfo-cache name class-info)))
+          (jdee-complete-add-to-classinfo-cache name class-info)))
 
     ;;Getting the class info depending on the access level
     (setq class-info
-	  (jdee-complete-get-accessible-info class-info access-level name))
+          (jdee-complete-get-accessible-info class-info access-level name))
     (setq class-info (jdee-complete-build-completion-list class-info))
 
     ;;Removing duplicates
@@ -381,7 +381,7 @@ informations on the completion."
     (while class-list
       (setq temp (car class-list))
        (if (not (jdee-complete-memberp (car temp) answer))
-	   (setq answer (append answer (list temp))))
+           (setq answer (append answer (list temp))))
       (setq class-list (cdr class-list)))
     answer))
 
@@ -391,10 +391,10 @@ informations on the completion."
     (while lst
       (setq tmp (caar lst))
       (if (string= tmp elt)
-	  (progn
-	   (setq answer t)
-	   (setq lst nil))
-	(setq lst (cdr lst))))
+          (progn
+           (setq answer t)
+           (setq lst nil))
+        (setq lst (cdr lst))))
     answer))
 
 (defun jdee-complete-get-accessible-info (class-info access name)
@@ -405,50 +405,50 @@ info\)\).  Each info list is in the format \(list \(list fields\)
 method will return a list concatenating the fields, methods, and inner
 classes for the access level."
   (let* ((public (nth jdee-complete-public class-info))
-	(protected (nth jdee-complete-protected class-info))
-	(package (nth jdee-complete-package class-info))
-	(private (nth jdee-complete-private class-info))
-	(package-name (jdee-parse-get-package-name))
-	(this (concat (if package-name
-			  (concat package-name "." ))
-		      (jdee-parse-get-class-at-point)))
-	answer fields constructors methods classes packagep)
+        (protected (nth jdee-complete-protected class-info))
+        (package (nth jdee-complete-package class-info))
+        (private (nth jdee-complete-private class-info))
+        (package-name (jdee-parse-get-package-name))
+        (this (concat (if package-name
+                          (concat package-name "." ))
+                      (jdee-parse-get-class-at-point)))
+        answer fields constructors methods classes packagep)
     (if (null package-name)
-	(setq package-name ""))
+        (setq package-name ""))
     (if package-name
-	(setq packagep (string-match package-name name)))
+        (setq packagep (string-match package-name name)))
     (setq fields (append (nth jdee-complete-fields public)
-			 (if (>= access jdee-complete-protected)
-			     (nth jdee-complete-fields protected))
-			 (if packagep
-			     (nth jdee-complete-fields package))
-			 (if (or (>= access jdee-complete-private)
-				 (string= name this))
-			     (nth jdee-complete-fields private))))
+                         (if (>= access jdee-complete-protected)
+                             (nth jdee-complete-fields protected))
+                         (if packagep
+                             (nth jdee-complete-fields package))
+                         (if (or (>= access jdee-complete-private)
+                                 (string= name this))
+                             (nth jdee-complete-fields private))))
     (setq constructors (append (nth jdee-complete-constructors public)
-			       (if (>= access jdee-complete-protected)
-				   (nth jdee-complete-constructors protected))
-			       (if packagep
-				   (nth jdee-complete-constructors package))
-			       (if (or (>= access jdee-complete-private)
-				       (string= name this))
-				   (nth jdee-complete-constructors private))))
+                               (if (>= access jdee-complete-protected)
+                                   (nth jdee-complete-constructors protected))
+                               (if packagep
+                                   (nth jdee-complete-constructors package))
+                               (if (or (>= access jdee-complete-private)
+                                       (string= name this))
+                                   (nth jdee-complete-constructors private))))
     (setq methods (append (nth jdee-complete-methods public)
-			  (if (>= access jdee-complete-protected)
-			      (nth jdee-complete-methods protected))
-			  (if packagep
-			      (nth jdee-complete-methods package))
-			  (if (or (>= access jdee-complete-private)
-				  (string= name this))
-			      (nth jdee-complete-methods private))))
+                          (if (>= access jdee-complete-protected)
+                              (nth jdee-complete-methods protected))
+                          (if packagep
+                              (nth jdee-complete-methods package))
+                          (if (or (>= access jdee-complete-private)
+                                  (string= name this))
+                              (nth jdee-complete-methods private))))
     (setq classes (append (nth jdee-complete-classes public)
-			  (if (>= access jdee-complete-protected)
-			     (nth jdee-complete-classes protected))
-			  (if packagep
-			      (nth jdee-complete-classes package))
-			  (if (or (>= access jdee-complete-private)
-				  (string= name this))
-			      (nth jdee-complete-classes private))))
+                          (if (>= access jdee-complete-protected)
+                             (nth jdee-complete-classes protected))
+                          (if packagep
+                              (nth jdee-complete-classes package))
+                          (if (or (>= access jdee-complete-private)
+                                  (string= name this))
+                              (nth jdee-complete-classes private))))
     (setq answer (list fields constructors methods classes))
     answer))
 
@@ -464,33 +464,33 @@ classes for the access level."
 into (\"var\" \"java.lang.String\ var\")"
   (let (result current prev)
     (if (null jdee-complete-unique-method-names)
-	(while variables
-	  (setq current (car (car variables)))
-	  (setq result
-		(append
-		 (list (cons (concat current
-				     (if jdee-complete-display-result-type
-					 (concat
-					  " : "
-					  (jdee-complete-maybe-unqualify
-					   (nth 1 (car variables))))))
-			     current))
-		 result))
-	  (setq variables (cdr variables)))
+        (while variables
+          (setq current (car (car variables)))
+          (setq result
+                (append
+                 (list (cons (concat current
+                                     (if jdee-complete-display-result-type
+                                         (concat
+                                          " : "
+                                          (jdee-complete-maybe-unqualify
+                                           (nth 1 (car variables))))))
+                             current))
+                 result))
+          (setq variables (cdr variables)))
       (while variables
-	(if (not (string= prev current))
-	    (progn
-	      (setq prev current)
-	      (setq result
-		    (append
-		     (list (cons (concat current
-					 (if jdee-complete-display-result-type
-					     (concat " : "
-						     (jdee-complete-maybe-unqualify
-						      (nth 1 (car variables))))))
-				 current))
-		     result))))
-	(setq variables (cdr variables))))
+        (if (not (string= prev current))
+            (progn
+              (setq prev current)
+              (setq result
+                    (append
+                     (list (cons (concat current
+                                         (if jdee-complete-display-result-type
+                                             (concat " : "
+                                                     (jdee-complete-maybe-unqualify
+                                                      (nth 1 (car variables))))))
+                                 current))
+                     result))))
+        (setq variables (cdr variables))))
     result))
 
 (defun jdee-complete-build-completion-list (classinfo)
@@ -503,7 +503,7 @@ jdee-backend-get-class-info function."
 
     ;;get the constructors
     (setq tmp (jdee-complete-get-methods
-	       (nth jdee-complete-constructors classinfo) t))
+               (nth jdee-complete-constructors classinfo) t))
     (if tmp (setq result (append tmp result)))
 
     ;; get the methods
@@ -512,41 +512,41 @@ jdee-backend-get-class-info function."
 
     ;; get inner classes
     (setq tmp (jdee-complete-get-inner-classes
-	       (nth jdee-complete-classes classinfo)))
+               (nth jdee-complete-classes classinfo)))
     (if tmp (setq result (append tmp result)))
 
     result))
 
 (defun jdee-complete-get-methods (classinfo &optional constructor)
   (let ((end-paren (if (null jdee-complete-add-space-after-method) "(" " ("))
-	(end-parens (if (null jdee-complete-insert-method-signature)
-			(if (null jdee-complete-add-space-after-method)
-			    "()"
-			  " ()") ""))
-	prev tmp current)
+        (end-parens (if (null jdee-complete-insert-method-signature)
+                        (if (null jdee-complete-add-space-after-method)
+                            "()"
+                          " ()") ""))
+        prev tmp current)
     (while classinfo
       (let* ((type (car (cdr (car classinfo))));;method type i.e. boolean
-	     (exceptions (jdee-get-exceptions (car (last (car classinfo)))))
-	     (method (jdee-complete-build-information-for-completion
-		      (car classinfo) end-paren))
-	     (display (jdee-complete-build-display-for-completion
-		      (car classinfo) end-paren constructor)))
-	(setq current (jdee-parse-get-unqualified-name (car (car classinfo))))
-	(if (not (and jdee-complete-unique-method-names
-		      (string= prev current)))
-	    (progn
-	      (setq prev current)
-	      (setq tmp (append
-			 (list
-			  (cons
-			   display
-			   (concat
-			    (if (null jdee-complete-insert-method-signature)
-				current
-			      method)
-			    end-parens)))
-			 tmp))))
-	(setq classinfo (cdr classinfo))))
+             (exceptions (jdee-get-exceptions (car (last (car classinfo)))))
+             (method (jdee-complete-build-information-for-completion
+                      (car classinfo) end-paren))
+             (display (jdee-complete-build-display-for-completion
+                      (car classinfo) end-paren constructor)))
+        (setq current (jdee-parse-get-unqualified-name (car (car classinfo))))
+        (if (not (and jdee-complete-unique-method-names
+                      (string= prev current)))
+            (progn
+              (setq prev current)
+              (setq tmp (append
+                         (list
+                          (cons
+                           display
+                           (concat
+                            (if (null jdee-complete-insert-method-signature)
+                                current
+                              method)
+                            end-parens)))
+                         tmp))))
+        (setq classinfo (cdr classinfo))))
     tmp))
 
 (defun jdee-complete-get-inner-classes(class-info)
@@ -554,16 +554,16 @@ jdee-backend-get-class-info function."
 them or nil"
   (let (tmp fullname pos name)
     (if class-info
-	(while class-info
-	  (let* ((fullname (caar class-info))
-		 (pos (string-match "\\$" fullname))
-		 (name (substring fullname (+ 1 pos))))
-	    (setq tmp
-		  (append
-		   (list (cons (concat name " : " fullname)
-			       name))
-		   tmp)))
-	  (setq class-info (cdr class-info))))
+        (while class-info
+          (let* ((fullname (caar class-info))
+                 (pos (string-match "\\$" fullname))
+                 (name (substring fullname (+ 1 pos))))
+            (setq tmp
+                  (append
+                   (list (cons (concat name " : " fullname)
+                               name))
+                   tmp)))
+          (setq class-info (cdr class-info))))
     tmp))
 
 (defun jdee-get-exceptions (exceptions)
@@ -571,11 +571,11 @@ them or nil"
 or nil"
   (if (and (listp exceptions) (car exceptions))
       (let ((exs ""))
-	(while exceptions
-	  (setq exs (concat exs (car exceptions)))
-	  (setq exceptions (cdr exceptions))
-	  (if exceptions (setq exs (concat exs ", "))))
-	exs)
+        (while exceptions
+          (setq exs (concat exs (car exceptions)))
+          (setq exceptions (cdr exceptions))
+          (if exceptions (setq exs (concat exs ", "))))
+        exs)
     nil))
 
 (defun jdee-complete-maybe-unqualify (type)
@@ -584,53 +584,53 @@ or nil"
     (jdee-parse-get-unqualified-name type)))
 
 (defun jdee-complete-build-display-for-completion (lst
-						  end-parens
-						  &optional constructor)
+                                                  end-parens
+                                                  &optional constructor)
   "Builds the string that describes a method in a menu for selecting a completion."
   (let ((result (concat
-		 (jdee-parse-get-unqualified-name (car lst))
-		 end-parens))
-	(rettype (car (cdr lst)))
-	(exceptions (if (and (listp (last lst)) (car (last lst)))
-			(car (last lst)))))
+                 (jdee-parse-get-unqualified-name (car lst))
+                 end-parens))
+        (rettype (car (cdr lst)))
+        (exceptions (if (and (listp (last lst)) (car (last lst)))
+                        (car (last lst)))))
     (if constructor
-	(setq lst (cdr lst))
+        (setq lst (cdr lst))
       (setq lst (cdr (cdr lst))))
     (while (and lst
-		(not (listp (car lst))))
+                (not (listp (car lst))))
       (setq result (concat result (jdee-complete-maybe-unqualify (car lst))))
       (setq lst (cdr lst))
       (if (and lst
-	       (not (listp (car lst))))
-	  (setq result (concat result ", "))))
+               (not (listp (car lst))))
+          (setq result (concat result ", "))))
     (setq result (concat result ")"))
     (concat result
-	    (if (or (and (not constructor) rettype jdee-complete-display-result-type)
-		    (and exceptions jdee-complete-display-throws)) " : ")
-	    (if (and (not constructor) rettype jdee-complete-display-result-type)
-		(jdee-complete-maybe-unqualify rettype))
-	    (if (and exceptions jdee-complete-display-throws)
-		(concat " throws "
-			(jdee-get-exceptions
-			 (mapcar 'jdee-complete-maybe-unqualify exceptions)))))))
+            (if (or (and (not constructor) rettype jdee-complete-display-result-type)
+                    (and exceptions jdee-complete-display-throws)) " : ")
+            (if (and (not constructor) rettype jdee-complete-display-result-type)
+                (jdee-complete-maybe-unqualify rettype))
+            (if (and exceptions jdee-complete-display-throws)
+                (concat " throws "
+                        (jdee-get-exceptions
+                         (mapcar 'jdee-complete-maybe-unqualify exceptions)))))))
 
 (defun jdee-complete-build-information-for-completion (lst
-						      end-parens
-						      &optional constructor)
+                                                      end-parens
+                                                      &optional constructor)
   "Builds the text that is inserted in the code for a particular completion."
   (let ((result (concat
-		 (jdee-parse-get-unqualified-name (car lst))
-		 end-parens)))
+                 (jdee-parse-get-unqualified-name (car lst))
+                 end-parens)))
     (if constructor
-	(setq lst (cdr lst))
+        (setq lst (cdr lst))
       (setq lst (cdr (cdr lst))))
     (while (and lst
-		(not (listp (car lst))))
+                (not (listp (car lst))))
       (setq result (concat result (car lst)))
       (setq lst (cdr lst))
       (if (and lst
-	       (not (listp (car lst))))
-	  (setq result (concat result ", "))))
+               (not (listp (car lst))))
+          (setq result (concat result ", "))))
     (setq result (concat result ")"))
     result))
 
@@ -639,20 +639,20 @@ or nil"
  (let (elem tmp)
     (setq jdee-complete-current-list-index (1+ jdee-complete-current-list-index))
     (if (>= jdee-complete-current-list-index (length jdee-complete-current-list))
-	(setq jdee-complete-current-list-index 0))
+        (setq jdee-complete-current-list-index 0))
     (setq elem (nth jdee-complete-current-list-index jdee-complete-current-list))
     (setq tmp (cdr elem))
     (if tmp
-	(progn
-	  (delete-region jdee-parse-current-beginning
-			 jdee-parse-current-end)
-	  (insert tmp)
-	  (setq jdee-complete-current-signature (car elem))
-	  (jdee-complete-place-cursor)
-	  (set-marker jdee-parse-current-end
-		      (+ (marker-position jdee-parse-current-beginning)
-			 (length tmp)))
-	  (jdee-complete-display-current-signature));;displaying the signature
+        (progn
+          (delete-region jdee-parse-current-beginning
+                         jdee-parse-current-end)
+          (insert tmp)
+          (setq jdee-complete-current-signature (car elem))
+          (jdee-complete-place-cursor)
+          (set-marker jdee-parse-current-end
+                      (+ (marker-position jdee-parse-current-beginning)
+                         (length tmp)))
+          (jdee-complete-display-current-signature));;displaying the signature
       (message (format "No completion at this point!(cycle)")))
     ;;  (goto-char (marker-position jdee-complete-current-end))
     ))
@@ -660,38 +660,38 @@ or nil"
 (defun jdee-complete-insert-completion (item)
   (if item
       (progn
-	(delete-region jdee-parse-current-beginning
-		       jdee-parse-current-end)
-	(insert item)
-	(jdee-complete-place-cursor)
-	(jdee-complete-display-current-signature)
-	(set-marker jdee-parse-current-end
-		    (+ (marker-position jdee-parse-current-beginning)
-		       (length item))))))
+        (delete-region jdee-parse-current-beginning
+                       jdee-parse-current-end)
+        (insert item)
+        (jdee-complete-place-cursor)
+        (jdee-complete-display-current-signature)
+        (set-marker jdee-parse-current-end
+                    (+ (marker-position jdee-parse-current-beginning)
+                       (length item))))))
 
 (defun jdee-complete-find-all-completions (pair lst &optional exact-match)
   (let* (tmp
-	 chop-pos
-	 (args (nth 2 pair))
-	 (pat (nth 1 pair))
-	 (result nil)
-	 (first-char (substring pat 0 1)))
+         chop-pos
+         (args (nth 2 pair))
+         (pat (nth 1 pair))
+         (result nil)
+         (first-char (substring pat 0 1)))
 
     (if (null args)
-	(setq exact-match nil)
+        (setq exact-match nil)
       (setq pat (concat pat args)))
 
     (if (string= pat "$")
-	(setq pat "\\$"))
+        (setq pat "\\$"))
 
     (while lst
       (setq tmp (car (car lst)))
       (setq chop-pos (string-match " : " tmp))
       (setq tmp (substring tmp 0 chop-pos))
       (if (if exact-match
-	      (string= pat tmp)
-	    (equal 0 (string-match pat tmp)))
-	  (setq result (append result (list (car lst)))))
+              (string= pat tmp)
+            (equal 0 (string-match pat tmp)))
+          (setq result (append result (list (car lst)))))
       (setq lst (cdr lst)))
     result))
 
@@ -703,34 +703,34 @@ ACCESS-LEVEL is one of: `jdee-complete-private'
 completions from beanshell."
   (let ((type (jdee-parse-eval-type-of (car pair))))
     (if type
-	(cond
-	 ((member type jdee-parse-primitive-types)
-	  (error "Cannot complete primitive type: %s" type))
+        (cond
+         ((member type jdee-parse-primitive-types)
+          (error "Cannot complete primitive type: %s" type))
 
-	 ((string= type "void")
-	  (error "Cannot complete return type of %s is void." (car pair)))
+         ((string= type "void")
+          (error "Cannot complete return type of %s is void." (car pair)))
 
-	 (access-level
-	  (let ((classinfo (jdee-complete-get-classinfo type access-level)))
-	    ;; FIXME: when is classinfo nil?
-	    (when classinfo
-	      (if (and (string= (nth 1 pair) "")
-		       (not exact-completion))
-		  (setq jdee-complete-current-list classinfo)
-		(setq jdee-complete-current-list
-		      (jdee-complete-find-all-completions
-		       pair classinfo exact-completion))))))
+         (access-level
+          (let ((classinfo (jdee-complete-get-classinfo type access-level)))
+            ;; FIXME: when is classinfo nil?
+            (when classinfo
+              (if (and (string= (nth 1 pair) "")
+                       (not exact-completion))
+                  (setq jdee-complete-current-list classinfo)
+                (setq jdee-complete-current-list
+                      (jdee-complete-find-all-completions
+                       pair classinfo exact-completion))))))
 
-	 (t
-	  (let ((classinfo (jdee-complete-get-classinfo type)))
-	    ;; FIXME: when is classinfo nil?
-	    (when classinfo
-	      (if (and (string= (nth 1 pair) "")
-		       (not exact-completion))
-		  (setq jdee-complete-current-list classinfo)
-		(setq jdee-complete-current-list
-		      (jdee-complete-find-all-completions
-		       pair classinfo exact-completion)))))))
+         (t
+          (let ((classinfo (jdee-complete-get-classinfo type)))
+            ;; FIXME: when is classinfo nil?
+            (when classinfo
+              (if (and (string= (nth 1 pair) "")
+                       (not exact-completion))
+                  (setq jdee-complete-current-list classinfo)
+                (setq jdee-complete-current-list
+                      (jdee-complete-find-all-completions
+                       pair classinfo exact-completion)))))))
 
       ;; type is nil
       nil)))
@@ -774,25 +774,25 @@ before invoking the completion"
   (let (index-alist pair name)
     (setq index-alist jdee-complete-current-list)
     (setq pair
-	  (if (= (length index-alist) 1)
-	      ;; if only one item match, return it
-	      (car index-alist)
-	    (if use-menu
-		(progn
-		  ;; delegates menu handling to imenu :-)
-		  (require 'imenu)
-		  (imenu--mouse-menu
-		   index-alist
-		   ;; Popup window at text cursor
-		   (jdee-cursor-posn-as-event)
-		   (or title "Completion")))
-	      ;; not menu
-	      (assoc (completing-read (or title "Completion: ")
-				      index-alist
-				      nil ;;predicate
-				      nil ;;required-match
-				      initial-input) ;;initial-input
-				      index-alist))))
+          (if (= (length index-alist) 1)
+              ;; if only one item match, return it
+              (car index-alist)
+            (if use-menu
+                (progn
+                  ;; delegates menu handling to imenu :-)
+                  (require 'imenu)
+                  (imenu--mouse-menu
+                   index-alist
+                   ;; Popup window at text cursor
+                   (jdee-cursor-posn-as-event)
+                   (or title "Completion")))
+              ;; not menu
+              (assoc (completing-read (or title "Completion: ")
+                                      index-alist
+                                      nil ;;predicate
+                                      nil ;;required-match
+                                      initial-input) ;;initial-input
+                                      index-alist))))
     (setq name (cdr pair))
     (setq jdee-complete-current-signature (car pair))
     (jdee-complete-insert-completion name)))
@@ -842,48 +842,48 @@ t   - show completion list in a menu
 
 string -  show completions in-line, cycling thru them."
   (let* ((pair (jdee-parse-java-variable-at-point))
-	 jdee-parse-attempted-to-import)
+         jdee-parse-attempted-to-import)
 
     ;; pair is (prefix  partial-identifier)
     (setq jdee-complete-current-list nil)
     (if pair
-	(condition-case err
-	    (jdee-complete-pair (jdee-complete-get-pair pair nil) completion-type)
-	  (error
-	   (condition-case err
-	       (jdee-complete-pair (jdee-complete-get-pair pair t) completion-type))
-	   (error (message "%s" (error-message-string err)))))
+        (condition-case err
+            (jdee-complete-pair (jdee-complete-get-pair pair nil) completion-type)
+          (error
+           (condition-case err
+               (jdee-complete-pair (jdee-complete-get-pair pair t) completion-type))
+           (error (message "%s" (error-message-string err)))))
 
       (message "No completion at this point"))))
 
 (defun jdee-complete-pair (pair completion-type)
   "PAIR is (PREFIX PARTIAL). COMPLETION-TYPE is as for `jdee-complete-generic'."
   (let ((completion-list
-	 (jdee-complete-find-completion-for-pair pair nil (jdee-complete-get-access pair))))
+         (jdee-complete-find-completion-for-pair pair nil (jdee-complete-get-access pair))))
 
     (if (null completion-list)
-	;; Check if PREFIX is in the current class
-	(setq completion-list
-	      (jdee-complete-find-completion-for-pair
-	       (list (concat "this." (car pair)) "")
-	       nil jdee-complete-private)))
+        ;; Check if PREFIX is in the current class
+        (setq completion-list
+              (jdee-complete-find-completion-for-pair
+               (list (concat "this." (car pair)) "")
+               nil jdee-complete-private)))
     ;;if completions is still null check if the method is in the
     ;;super class
     (if (null completion-list)
-	(setq completion-list (jdee-complete-find-completion-for-pair
-			       (list (concat "super." (car pair)) "")
-			       nil jdee-complete-protected)))
+        (setq completion-list (jdee-complete-find-completion-for-pair
+                               (list (concat "super." (car pair)) "")
+                               nil jdee-complete-protected)))
 
     (if completion-list
-	(let ((title (concat (car pair) "."
-			     (car (cdr pair)) "[...]")))
-	  (if (null completion-type)
-	      (jdee-complete-choose-completion title (car (cdr pair)))
-	    (if (string= completion-type "in-line")
-		(progn
-		  (setq jdee-complete-current-list-index -1)
-		  (jdee-complete-complete-cycle))
-	      (jdee-complete-choose-completion title (car (cdr pair)) t))))
+        (let ((title (concat (car pair) "."
+                             (car (cdr pair)) "[...]")))
+          (if (null completion-type)
+              (jdee-complete-choose-completion title (car (cdr pair)))
+            (if (string= completion-type "in-line")
+                (progn
+                  (setq jdee-complete-current-list-index -1)
+                  (jdee-complete-complete-cycle))
+              (jdee-complete-choose-completion title (car (cdr pair)) t))))
       (error "No completion at this point"))))
 
 (defun jdee-complete-get-access (pair)
@@ -892,9 +892,9 @@ string -  show completions in-line, cycling thru them."
 `jdee-complete-protected'. Otherwise return nil."
   (let (access)
     (if (string= (car pair) "this")
-	(setq access jdee-complete-private)
+        (setq access jdee-complete-private)
       (if (string= (car pair) "super")
-	  (setq access jdee-complete-protected)))
+          (setq access jdee-complete-protected)))
     access))
 
 (defun jdee-complete-get-pair (pair op)
@@ -905,14 +905,14 @@ if OP is non-nil, return (PARTIAL PARTIAL)."
 
   (let ((tmp (list (car pair) (cadr pair))));; copy of PAIR
     (if (and op
-	     (string= (car tmp) "" )
-	     (not (string= (cadr tmp) "")))
-	(setcar tmp (cadr tmp)))
+             (string= (car tmp) "" )
+             (not (string= (cadr tmp) "")))
+        (setcar tmp (cadr tmp)))
 
     (if (string= (car tmp) "" )
-	;; PREFIX and PARTIAL both nil
-	;; FIXME: can we get here?
-	(setcar tmp "this"))
+        ;; PREFIX and PARTIAL both nil
+        ;; FIXME: can we get here?
+        (setcar tmp "this"))
     tmp))
 
 (defun jdee-complete ()
@@ -937,12 +937,12 @@ inside the buffer and replace it with message. Message should not be
 longer than a line."
   (interactive)
   (let* ((popup (get-buffer-window buffer-or-name));;last popup window
-	 (new (get-buffer-create buffer-or-name));;new popup window
-	 (current (current-buffer));;current buffer
-	 (min window-min-height);;current window-min-height
-	 (w (selected-window));;selected window
-	 (height (window-height w));;window height
-	 w2)
+         (new (get-buffer-create buffer-or-name));;new popup window
+         (current (current-buffer));;current buffer
+         (min window-min-height);;current window-min-height
+         (w (selected-window));;selected window
+         (height (window-height w));;window height
+         w2)
     (if popup (delete-window popup));;deleting previous windows
     (set-window-buffer w new);;set buffer of current window to be the new
     (erase-buffer)
@@ -951,10 +951,10 @@ longer than a line."
     (setq w2 (split-window w (- height 2)));;split windows
     (set-window-buffer w current);;restore the buffer in the current window
     (if (> (window-height w2) 2);;if the popup window is larger than 2
-	(enlarge-window (- (window-height w2) 2)));;resize it to 2
+        (enlarge-window (- (window-height w2) 2)));;resize it to 2
     (setq window-min-height min);; restore window-min-height
     (run-at-time jdee-complete-signature-display-time
-		 nil 'delete-window w2)));;set timer to delete popup window
+                 nil 'delete-window w2)));;set timer to delete popup window
 
 (defun jdee-complete-display-current-signature()
   "Displays the current signature: `jdee-complete-current-signature'. The
@@ -962,27 +962,27 @@ display mode will depend on the variable `jdee-complete-signature-display'"
   (interactive)
   (if jdee-complete-current-signature
       (let ((display (car jdee-complete-signature-display)))
-	(cond ((string= display "Eldoc") ;;eldoc
-	       (setq jdee-complete-display-signature t)
-	       (run-at-time jdee-complete-signature-display-time
-			    nil `set-variable
-			    `jdee-complete-display-signature nil)
-	       (eldoc-message jdee-complete-current-signature))
-	      ;;use buffer
-	      ((string= display "Buffer")
-	       (jdee-complete-popup-message jdee-complete-current-signature
-					   jdee-complete-signature-buffer))
-	      (t));; do nothing
-	)))
+        (cond ((string= display "Eldoc") ;;eldoc
+               (setq jdee-complete-display-signature t)
+               (run-at-time jdee-complete-signature-display-time
+                            nil `set-variable
+                            `jdee-complete-display-signature nil)
+               (eldoc-message jdee-complete-current-signature))
+              ;;use buffer
+              ((string= display "Buffer")
+               (jdee-complete-popup-message jdee-complete-current-signature
+                                           jdee-complete-signature-buffer))
+              (t));; do nothing
+        )))
 
 (defun jdee-complete-place-cursor ()
   "Places the cursor in between the parenthesis after a
 completion. This is only done for methods that contain parameters, for
 all the other completions the cursor is place at the end."
   (let ((end-paren (string-match ")" jdee-complete-current-signature))
-	(start-paren (string-match "(" jdee-complete-current-signature)))
+        (start-paren (string-match "(" jdee-complete-current-signature)))
     (if (and end-paren start-paren (not (= start-paren (- end-paren 1))))
-	(goto-char (- (point) 1)))))
+        (goto-char (- (point) 1)))))
 
 (provide 'jdee-complete)
 

--- a/jdee-custom.el
+++ b/jdee-custom.el
@@ -46,8 +46,8 @@ restoring it to the state of a variable that has never been customized."
   '(("Save in JDEE Project File" jdee-custom-variable-set
      (lambda (widget)
        (and
-	(eq (widget-get widget :custom-state) 'modified)
-	(string-match "^jdee-" (symbol-name (widget-value widget))))))
+        (eq (widget-get widget :custom-state) 'modified)
+        (string-match "^jdee-" (symbol-name (widget-value widget))))))
     ("Set for Current Session" custom-variable-set
      (lambda (widget)
        (eq (widget-get widget :custom-state) 'modified)))
@@ -57,18 +57,18 @@ restoring it to the state of a variable that has never been customized."
     ("Reset to Current" custom-redraw
      (lambda (widget)
        (and (default-boundp (widget-value widget))
-	    (memq (widget-get widget :custom-state) '(modified changed)))))
+            (memq (widget-get widget :custom-state) '(modified changed)))))
     ("Reset to Saved" custom-variable-reset-saved
      (lambda (widget)
        (and (or (get (widget-value widget) 'saved-value)
-		(get (widget-value widget) 'saved-variable-comment))
-	    (memq (widget-get widget :custom-state)
-		  '(modified set changed rogue)))))
+                (get (widget-value widget) 'saved-variable-comment))
+            (memq (widget-get widget :custom-state)
+                  '(modified set changed rogue)))))
     ("Erase Customization" jdee-custom-variable-reset-standard
      (lambda (widget)
        (and (get (widget-value widget) 'standard-value)
-	    (memq (widget-get widget :custom-state)
-		  '(modified set changed saved rogue)))))
+            (memq (widget-get widget :custom-state)
+                  '(modified set changed saved rogue)))))
     ("---" ignore ignore)
     ("Add Comment" custom-comment-show custom-comment-invisible-p)
     ("---" ignore ignore)
@@ -95,14 +95,14 @@ Optional EVENT is the location for the menu."
       (custom-variable-state-set widget))
     (custom-redraw-magic widget)
     (let* ((completion-ignore-case t)
-	   (answer (widget-choose (concat "Operation on "
-					  (custom-unlispify-tag-name
-					   (widget-get widget :value)))
-				  (custom-menu-filter jdee-custom-variable-menu
-						      widget)
-				  event)))
+           (answer (widget-choose (concat "Operation on "
+                                          (custom-unlispify-tag-name
+                                           (widget-get widget :value)))
+                                  (custom-menu-filter jdee-custom-variable-menu
+                                                      widget)
+                                  event)))
       (if answer
-	  (funcall answer widget)))))
+          (funcall answer widget)))))
 
 
 (define-widget 'jdee-custom-variable 'custom
@@ -132,18 +132,18 @@ Optional EVENT is the location for the menu."
   (unless (get symbol 'custom-type)
     (error "Variable %s cannot be customized" symbol))
   (custom-buffer-create (list (list symbol 'jdee-custom-variable))
-			(format "*Customize Option: %s*"
-				(custom-unlispify-tag-name symbol))))
+                        (format "*Customize Option: %s*"
+                                (custom-unlispify-tag-name symbol))))
 
 
 (defun jdee-custom-adjust-group (group)
   (let ((symbol-specs (get group 'custom-group)))
     (dolist (spec symbol-specs)
       (let ((symbol (nth 0 spec))
-	    (symbol-type (nth 1 spec)))
-	(if (eq symbol-type 'custom-group)
-	    (jdee-custom-adjust-group symbol)
-	  (setcdr spec (list 'jdee-custom-variable)))))))
+            (symbol-type (nth 1 spec)))
+        (if (eq symbol-type 'custom-group)
+            (jdee-custom-adjust-group symbol)
+          (setcdr spec (list 'jdee-custom-variable)))))))
 
 (defun jdee-custom-adjust-groups ()
   "Change the symbol type in the symbol spec lists for all

--- a/jdee-db.el
+++ b/jdee-db.el
@@ -117,15 +117,15 @@ argument to pass to the Java interpreter. This option overrides the
 The messages are printed in the run buffer."
   :group 'jdee-db-options
   :type '(list :indent 2
-	       (checkbox :format "\n  %[%v%] %h \n"
-			 :doc "Print classes loaded.
+               (checkbox :format "\n  %[%v%] %h \n"
+                         :doc "Print classes loaded.
 Prints a message in the run buffer each time a class is loaded.")
-	       (checkbox :format "%[%v%] %h \n"
-			 :doc "Print memory freed.
+               (checkbox :format "%[%v%] %h \n"
+                         :doc "Print memory freed.
 Prints a message in the run buffer each time the garbage collector
 frees memory.")
-	       (checkbox :format "%[%v%] %h \n"
-			 :doc "Print JNI info.
+               (checkbox :format "%[%v%] %h \n"
+                         :doc "Print JNI info.
 Prints JNI-related messages including information about which native
 methods have been linked and warnings about excessive creation of
 local references.")))
@@ -137,86 +137,86 @@ Property Name field; enter its value, for example, green, in the
 Property Value field. You can specify as many properties as you like."
   :group 'jdee-db-options
   :type '(repeat (cons
-		  (string :tag "Property Name")
-		  (string :tag "Property Value"))))
+                  (string :tag "Property Name")
+                  (string :tag "Property Value"))))
 
 (defcustom jdee-db-option-heap-size (list
-				    (cons 1 "megabytes")
-				    (cons 16 "megabytes"))
+                                    (cons 1 "megabytes")
+                                    (cons 16 "megabytes"))
 "*Specify the initial and maximum size of the interpreter heap."
 :group 'jdee-db-options
 :type '(list
-	(cons (integer :tag "Start")
-	     (radio-button-choice (const "bytes")
-				  (const "kilobytes")
-				  (const "megabytes")
-				  (const "gigabytes")))
-	(cons (integer :tag "Max")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))))
+        (cons (integer :tag "Start")
+             (radio-button-choice (const "bytes")
+                                  (const "kilobytes")
+                                  (const "megabytes")
+                                  (const "gigabytes")))
+        (cons (integer :tag "Max")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))))
 
 
 (defcustom jdee-db-option-stack-size (list
-				     (cons 128 "kilobytes")
-				     (cons 400 "kilobytes"))
+                                     (cons 128 "kilobytes")
+                                     (cons 400 "kilobytes"))
   "*Specify size of the C and Java stacks."
   :group 'jdee-db-options
   :type '(list
-	  (cons (integer :tag "C Stack")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))
-	  (cons (integer :tag "Java Stack")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))))
+          (cons (integer :tag "C Stack")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))
+          (cons (integer :tag "Java Stack")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))))
 
 (defcustom jdee-db-option-garbage-collection (list t t)
   "*Specify garbage collection options."
   :group 'jdee-db-options
   :type '(list :indent 2
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Collect garbage asynchronously.")
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Collect unused classes.")))
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Collect garbage asynchronously.")
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Collect unused classes.")))
 
 (defcustom jdee-db-option-java-profile (cons nil "./java.prof")
   "*Enable Java profiling."
   :group 'jdee-db-options
   :type '(cons boolean
-	       (file :tag "File"
-		     :help-echo
+               (file :tag "File"
+                     :help-echo
 "Specify where to put profile results here.")))
 
 (defcustom jdee-db-option-heap-profile (cons nil
-					    (list "./java.hprof"
-						  5
-						  20
-						  "Allocation objects"))
+                                            (list "./java.hprof"
+                                                  5
+                                                  20
+                                                  "Allocation objects"))
 "*Output heap profiling data."
   :group 'jdee-db-options
   :type '(cons boolean
-	       (list
-		(string :tag "Output File Path")
-		(integer :tag "Stack Trace Depth")
-		(integer :tag "Allocation Sites")
-		(radio-button-choice :format "%t \n%v"
-				     :tag "Sort output based on:"
-		 (const "Allocation objects")
-		 (const "Live objects")))))
+               (list
+                (string :tag "Output File Path")
+                (integer :tag "Stack Trace Depth")
+                (integer :tag "Allocation Sites")
+                (radio-button-choice :format "%t \n%v"
+                                     :tag "Sort output based on:"
+                 (const "Allocation objects")
+                 (const "Live objects")))))
 
 (defcustom jdee-db-option-verify (list nil t)
   "*Verify classes."
   :group 'jdee-db-options
   :type '(list :indent 2
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Executed code in all classes.")
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Classes loaded by a classloader.")))
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Executed code in all classes.")
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Classes loaded by a classloader.")))
 
 (defcustom jdee-db-option-host ""
   "Host of a remote process to which you wish to attach. This
@@ -235,17 +235,17 @@ process. Selecting \"Specify\" allows you to specify a default socket
 host and port to be used by the debugger. "
   :group 'jdee-db-options
   :type '(choice
-	  (const :menu-tag "Prompt" nil)
-	  (list
-	   :menu-tag "Specify" :tag "Socket Address" :inline nil
-	   (choice
-	    :tag "Host"
-	    (const :menu-tag "Local" nil)
-	    (string :menu-tag "Remote" :tag "Name"))
-	   (choice
-	    :tag "Port"
-	    (const :menu-tag "Default" "4444")
-	    (string :menu-tag "Custom")))))
+          (const :menu-tag "Prompt" nil)
+          (list
+           :menu-tag "Specify" :tag "Socket Address" :inline nil
+           (choice
+            :tag "Host"
+            (const :menu-tag "Local" nil)
+            (string :menu-tag "Remote" :tag "Name"))
+           (choice
+            :tag "Port"
+            (const :menu-tag "Default" "4444")
+            (string :menu-tag "Custom")))))
 
 
 
@@ -260,8 +260,8 @@ enter the shared memory name. Selecting \"Specify\" allows you to
 specify a name of your choosing."
   :group 'jdee-db-options
   :type '(choice
-	  (const :menu-tag "Prompt" nil)
-	  (string :menu-tag "Specify" :tag "Name")))
+          (const :menu-tag "Prompt" nil)
+          (string :menu-tag "Specify" :tag "Name")))
 
 
 (defcustom jdee-db-option-vm-args nil
@@ -290,8 +290,8 @@ Java source or a debug buffer."
     (or
      (eq major-mode 'jdee-mode)
      (and (slot-boundp 'jdee-db-debugger 'the-debugger)
-	  (eq (current-buffer)
-	      (oref (oref-default 'jdee-db-debugger the-debugger) buffer))))
+          (eq (current-buffer)
+              (oref (oref-default 'jdee-db-debugger the-debugger) buffer))))
     nil
     "This command works only in a Java source or debug buffer."))
 
@@ -304,39 +304,39 @@ to be used for debugging the JDEE's debuggers."
 (defun jdee-db-log-debugger-output (output)
   (if jdee-db-log-debugger-output-flag
       (let ((buf (get-buffer "debugger output")))
-	(when (not buf)
-	  (setq buf (get-buffer-create  "debugger output"))
-	  (pop-to-buffer buf))
-	(with-current-buffer buf
-	  (goto-char (point-max))
-	  (insert output)))))
+        (when (not buf)
+          (setq buf (get-buffer-create  "debugger output"))
+          (pop-to-buffer buf))
+        (with-current-buffer buf
+          (goto-char (point-max))
+          (insert output)))))
 
 (defun jdee-db-get-debuggee-status ()
   "Get the`jdee-db-debuggee-status' of the
 current debuggee process."
   (if (slot-boundp 'jdee-db-debugger 'the-debugger)
       (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	     (debuggee (oref debugger debuggee)))
-	(oref debuggee status))))
+             (debuggee (oref debugger debuggee)))
+        (oref debuggee status))))
 
 
 (defun jdee-db-debuggee-stopped-p ()
   "Return t if current debuggee process is stopped."
   (let ((status (jdee-db-get-debuggee-status)))
      (if status
-	 (oref status stopped-p))))
+         (oref status stopped-p))))
 
 (defun jdee-db-debuggee-suspended-p ()
   "Return t if current debuggee process is suspended."
   (let ((status (jdee-db-get-debuggee-status)))
      (if status
-	 (oref status suspended-p))))
+         (oref status suspended-p))))
 
 (defun jdee-db-debuggee-running-p ()
   "Return t if current debuggee process is running."
   (let ((status (jdee-db-get-debuggee-status)))
      (if status
-	 (oref status running-p))))
+         (oref status running-p))))
 
 
 ;; FIXME: the variable 'jdb-db-debugger' is not used anywhere else, so
@@ -348,14 +348,14 @@ current debuggee process."
 ;;   (interactive
 ;;    "sEnter name of Java interpreter: \nsIs %s executable? (yes): ")
 ;;   (let ((db name)
-;; 	(type
-;; 	 (if (stringp is-executable)
-;; 	     (if (or
-;; 		  (string= is-executable "")
-;; 		  (eq (aref is-executable 0) ?y))
-;; 		 "Executable"
-;; 	       "Class")
-;; 	   "Executable")))
+;;         (type
+;;          (if (stringp is-executable)
+;;              (if (or
+;;                   (string= is-executable "")
+;;                   (eq (aref is-executable 0) ?y))
+;;                  "Executable"
+;;                "Class")
+;;            "Executable")))
 ;;     (setq jdee-db-debugger (cons "Other" (cons db type)))))
 
 ;;;###autoload
@@ -384,39 +384,39 @@ current debuggee process."
 the line at which you have specified that a breakpoint to be set."
   :group 'jdee-project
   :type '(cons :tag "Colors"
-	  (string :tag "Foreground")
-	  (string :tag "Background"))
+          (string :tag "Foreground")
+          (string :tag "Background"))
   :set '(lambda (sym val)
-	  (make-face 'jdee-db-spec-breakpoint-face)
-	  (set-face-foreground 'jdee-db-spec-breakpoint-face (car val))
-	  (set-face-background 'jdee-db-spec-breakpoint-face (cdr val))
-	  (set-default sym val)))
+          (make-face 'jdee-db-spec-breakpoint-face)
+          (set-face-foreground 'jdee-db-spec-breakpoint-face (car val))
+          (set-face-background 'jdee-db-spec-breakpoint-face (cdr val))
+          (set-default sym val)))
 
 (defcustom jdee-db-requested-breakpoint-face-colors (cons "black" "yellow")
 "*Specifies the foreground and background colors used to highlight
 the line at which you have requested a breakpoint to be set."
   :group 'jdee-project
   :type '(cons :tag "Colors"
-	  (string :tag "Foreground")
-	  (string :tag "Background"))
+          (string :tag "Foreground")
+          (string :tag "Background"))
   :set '(lambda (sym val)
-	  (make-face 'jdee-db-requested-breakpoint-face)
-	  (set-face-foreground 'jdee-db-requested-breakpoint-face (car val))
-	  (set-face-background 'jdee-db-requested-breakpoint-face (cdr val))
-	  (set-default sym val)))
+          (make-face 'jdee-db-requested-breakpoint-face)
+          (set-face-foreground 'jdee-db-requested-breakpoint-face (car val))
+          (set-face-background 'jdee-db-requested-breakpoint-face (cdr val))
+          (set-default sym val)))
 
 (defcustom jdee-db-active-breakpoint-face-colors (cons "black" "red")
 "*Specifies the foreground and background colors used to highlight
 a line where an active breakpoint exists."
   :group 'jdee-project
   :type '(cons :tag "Colors"
-	  (string :tag "Foreground")
-	  (string :tag "Background"))
+          (string :tag "Foreground")
+          (string :tag "Background"))
   :set '(lambda (sym val)
-	  (make-face 'jdee-db-active-breakpoint-face)
-	  (set-face-foreground 'jdee-db-active-breakpoint-face (car val))
-	  (set-face-background 'jdee-db-active-breakpoint-face (cdr val))
-	  (set-default sym val)))
+          (make-face 'jdee-db-active-breakpoint-face)
+          (set-face-foreground 'jdee-db-active-breakpoint-face (car val))
+          (set-face-background 'jdee-db-active-breakpoint-face (cdr val))
+          (set-default sym val)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -427,8 +427,8 @@ a line where an active breakpoint exists."
 
 (defclass jdee-db-breakpoint-marker ()
   ((marker :initarg :marker
-	   :documentation
-	   "Overlay in Emacs, extent in XEmacs"))
+           :documentation
+           "Overlay in Emacs, extent in XEmacs"))
   "Indicates the location of breakpoints in a source buffer. This class
 uses overlays as markers in Emacs and extents in XEmacs.")
 
@@ -439,7 +439,7 @@ uses overlays as markers in Emacs and extents in XEmacs.")
   (call-next-method)
 
   (oset this marker
-	(make-overlay
+        (make-overlay
          (jdee-line-beginning-position)
          (1+ (jdee-line-end-position))
          (current-buffer) nil t)))
@@ -472,32 +472,32 @@ uses overlays as markers in Emacs and extents in XEmacs.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-breakpoint ()
   ((id       :initarg :id
-	     :type integer
-	     :documentation
-	     "Identifies this breakpoint.")
+             :type integer
+             :documentation
+             "Identifies this breakpoint.")
    (file     :initarg :file
-	     :initform ""
-	     :type string
-	     :documentation
-	     "Pathname of file containing this breakpoint.")
+             :initform ""
+             :type string
+             :documentation
+             "Pathname of file containing this breakpoint.")
    (line     :initarg :line
-	     :type integer
-	     :documentation
-	     "Number of line at which breakpoint is set.")
+             :type integer
+             :documentation
+             "Number of line at which breakpoint is set.")
    (marker   :initarg :marker
-	     :type (or null jdee-db-breakpoint-marker)
-	     :initform nil
-	     :documentation
-	     "Marker used to highlight breakpoint line.")
+             :type (or null jdee-db-breakpoint-marker)
+             :initform nil
+             :documentation
+             "Marker used to highlight breakpoint line.")
    (class    :initarg :class
-	     :type string
-	     :documentation
-	     "Qualified name of class containing breakpoint.")
+             :type string
+             :documentation
+             "Qualified name of class containing breakpoint.")
    (status   :initarg status
-	     :type symbol
-	     :initform specified
-	     :documentation
-	     "Status of this breakpoint. Legal values are `specified', `requested', `active'."))
+             :type symbol
+             :initform specified
+             :documentation
+             "Status of this breakpoint. Legal values are `specified', `requested', `active'."))
   (:allow-nil-initform t)
   "Class of breakpoints.")
 
@@ -511,8 +511,8 @@ uses overlays as markers in Emacs and extents in XEmacs.")
   (assert (oref this file))
 
   (oset this
-	marker
-	(jdee-db-breakpoint-marker "breakpoint marker"))
+        marker
+        (jdee-db-breakpoint-marker "breakpoint marker"))
 
   (jdee-db-breakpoint-marker-set-face
    (oref this marker) 'jdee-db-spec-breakpoint-face))
@@ -521,9 +521,9 @@ uses overlays as markers in Emacs and extents in XEmacs.")
   "Get the number of the line at which this breakpoint is set."
   (with-current-buffer (find-file-noselect (oref this file))
     (if (oref this marker)
-	(let ((marker-start
-	       (overlay-start (oref (oref this marker) marker))))
-	  (jdee-get-line-at-point marker-start))
+        (let ((marker-start
+               (overlay-start (oref (oref this marker) marker))))
+          (jdee-get-line-at-point marker-start))
       (oref this line))))
 
 (defvar jdee-db-breakpoints nil
@@ -534,70 +534,70 @@ uses overlays as markers in Emacs and extents in XEmacs.")
   "Get breakpoint marker at FILE and LINE."
   (let ((bp (jdee-db-find-breakpoint file line)))
     (if bp
-	(oref bp marker))))
+        (oref bp marker))))
 
 (defun jdee-db-mark-breakpoint-specified (file line)
   "Changes the face of the breakpoint marker at LINE in FILE
 to the specified face."
   (let ((marker (jdee-db-get-breakpoint-marker file line)))
     (if marker
-	(jdee-db-breakpoint-marker-set-face marker 'jdee-db-spec-breakpoint-face))))
+        (jdee-db-breakpoint-marker-set-face marker 'jdee-db-spec-breakpoint-face))))
 
 (defun jdee-db-mark-breakpoint-active (file line)
   "Changes the face of the breakpoint marker at LINE in FILE
 to the active face."
   (let ((marker (jdee-db-get-breakpoint-marker file line)))
     (if marker
-	(jdee-db-breakpoint-marker-set-face marker 'jdee-db-active-breakpoint-face))))
+        (jdee-db-breakpoint-marker-set-face marker 'jdee-db-active-breakpoint-face))))
 
 (defun jdee-db-mark-breakpoint-requested (file line)
   "Changes the face of the breakpoint marker at LINE in FILE
 to the active face."
   (let ((marker (jdee-db-get-breakpoint-marker file line)))
     (if marker
-	(jdee-db-breakpoint-marker-set-face marker 'jdee-db-requested-breakpoint-face))))
+        (jdee-db-breakpoint-marker-set-face marker 'jdee-db-requested-breakpoint-face))))
 
 (defun jdee-db-set-all-breakpoints-specified ()
   "Changes the face of all breakpoints to `jdee-db-spec-breakpoint-face'
 and sets the status of all breakpoints to `specified'."
   (loop for bp-assoc in jdee-db-breakpoints do
-	(let* ((bp (cdr bp-assoc))
-	       (marker (oref bp marker)))
-	  (oset bp status 'specified)
-	  (if marker
-	      (jdee-db-breakpoint-marker-set-face marker 'jdee-db-spec-breakpoint-face)))))
+        (let* ((bp (cdr bp-assoc))
+               (marker (oref bp marker)))
+          (oset bp status 'specified)
+          (if marker
+              (jdee-db-breakpoint-marker-set-face marker 'jdee-db-spec-breakpoint-face)))))
 
 (defun jdee-db-delete-breakpoint (bp)
   "Delete the breakpoint at LINE in FILE."
   (setq jdee-db-breakpoints
-	;; bp will be in the list so don't run the risk of using a
-	;; deleted extent.
-	(let ((bpline (jdee-db-breakpoint-get-line bp)))
-	  (cl-remove-if
-	   (lambda (assoc-x)
-	     (let* ((xbp (cdr assoc-x))
-		    (xfile (oref xbp file))
-		    (deletep
-		     (and
-		      (string= (oref bp file) xfile)
-		      (equal bpline (jdee-db-breakpoint-get-line  xbp)))))
-	       (if deletep
-		   (jdee-db-breakpoint-marker-delete
-		    (oref bp marker)))
-	       deletep))
-	   jdee-db-breakpoints))))
+        ;; bp will be in the list so don't run the risk of using a
+        ;; deleted extent.
+        (let ((bpline (jdee-db-breakpoint-get-line bp)))
+          (cl-remove-if
+           (lambda (assoc-x)
+             (let* ((xbp (cdr assoc-x))
+                    (xfile (oref xbp file))
+                    (deletep
+                     (and
+                      (string= (oref bp file) xfile)
+                      (equal bpline (jdee-db-breakpoint-get-line  xbp)))))
+               (if deletep
+                   (jdee-db-breakpoint-marker-delete
+                    (oref bp marker)))
+               deletep))
+           jdee-db-breakpoints))))
 
 (defun jdee-db-clear-breakpoints ()
   "Clear all breakpoints from all buffers."
   (mapc
    (lambda (assoc-x)
      (let* ((xbp (cdr assoc-x))
-	    (file (oref xbp file))
-	    (buf (find-buffer-visiting file)))
+            (file (oref xbp file))
+            (buf (find-buffer-visiting file)))
        (if buf
-	   (with-current-buffer buf
-	     (let ((xmarker (oref xbp marker)))
-	       (jdee-db-breakpoint-marker-delete xmarker))))))
+           (with-current-buffer buf
+             (let ((xmarker (oref xbp marker)))
+               (jdee-db-breakpoint-marker-delete xmarker))))))
       jdee-db-breakpoints)
   (setq jdee-db-breakpoints nil))
 
@@ -608,116 +608,116 @@ particular breakpoint and to select breakpoints to be clear."
   (interactive "i")
   (if jdee-db-breakpoints
       (progn
-	(switch-to-buffer "*Breakpoints List*")
-	(kill-all-local-variables)
-	(make-local-variable 'jdee-db-bp-list)
-	(setq jdee-db-bp-list nil)
-	(let ((inhibit-read-only t))
-	  (erase-buffer))
-	(setq active (not active))
-	(widget-insert "Breakpoints:\n\n")
-	(mapc
-	 (lambda (assoc-x)
-	   (let* ((xbp (cdr assoc-x))
-		  (id (oref xbp id))
-		  (class (oref xbp class))
-		  (file (oref xbp file))
-		  (line (oref xbp line))
-		  (status (oref xbp status)))
-	     (widget-create
-	      'checkbox
-	      :notify (lambda (widget &rest ignore)
-			(if (widget-value widget)
-			    (setq jdee-db-bp-list
-				  (delete (widget-get widget :id)
-					  jdee-db-bp-list))
-			  (setq jdee-db-bp-list
-				(append jdee-db-bp-list
-					(list (widget-get widget :id))))))
-	      :id id
-	      active)
-	   (if (not active)
-		(setq jdee-db-bp-list (append jdee-db-bp-list (list id))))
-	    (widget-insert " ")
-	    (widget-create 'push-button
-			   :notify (lambda (widget &rest ignore)
-				     (progn
-				       (find-file-other-window
-					(widget-get widget :file))
-				       (goto-char (point-min))
-				       (forward-line
-					(1- (widget-get widget :line)))))
+        (switch-to-buffer "*Breakpoints List*")
+        (kill-all-local-variables)
+        (make-local-variable 'jdee-db-bp-list)
+        (setq jdee-db-bp-list nil)
+        (let ((inhibit-read-only t))
+          (erase-buffer))
+        (setq active (not active))
+        (widget-insert "Breakpoints:\n\n")
+        (mapc
+         (lambda (assoc-x)
+           (let* ((xbp (cdr assoc-x))
+                  (id (oref xbp id))
+                  (class (oref xbp class))
+                  (file (oref xbp file))
+                  (line (oref xbp line))
+                  (status (oref xbp status)))
+             (widget-create
+              'checkbox
+              :notify (lambda (widget &rest ignore)
+                        (if (widget-value widget)
+                            (setq jdee-db-bp-list
+                                  (delete (widget-get widget :id)
+                                          jdee-db-bp-list))
+                          (setq jdee-db-bp-list
+                                (append jdee-db-bp-list
+                                        (list (widget-get widget :id))))))
+              :id id
+              active)
+           (if (not active)
+                (setq jdee-db-bp-list (append jdee-db-bp-list (list id))))
+            (widget-insert " ")
+            (widget-create 'push-button
+                           :notify (lambda (widget &rest ignore)
+                                     (progn
+                                       (find-file-other-window
+                                        (widget-get widget :file))
+                                       (goto-char (point-min))
+                                       (forward-line
+                                        (1- (widget-get widget :line)))))
 
-			   :button-face
-			    (cond
-			     ((eq status 'specified)
-			      'jdee-db-spec-breakpoint-face)
-			     ((eq status 'active)
-			      'jdee-db-active-breakpoint-face)
-			     (t 'jdee-db-requested-breakpoint-face))
-			   :file file
-			   :line line
-			   (format "%s:%d" class line))
-	    (widget-insert "\n")))
-	 jdee-db-breakpoints)
-	(widget-insert "\n")
-	(widget-create 'push-button
-		       :notify (lambda (&rest ignore)
-				 (jdee-debug-list-breakpoints t))
-		       "Clear All")
-	(widget-insert " ")
-	(widget-create 'push-button
-		       :notify (lambda (&rest ignore)
-				 (progn
-				   (jdee-db-process-breakpoints)
-				   (kill-buffer "*Breakpoints List*")))
-		       "Apply Form")
-	(use-local-map widget-keymap)
-	(widget-insert "\n")
-	(widget-setup))
+                           :button-face
+                            (cond
+                             ((eq status 'specified)
+                              'jdee-db-spec-breakpoint-face)
+                             ((eq status 'active)
+                              'jdee-db-active-breakpoint-face)
+                             (t 'jdee-db-requested-breakpoint-face))
+                           :file file
+                           :line line
+                           (format "%s:%d" class line))
+            (widget-insert "\n")))
+         jdee-db-breakpoints)
+        (widget-insert "\n")
+        (widget-create 'push-button
+                       :notify (lambda (&rest ignore)
+                                 (jdee-debug-list-breakpoints t))
+                       "Clear All")
+        (widget-insert " ")
+        (widget-create 'push-button
+                       :notify (lambda (&rest ignore)
+                                 (progn
+                                   (jdee-db-process-breakpoints)
+                                   (kill-buffer "*Breakpoints List*")))
+                       "Apply Form")
+        (use-local-map widget-keymap)
+        (widget-insert "\n")
+        (widget-setup))
     (message "No breakpoints")))
 
 (defun jdee-db-process-breakpoints ()
   "Deletes all the breakpoints found in `jdee-db-bp-list'"
   (if jdee-db-bp-list
       (if (jdee-db-debuggee-running-p)
-	  (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-		 (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
-	    (oset
-	     bp-cmd
-	     breakpoints
-	     (mapcar
-	      (lambda (assoc-x)
-		(jdee-db-find-breakpoint-by-id assoc-x))
-	      jdee-db-bp-list))
-	    (jdee-db-exec-cmd debugger bp-cmd))
-	(loop for bp-assoc in jdee-db-bp-list do
-	      (let ((bp (jdee-db-find-breakpoint-by-id bp-assoc)))
-		(jdee-db-delete-breakpoint bp))))))
+          (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                 (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
+            (oset
+             bp-cmd
+             breakpoints
+             (mapcar
+              (lambda (assoc-x)
+                (jdee-db-find-breakpoint-by-id assoc-x))
+              jdee-db-bp-list))
+            (jdee-db-exec-cmd debugger bp-cmd))
+        (loop for bp-assoc in jdee-db-bp-list do
+              (let ((bp (jdee-db-find-breakpoint-by-id bp-assoc)))
+                (jdee-db-delete-breakpoint bp))))))
 
 (defun jdee-db-breakpoints-add (bp)
   "Adds this breakpoint to the list of breakpoints."
   (setq jdee-db-breakpoints
-	(cons (cons (oref bp id) bp)
-	      jdee-db-breakpoints)))
+        (cons (cons (oref bp id) bp)
+              jdee-db-breakpoints)))
 
 
 (defun jdee-db-find-breakpoint-by-id (id)
   "Finds the breakpoint object with ID"
   (cdr (cl-find-if
-	(lambda (assoc-x)
-	  (let ((bp (cdr assoc-x)))
-	    (= (oref bp id) id)))
-	jdee-db-breakpoints)))
+        (lambda (assoc-x)
+          (let ((bp (cdr assoc-x)))
+            (= (oref bp id) id)))
+        jdee-db-breakpoints)))
 
 (defun jdee-db-find-breakpoint (file line)
   "Finds the breakpoint object for the breakpoint at FILE and LINE."
   (cdr (cl-find-if
-	(lambda (assoc-x)
-	  (let ((bp (cdr assoc-x)))
-	       (and (string= (oref bp file) file)
-		    (equal (jdee-db-breakpoint-get-line bp) line))))
-	jdee-db-breakpoints)))
+        (lambda (assoc-x)
+          (let ((bp (cdr assoc-x)))
+               (and (string= (oref bp file) file)
+                    (equal (jdee-db-breakpoint-get-line bp) line))))
+        jdee-db-breakpoints)))
 
 
 (defvar jdee-db-breakpoint-id-counter 0
@@ -729,10 +729,10 @@ in the current buffer to nil."
  (when (eq major-mode 'jdee-mode)
    (let ((file (buffer-file-name)))
      (loop for bp-assoc in jdee-db-breakpoints do
-	   (let ((bp (cdr bp-assoc)))
-	     (when (string= (oref bp file) file)
-	       (oset bp line (jdee-db-breakpoint-get-line bp))
-	       (oset bp marker nil)))))))
+           (let ((bp (cdr bp-assoc)))
+             (when (string= (oref bp file) file)
+               (oset bp line (jdee-db-breakpoint-get-line bp))
+               (oset bp marker nil)))))))
 
 (add-hook 'kill-buffer-hook 'jdee-db-nullify-breakpoint-markers)
 
@@ -741,27 +741,27 @@ in the current buffer to nil."
 already highlighted."
   (save-excursion
     (loop for bp-assoc in jdee-db-breakpoints do
-	  (let* ((bp (cdr bp-assoc))
-		 (file (buffer-file-name))
-		 (line (oref bp line))
-		 (status (oref bp status)))
-	    (if (string-equal file (oref bp file))
-		(progn
-		  (goto-char (point-min))
-		  (forward-line (1- line))
-		  (oset bp
-			marker
-			(jdee-db-breakpoint-marker "breakpoint marker"))
-		  (cond
-		   ((eq status 'specified)
-		    (jdee-db-mark-breakpoint-specified file line))
-		   ((eq status 'requested)
-		    (jdee-db-mark-breakpoint-requested file line))
-		   ((eq status 'active)
-		    (jdee-db-mark-breakpoint-active file line))
-		   (t
-		    (error "Unknown breakpoint status: %s"
-			   (symbol-name status))))))))
+          (let* ((bp (cdr bp-assoc))
+                 (file (buffer-file-name))
+                 (line (oref bp line))
+                 (status (oref bp status)))
+            (if (string-equal file (oref bp file))
+                (progn
+                  (goto-char (point-min))
+                  (forward-line (1- line))
+                  (oset bp
+                        marker
+                        (jdee-db-breakpoint-marker "breakpoint marker"))
+                  (cond
+                   ((eq status 'specified)
+                    (jdee-db-mark-breakpoint-specified file line))
+                   ((eq status 'requested)
+                    (jdee-db-mark-breakpoint-requested file line))
+                   ((eq status 'active)
+                    (jdee-db-mark-breakpoint-active file line))
+                   (t
+                    (error "Unknown breakpoint status: %s"
+                           (symbol-name status))))))))
     ))
 
 
@@ -776,8 +776,8 @@ already highlighted."
 
 (defun jdee-db-query-source-file (class)
   (let ((source-file
-	 (read-file-name
-	  (format "Cannot find %s source. Enter path: " class))))
+         (read-file-name
+          (format "Cannot find %s source. Enter path: " class))))
   (if (and
        source-file
        (file-exists-p source-file)
@@ -793,39 +793,39 @@ the user for the path to the source file. If successful, this function
 returns an unselected buffer containing the source file for the
 class. Otherwise, it returns nil."
   (let* ((source-file (jdee-find-class-source-file class))
-	 (source-buffer
-	  (if source-file
-	      (find-file-noselect source-file)
-	    (if jdee-db-query-missing-source-files
-		(jdee-db-query-source-file class)))))
+         (source-buffer
+          (if source-file
+              (find-file-noselect source-file)
+            (if jdee-db-query-missing-source-files
+                (jdee-db-query-source-file class)))))
     source-buffer))
 
 (defun jdee-db-set-debug-cursor (class file line)
   "Shows the source at LINE in CLASS."
   (let* ((buffer (jdee-db-find-class-source class))
-	 (window
-	  (and buffer
-	       (or (get-buffer-window buffer)
-		   (selected-window))))
-	  pos)
+         (window
+          (and buffer
+               (or (get-buffer-window buffer)
+                   (selected-window))))
+          pos)
     (if buffer
-	(progn
-	  (if (not (get-buffer-window buffer))
-	      (set-window-buffer window buffer))
-	  (with-current-buffer buffer
-	    (save-restriction
-	      (widen)
-	      (goto-char (point-min))
-	      (forward-line (1- line))
-	      (setq pos (point))
-	      (setq overlay-arrow-string "=>")
-	      (or overlay-arrow-position
-		  (setq overlay-arrow-position (make-marker)))
-	      (set-marker overlay-arrow-position (point) (current-buffer)))
-	    (cond ((or (< pos (point-min)) (> pos (point-max)))
-		   (widen)
-		   (goto-char pos))))
-	  (set-window-point window overlay-arrow-position)))))
+        (progn
+          (if (not (get-buffer-window buffer))
+              (set-window-buffer window buffer))
+          (with-current-buffer buffer
+            (save-restriction
+              (widen)
+              (goto-char (point-min))
+              (forward-line (1- line))
+              (setq pos (point))
+              (setq overlay-arrow-string "=>")
+              (or overlay-arrow-position
+                  (setq overlay-arrow-position (make-marker)))
+              (set-marker overlay-arrow-position (point) (current-buffer)))
+            (cond ((or (< pos (point-min)) (> pos (point-max)))
+                   (widen)
+                   (goto-char pos))))
+          (set-window-point window overlay-arrow-position)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -835,20 +835,20 @@ class. Otherwise, it returns nil."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-debuggee-status ()
   ((running-p   :initarg :running-p
-		:type boolean
-		:initform nil
-		:documentation
-		"Non-nil if debuggee process is running.")
+                :type boolean
+                :initform nil
+                :documentation
+                "Non-nil if debuggee process is running.")
    (stopped-p   :initarg :stopped-p
-		:type boolean
-		:initform nil
-		:documentation
-		"Non-nil if debuggee process is stopped.")
+                :type boolean
+                :initform nil
+                :documentation
+                "Non-nil if debuggee process is stopped.")
    (suspended-p :initarg :suspended-p
-		:type boolean
-		:initform nil
-		:documentation
-		"Non-nil if debuggee process is suspended."))
+                :type boolean
+                :initform nil
+                :documentation
+                "Non-nil if debuggee process is suspended."))
   "Status of debuggee process.")
 
 (defmethod initialize-instance ((this jdee-db-debuggee-status) &rest fields)
@@ -868,18 +868,18 @@ class. Otherwise, it returns nil."
 
 (defclass jdee-db-socket-connector (jdee-db-connector)
   ((port :initarg :port
-	 :type (or null string)
-	 :initform nil
-	 :documentation
-	 "Port to the debuggee process."))
+         :type (or null string)
+         :initform nil
+         :documentation
+         "Port to the debuggee process."))
   "Connect via a socket.")
 
 (defclass jdee-db-shared-memory-connector (jdee-db-connector)
   ((name  :initarg :name
-	  :type (or null string)
-	  :initform nil
-	  :documentation
-	  "Shared memory name of debuggee process."))
+          :type (or null string)
+          :initform nil
+          :documentation
+          "Shared memory name of debuggee process."))
   "Connect via a shared-memory transport (Windows only).")
 
 
@@ -891,41 +891,41 @@ class. Otherwise, it returns nil."
 
 
 (defclass jdee-db-socket-attach-connector (jdee-db-socket-connector
-					  jdee-db-attach-connector)
+                                          jdee-db-attach-connector)
   ((host        :initarg :host
-		:type (or null string)
-		:initform nil
-		:documentation
-		"Host on which the debuggee process runs."))
+                :type (or null string)
+                :initform nil
+                :documentation
+                "Host on which the debuggee process runs."))
   "Attach via a socket.")
 
 (defclass jdee-db-shared-memory-attach-connector (jdee-db-shared-memory-connector
-						 jdee-db-attach-connector)
+                                                 jdee-db-attach-connector)
   ()
   "Attach via a shared memory connection.")
 
 (defclass jdee-db-socket-listen-connector (jdee-db-socket-connector
-					  jdee-db-listen-connector)
+                                          jdee-db-listen-connector)
   ()
   "Listen via a socket.")
 
 (defclass jdee-db-shared-memory-listen-connector (jdee-db-shared-memory-connector
-						 jdee-db-listen-connector)
+                                                 jdee-db-listen-connector)
   ()
   "Listen via a shared memory connection.")
 
 
 (defclass jdee-db-debuggee ()
   ((status      :initarg :status
-		:type jdee-db-debuggee-status
-		:documentation
-		"Status of debuggee process.")
+                :type jdee-db-debuggee-status
+                :documentation
+                "Status of debuggee process.")
 
   (stack-depth  :initarg :stack-depth
-		:type string
-		:initform ""
-		:documentation
-		"Stack depth."))
+                :type string
+                :initform ""
+                :documentation
+                "Stack depth."))
   "Program being debugged.")
 
 (defmethod initialize-instance ((this jdee-db-debuggee) &rest fields)
@@ -935,21 +935,21 @@ class. Otherwise, it returns nil."
 
 (defclass jdee-db-debuggee-app (jdee-db-debuggee)
   ((main-class  :initarg :main-class
-		:type string
-		:documentation
-		"Qualified name of debuggee main class.")
+                :type string
+                :documentation
+                "Qualified name of debuggee main class.")
 
    (connector   :initarg :connector
-		:type jdee-db-connector
-		:documentation
-		"Type of connector between this debuggee and the debugger."))
+                :type jdee-db-connector
+                :documentation
+                "Type of connector between this debuggee and the debugger."))
   "Application being debugged.")
 
 (defclass jdee-db-debuggee-applet (jdee-db-debuggee)
   ((doc :initarg :doc
-	:type string
-	:documentation
-	"Path of applet HTML document."))
+        :type string
+        :documentation
+        "Path of applet HTML document."))
   "Applet being debugged.")
 
 
@@ -960,13 +960,13 @@ class. Otherwise, it returns nil."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-cmd ()
   ((name           :initarg :name
-		   :type string
-		   :documentation
-		   "Name of command.")
+                   :type string
+                   :documentation
+                   "Name of command.")
    (debugger       :initarg :debugger
-		   :type jdee-db-debugger
-		   :documentation
-		   "Debugger."))
+                   :type jdee-db-debugger
+                   :documentation
+                   "Debugger."))
   "Super class of debugger commands.")
 
 
@@ -994,9 +994,9 @@ response to this command."
 
 (defclass jdee-db-cmd-breakpoint (jdee-db-cmd)
   ((breakpoints :initarg :breakpoints
-		:type list
-		:documentation
-		"List of breakpoint specification."))
+                :type list
+                :documentation
+                "List of breakpoint specification."))
   "Class of breakpoint commands.")
 
 (defclass jdee-db-cmd-launch (jdee-db-cmd)
@@ -1005,9 +1005,9 @@ response to this command."
 
 (defclass jdee-db-cmd-launch-app (jdee-db-cmd-launch)
   ((main-class :initarg :main-class
-	       :type string
-	       :documentation
-	       "Main class of applications to be debugged."))
+               :type string
+               :documentation
+               "Main class of applications to be debugged."))
    "Launch an application in debug mode.")
 
 (defmethod initialize-instance ((this jdee-db-cmd-launch-app) &rest fields)
@@ -1016,9 +1016,9 @@ response to this command."
 
 (defclass jdee-db-cmd-launch-applet (jdee-db-cmd-launch)
   ((doc  :initarg :doc
-	 :type string
-	 :documentation
-	 "Path of applet document."))
+         :type string
+         :documentation
+         "Path of applet document."))
    "Launch an applet in debug mode.")
 
 (defmethod initialize-instance ((this jdee-db-cmd-launch-applet) &rest fields)
@@ -1029,61 +1029,61 @@ response to this command."
 
 (defclass jdee-db-cmd-set ()
   ((debugger          :initarg :debugger
-		      :type jdee-db-debugger
-		      :documentation
-		      "Debugger that owns this command set.")
+                      :type jdee-db-debugger
+                      :documentation
+                      "Debugger that owns this command set.")
    (launch-app        :initarg :launch-app
-		      :type jdee-db-cmd-launch-app
-		      :documentation
-		      "Launch debuggee application")
+                      :type jdee-db-cmd-launch-app
+                      :documentation
+                      "Launch debuggee application")
    (launch-applet     :initarg :launch-applet
-		      :type jdee-db-cmd-launch-applet
-		      :documentation
-		      "Launch debuggee applet")
+                      :type jdee-db-cmd-launch-applet
+                      :documentation
+                      "Launch debuggee applet")
    (run               :initarg :run
-		      :type jdee-db-cmd
-		      :documentation
-		      "Starts the current debuggee application.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Starts the current debuggee application.")
    (cont              :initarg :cont
-		      :type jdee-db-cmd
-		      :documentation
-		      "Continues the current debuggee application.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Continues the current debuggee application.")
    (quit              :initarg :quit
-		      :type jdee-db-cmd
-		      :documentation
-		      "Quit debugging the current application.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Quit debugging the current application.")
    (step-over         :initarg :step-over
-		      :type jdee-db-cmd
-		      :documentation
-		      "Step to the next line in the current frame.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Step to the next line in the current frame.")
    (step-into         :initarg :step-into
-		      :type jdee-db-cmd
-		      :documentation
-		      "Step to the next line in the current program.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Step to the next line in the current program.")
    (step-out          :initarg :step-out
-		      :type jdee-db-cmd
-		      :documentation
-		      "Continue to the end of the current method.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Continue to the end of the current method.")
    (up                :initarg :up
-		      :type jdee-db-cmd
-		      :documentation
-		      "Move up the stack.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Move up the stack.")
    (down              :initarg :down
-		      :type jdee-db-cmd
-		      :documentation
-		      "Move down the stack.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Move down the stack.")
    (where             :initarg :where
-		      :type jdee-db-cmd
-		      :documentation
-		      "Point to the current stopping point.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Point to the current stopping point.")
    (set-bp            :initarg :set-bp
-		      :type jdee-db-cmd
-		      :documentation
-		      "Cmd that asks debugger to set a breakpoint.")
+                      :type jdee-db-cmd
+                      :documentation
+                      "Cmd that asks debugger to set a breakpoint.")
    (clear-bp          :initarg :clear-bp
-		      :type jdee-db-cmd
-		      :documentation
-		      "Cmd that asks debugger to set a breakpoint."))
+                      :type jdee-db-cmd
+                      :documentation
+                      "Cmd that asks debugger to set a breakpoint."))
   "Set of debugger commands implemented by this debugger.")
 
 
@@ -1095,9 +1095,9 @@ response to this command."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-listener ()
   ((debugger   :initarg :debugger
-	       :type jdee-db-debugger
-	       :documentation
-	       "The debugger"))
+               :type jdee-db-debugger
+               :documentation
+               "The debugger"))
   "Listens to the output from the debugger.")
 
 (defmethod jdee-db-listener-filter-output ((this jdee-db-listener) output)
@@ -1112,72 +1112,72 @@ response to this command."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-debugger ()
   ((name          :initarg :name
-		  :type string
-		  :initform "Java debugger"
-		  :documentation
-		  "Name of this Java debugger.")
+                  :type string
+                  :initform "Java debugger"
+                  :documentation
+                  "Name of this Java debugger.")
    (buffer-name   :initarg :buffer-name
-		  :initform "Java Debugger"
-		  :type string
-		  :documentation
-		  "Name of buffer used to interact with debugger.")
+                  :initform "Java Debugger"
+                  :type string
+                  :documentation
+                  "Name of buffer used to interact with debugger.")
    (buffer        :initarg :buffer
-		  :type buffer
-		  :documentation
-		  "Buffer used to interact with debugger.")
+                  :type buffer
+                  :documentation
+                  "Buffer used to interact with debugger.")
 
    (process       :initarg :process
-		  :documentation
-		  "Debugger process.")
+                  :documentation
+                  "Debugger process.")
 
    (running-p     :initarg :process
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "Non-nil if debugger process is running.")
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "Non-nil if debugger process is running.")
 
    (proc-filter   :initarg :proc-filter
-		  :type function
-		  :documentation
-		  "Function used to parse debug output.")
+                  :type function
+                  :documentation
+                  "Function used to parse debug output.")
 
    (listeners     :initarg :listeners
-		  :type list
-		  :initform nil
-		  :documentation
-		  "List of debugger output listeners.")
+                  :type list
+                  :initform nil
+                  :documentation
+                  "List of debugger output listeners.")
 
    (cmd-set       :initarg :cmd-set
-		  :type jdee-db-cmd-set
-		  :documentation
-		  "Commands implemented by this debugger.")
+                  :type jdee-db-cmd-set
+                  :documentation
+                  "Commands implemented by this debugger.")
 
    (next-cmd      :initarg :next-cmd
-		  :type list
-		  :initform nil
-		  :documentation
-		  "Next command(s) to execute.")
+                  :type list
+                  :initform nil
+                  :documentation
+                  "Next command(s) to execute.")
 
    (last-cmd      :initarg :last-cmd
-		  :type (or null jdee-db-cmd)
-		  :documentation
-		  "Last command send to the debugger.")
+                  :type (or null jdee-db-cmd)
+                  :documentation
+                  "Last command send to the debugger.")
 
    (debuggee      :initarg :debuggee
-		  :type jdee-db-debuggee
-		  :documentation
-		  "Application process being debugged.")
+                  :type jdee-db-debuggee
+                  :documentation
+                  "Application process being debugged.")
 
    (the-debugger  :type jdee-db-debugger
-		  :allocation :class
-		  :documentation
-		  "The currently active debugger."))
+                  :allocation :class
+                  :documentation
+                  "The currently active debugger."))
    "Class of Java debuggers.")
 
 (defmethod initialize-instance ((this jdee-db-debugger) &rest fields)
   "Constructor for generic debugger."
   (oset this cmd-set
-	(jdee-db-cmd-set "Generic commands" :debugger this))
+        (jdee-db-cmd-set "Generic commands" :debugger this))
   (oset this last-cmd nil))
 
 
@@ -1190,30 +1190,30 @@ response to this command."
 ready to accept the next command."
   (and output
        (or
-	(string-match ">[ ]*$" output)
-	(string-match "[a-zA-Z0-9]+\[[0-9]+\][ ]*$" output)
-	(string-match "VM Started:[ ]*$" output))))
+        (string-match ">[ ]*$" output)
+        (string-match "[a-zA-Z0-9]+\[[0-9]+\][ ]*$" output)
+        (string-match "VM Started:[ ]*$" output))))
 
 
 (defmethod jdee-db-process-debugger-output ((this jdee-db-debugger) output)
   "Process debugger output."
   (jdee-db-log-debugger-output (concat "<<" output ">>"))
   (let ((proc (oref this process))
-	(listeners (oref this listeners))
-	(response output)
-	(last-cmd (oref this last-cmd)))
+        (listeners (oref this listeners))
+        (response output)
+        (last-cmd (oref this last-cmd)))
 
     (loop for listener in listeners do
-	  (setq output
-		(jdee-db-listener-filter-output listener output)))
+          (setq output
+                (jdee-db-listener-filter-output listener output)))
 
     (comint-output-filter proc output)
 
     (if last-cmd
-	(jdee-db-cmd-notify-response last-cmd response))
+        (jdee-db-cmd-notify-response last-cmd response))
 
     (if (jdee-db-ready-p this (car (last (split-string output "\n"))))
-	(jdee-db-exec-next-cmd this))))
+        (jdee-db-exec-next-cmd this))))
 
 (defmethod jdee-db-add-listener ((this jdee-db-debugger) listener)
   "Adds LISTENER to the list of listeners listening for response
@@ -1243,37 +1243,37 @@ function that invokes `jdee-db-process-debugger-output'."
 when the debugger process terminates."
   (let ((proc (oref this process)))
     (cond ((null (buffer-name (process-buffer proc)))
-	 ;; buffer killed
-	 ;; Stop displaying an arrow in a source file.
-	   (setq overlay-arrow-position nil)
-	   (set-process-buffer proc nil))
-	  ((memq (process-status proc) '(signal exit))
-	   ;; Stop displaying an arrow in a source file.
-	   (setq overlay-arrow-position nil)
-	   (let* ((obuf (current-buffer)))
-	     ;; save-excursion isn't the right thing if
-	     ;;  process-buffer is current-buffer
-	     (unwind-protect
-		 (progn
-		   ;; Write something in debugger buffer and hack its mode line,
-		   (set-buffer (process-buffer proc))
-		   ;; Fix the mode line.
-		   (setq mode-line-process
-			 (concat ":"
-				 (symbol-name (process-status proc))))
-		   (force-mode-line-update)
-		   (if (eobp)
-		       (insert ?\n mode-name " " msg)
-		     (save-excursion
-		       (goto-char (point-max))
-		       (insert ?\n mode-name " " msg)))
-		 ;; If buffer and mode line will show that the process
-		 ;; is dead, we can delete it now.  Otherwise it
-		 ;; will stay around until M-x list-processes.
-		 (delete-process proc))
-	     ;; Restore old buffer, but don't restore old point
-	     ;; if obuf is the command buffer.
-	     (set-buffer obuf)))))))
+         ;; buffer killed
+         ;; Stop displaying an arrow in a source file.
+           (setq overlay-arrow-position nil)
+           (set-process-buffer proc nil))
+          ((memq (process-status proc) '(signal exit))
+           ;; Stop displaying an arrow in a source file.
+           (setq overlay-arrow-position nil)
+           (let* ((obuf (current-buffer)))
+             ;; save-excursion isn't the right thing if
+             ;;  process-buffer is current-buffer
+             (unwind-protect
+                 (progn
+                   ;; Write something in debugger buffer and hack its mode line,
+                   (set-buffer (process-buffer proc))
+                   ;; Fix the mode line.
+                   (setq mode-line-process
+                         (concat ":"
+                                 (symbol-name (process-status proc))))
+                   (force-mode-line-update)
+                   (if (eobp)
+                       (insert ?\n mode-name " " msg)
+                     (save-excursion
+                       (goto-char (point-max))
+                       (insert ?\n mode-name " " msg)))
+                 ;; If buffer and mode line will show that the process
+                 ;; is dead, we can delete it now.  Otherwise it
+                 ;; will stay around until M-x list-processes.
+                 (delete-process proc))
+             ;; Restore old buffer, but don't restore old point
+             ;; if obuf is the command buffer.
+             (set-buffer obuf)))))))
 
 
 (defmethod jdee-db-notify-process-status-change ((this jdee-db-debugger) msg)
@@ -1288,25 +1288,25 @@ the debugger process changes. The default method invokes
    (oref this process)
    (lambda (process msg)
        (jdee-db-notify-process-status-change
-	(oref-default 'jdee-db-debugger the-debugger) msg))))
+        (oref-default 'jdee-db-debugger the-debugger) msg))))
 
 (defmethod jdee-db-exec-next-cmd ((this jdee-db-debugger))
   "Executes the next command on the debugger's pending
 command list."
   (let ((curr-cmd (car (oref this next-cmd))))
     (if curr-cmd
-	(progn
-	  (oset this next-cmd (cdr (oref this next-cmd)))
-	  (oset this last-cmd curr-cmd)
-	  (jdee-db-cmd-init curr-cmd)
-	  (with-current-buffer (oref this buffer)
-	    (let ((proc (oref this process))
-		  (cmd-line (jdee-db-cmd-make-command-line curr-cmd)))
-	      (if cmd-line
-		  (progn
-		    (goto-char (point-max))
-		    (insert cmd-line)
-		    (comint-send-input)))))))))
+        (progn
+          (oset this next-cmd (cdr (oref this next-cmd)))
+          (oset this last-cmd curr-cmd)
+          (jdee-db-cmd-init curr-cmd)
+          (with-current-buffer (oref this buffer)
+            (let ((proc (oref this process))
+                  (cmd-line (jdee-db-cmd-make-command-line curr-cmd)))
+              (if cmd-line
+                  (progn
+                    (goto-char (point-max))
+                    (insert cmd-line)
+                    (comint-send-input)))))))))
 
 (defmethod jdee-db-exec-cmds ((this jdee-db-debugger) cmds)
   "Executes list of debugger CMDS."
@@ -1325,18 +1325,18 @@ command list."
   ;; classpath, if set; otherwise, the global
   ;; classpath.
   (let ((classpath
-	 (if jdee-db-option-classpath
-	     jdee-db-option-classpath
-	   jdee-global-classpath))
-	(symbol
-	 (if jdee-db-option-classpath
-	     'jdee-db-option-classpath
-	   'jdee-global-classpath)))
+         (if jdee-db-option-classpath
+             jdee-db-option-classpath
+           jdee-global-classpath))
+        (symbol
+         (if jdee-db-option-classpath
+             'jdee-db-option-classpath
+           'jdee-global-classpath)))
     (if classpath
-	(list
-	 "-classpath"
-	 (jdee-build-classpath
-	  classpath symbol)))))
+        (list
+         "-classpath"
+         (jdee-build-classpath
+          classpath symbol)))))
 
 (defmethod jdee-db-classic-mode-arg ((this jdee-db-debugger))
   "Generate the classic mode command-line argument for jdb."
@@ -1348,140 +1348,140 @@ command list."
   (if jdee-db-option-properties
       (mapcar
        (lambda (prop)
-	 (concat "-D" (car prop) "=" (cdr prop)))
+         (concat "-D" (car prop) "=" (cdr prop)))
        jdee-db-option-properties)))
 
 
 (defmethod jdee-db-verbose-args ((this jdee-db-debugger))
   "Get the debugger verbosity arguments for jdb."
   (let ((print-classes-loaded
-	 (nth 0 jdee-db-option-verbose))
-	(print-memory-freed
-	 (nth 1 jdee-db-option-verbose))
-	(print-jni-info
-	 (nth 2 jdee-db-option-verbose))
-	options)
+         (nth 0 jdee-db-option-verbose))
+        (print-memory-freed
+         (nth 1 jdee-db-option-verbose))
+        (print-jni-info
+         (nth 2 jdee-db-option-verbose))
+        options)
 
     (if print-classes-loaded
-	(add-to-list 'options "-verbose:class"))
+        (add-to-list 'options "-verbose:class"))
 
     (if print-memory-freed
-	(add-to-list 'options "-verbosegc"))
+        (add-to-list 'options "-verbosegc"))
 
     (if print-jni-info
-	(add-to-list options "-verbosejni"))
+        (add-to-list options "-verbosejni"))
 
     options))
 
 (defmethod jdee-db-heap-size-args ((this jdee-db-debugger))
   "Generate heap size options."
   (let* ((memory-unit-abbrevs
-	 (list (cons "bytes" "")
-	       (cons "kilobytes" "k")
-	       (cons "megabytes" "m")
-	       (cons "gigabytes" "g")))
-	 (start-cons (nth 0 jdee-db-option-heap-size))
-	 (start-size (format "%d%s" (car start-cons)
-			     (cdr (assoc (cdr start-cons)
-					 memory-unit-abbrevs))))
-	 (max-cons (nth 1 jdee-db-option-heap-size))
-	 (max-size (format "%d%s" (car max-cons)
-			   (cdr (assoc (cdr max-cons)
-				       memory-unit-abbrevs))))
-	 options)
+         (list (cons "bytes" "")
+               (cons "kilobytes" "k")
+               (cons "megabytes" "m")
+               (cons "gigabytes" "g")))
+         (start-cons (nth 0 jdee-db-option-heap-size))
+         (start-size (format "%d%s" (car start-cons)
+                             (cdr (assoc (cdr start-cons)
+                                         memory-unit-abbrevs))))
+         (max-cons (nth 1 jdee-db-option-heap-size))
+         (max-size (format "%d%s" (car max-cons)
+                           (cdr (assoc (cdr max-cons)
+                                       memory-unit-abbrevs))))
+         options)
     (if (not (string= start-size "1m"))
-	(setq options
-	      (append options (list (concat "-Xms" start-size)))))
+        (setq options
+              (append options (list (concat "-Xms" start-size)))))
     (if (not (string= max-size "16m"))
-	(setq options
-	      (append options (list (concat "-Xmx" max-size)))))
+        (setq options
+              (append options (list (concat "-Xmx" max-size)))))
     options))
 
 (defmethod jdee-db-stack-size-args ((this jdee-db-debugger))
   "Generate stack size arguments."
   (let* ((memory-unit-abbrevs
-	 (list (cons "bytes" "")
-	       (cons "kilobytes" "k")
-	       (cons "megabytes" "m")
-	       (cons "gigabytes" "g")))
-	 (c-cons (nth 0 jdee-db-option-stack-size))
-	 (c-size (format "%d%s" (car c-cons)
-			 (cdr (assoc (cdr c-cons)
-				     memory-unit-abbrevs))))
-	 (java-cons (nth 1 jdee-db-option-stack-size))
-	 (java-size (format "%d%s" (car java-cons)
-			    (cdr (assoc (cdr java-cons)
-					memory-unit-abbrevs))))
-	 option)
+         (list (cons "bytes" "")
+               (cons "kilobytes" "k")
+               (cons "megabytes" "m")
+               (cons "gigabytes" "g")))
+         (c-cons (nth 0 jdee-db-option-stack-size))
+         (c-size (format "%d%s" (car c-cons)
+                         (cdr (assoc (cdr c-cons)
+                                     memory-unit-abbrevs))))
+         (java-cons (nth 1 jdee-db-option-stack-size))
+         (java-size (format "%d%s" (car java-cons)
+                            (cdr (assoc (cdr java-cons)
+                                        memory-unit-abbrevs))))
+         option)
 
     (if (not (string= c-size "128k"))
-	(setq option
-	      (append option (list (concat "-Xss" c-size)))))
+        (setq option
+              (append option (list (concat "-Xss" c-size)))))
 
     (if (not (string= java-size "400k"))
-	(setq option
-	      (append option (list (concat "-Xoss" java-size)))))
+        (setq option
+              (append option (list (concat "-Xoss" java-size)))))
     option))
 
 (defmethod jdee-db-garbage-collection-args ((this jdee-db-debugger))
   "Set garbage collection options."
   (let ((no-gc-asynch (not
-		       (nth 0 jdee-db-option-garbage-collection)))
-	(no-gc-classes (not
-			(nth 1 jdee-db-option-garbage-collection)))
-	options)
+                       (nth 0 jdee-db-option-garbage-collection)))
+        (no-gc-classes (not
+                        (nth 1 jdee-db-option-garbage-collection)))
+        options)
 
     (if no-gc-asynch
-	(setq options (append options '("-Xnoasyncgc"))))
+        (setq options (append options '("-Xnoasyncgc"))))
 
     (if no-gc-classes
-	(setq options (append options '("-Xnoclassgc"))))
+        (setq options (append options '("-Xnoclassgc"))))
 
     options))
 
 (defmethod jdee-db-garbage-collection-arg ((this jdee-db-debugger))
   "Generate Java profile arg."
   (let ((profilep (car jdee-db-option-java-profile))
-	(file (cdr jdee-db-option-java-profile)))
+        (file (cdr jdee-db-option-java-profile)))
 
     (if profilep
-	(if (string= file "./java.prof")
-	    (list "-Xprof")
-	  (list (concat "-Xprof:" file))))))
+        (if (string= file "./java.prof")
+            (list "-Xprof")
+          (list (concat "-Xprof:" file))))))
 
 
 (defmethod jdee-db-heap-profile-arg ((this jdee-db-debugger))
   "Generate heap profile option."
   (let* ((profilep (car jdee-db-option-heap-profile))
-	 (prof-options (cdr jdee-db-option-heap-profile))
-	 (file (nth 0 prof-options))
-	 (depth (nth 1 prof-options))
-	 (top (nth 2 prof-options))
-	 (sort
-	  (downcase (substring (nth 3 prof-options) 0 1))))
+         (prof-options (cdr jdee-db-option-heap-profile))
+         (file (nth 0 prof-options))
+         (depth (nth 1 prof-options))
+         (top (nth 2 prof-options))
+         (sort
+          (downcase (substring (nth 3 prof-options) 0 1))))
     (if profilep
-	(if (and (string= file "./java.hprof")
-		 (equal depth 5)
-		 (equal top 20)
-		 (string= sort "a"))
-	    (list "-Xhprof")
-	  (list
-	   (format
-	    "-Xhprof:file=%s,depth=%d,top=%d,sort=%s"
-	    file depth top sort))))))
+        (if (and (string= file "./java.hprof")
+                 (equal depth 5)
+                 (equal top 20)
+                 (string= sort "a"))
+            (list "-Xhprof")
+          (list
+           (format
+            "-Xhprof:file=%s,depth=%d,top=%d,sort=%s"
+            file depth top sort))))))
 
 (defmethod jdee-db-verify-arg ((this jdee-db-debugger))
   ;; Set verify options.
   (let ((verify-all (nth 0 jdee-db-option-verify))
-	(verify-remote (nth 1 jdee-db-option-verify)))
+        (verify-remote (nth 1 jdee-db-option-verify)))
     (if verify-all
-	(list"-Xverify")
+        (list"-Xverify")
       ;      (if verify-remote
-      ;	  (list "-Xverifyremote"))
+      ;          (list "-Xverifyremote"))
       (if (and
-	   (not verify-all)
-	   (not verify-remote))
-	  (list "-Xnoverify")))))
+           (not verify-all)
+           (not verify-remote))
+          (list "-Xnoverify")))))
 
 
 (defmethod jdee-db-command-line-args ((this jdee-db-debugger))
@@ -1489,7 +1489,7 @@ command list."
   (if jdee-db-option-vm-args
       (mapcar
        (lambda (arg)
-	 arg)
+         arg)
        jdee-db-option-vm-args)))
 
 
@@ -1573,39 +1573,39 @@ buffer. This command creates a command buffer for the debug session."
       (jdee-bug-debug-app)
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     (let* ((debugger (jdee-db-get-the-debugger))
-	   (application-main-class
-	    (let ((main-class jdee-run-application-class))
-	      (if (or
-		   (not main-class)
-		   (string= main-class ""))
-		  (setq main-class
-			(if (buffer-file-name)
-			    (concat (jdee-parse-get-package)
-				    (file-name-sans-extension
-				     (file-name-nondirectory (buffer-file-name))))
-			  (read-string "Java class to debug: "))))
-	      main-class))
-	   (cmd-set (oref debugger cmd-set))
-	   (launch-cmd (oref cmd-set launch-app)))
+           (application-main-class
+            (let ((main-class jdee-run-application-class))
+              (if (or
+                   (not main-class)
+                   (string= main-class ""))
+                  (setq main-class
+                        (if (buffer-file-name)
+                            (concat (jdee-parse-get-package)
+                                    (file-name-sans-extension
+                                     (file-name-nondirectory (buffer-file-name))))
+                          (read-string "Java class to debug: "))))
+              main-class))
+           (cmd-set (oref debugger cmd-set))
+           (launch-cmd (oref cmd-set launch-app)))
 
 
       (jdee-db-create-debuggee-app debugger application-main-class)
 
       (if (not (oref debugger running-p))
-	  (jdee-db-debugger-start debugger))
+          (jdee-db-debugger-start debugger))
 
       (oset-default 'jdee-db-debugger the-debugger debugger)
 
       ;; Forward to the debugger any breakpoint requests made
       ;; by the user before launching the application.
       (if jdee-db-breakpoints
-	  (let ((bp-cmd (oref (oref debugger cmd-set) set-bp)))
-	    (oset
-	     bp-cmd
-	     breakpoints
-	     (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
-	    (jdee-db-exec-cmds debugger (list launch-cmd bp-cmd)))
-	(jdee-db-exec-cmd debugger launch-cmd)))))
+          (let ((bp-cmd (oref (oref debugger cmd-set) set-bp)))
+            (oset
+             bp-cmd
+             breakpoints
+             (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
+            (jdee-db-exec-cmds debugger (list launch-cmd bp-cmd)))
+        (jdee-db-exec-cmd debugger launch-cmd)))))
 
 (defun jdee-debugger-running-p ()
   "Returns nonnil if the debugger is running."
@@ -1615,23 +1615,23 @@ buffer. This command creates a command buffer for the debug session."
     (jdee-dbs-debugger-running-p)
     (jdee-dbs-get-target-process))
    (let ((debugger
-	  (if (slot-boundp (jdee-db-get-the-debugger) 'the-debugger)
-	      (oref (jdee-db-get-the-debugger) the-debugger))))
+          (if (slot-boundp (jdee-db-get-the-debugger) 'the-debugger)
+              (oref (jdee-db-get-the-debugger) the-debugger))))
     (and debugger
-	 (oref debugger running-p)))))
+         (oref debugger running-p)))))
 
 (defun jdee-debug-applet-init (applet-class applet-doc-path)
   (let* ((debugger (jdee-db-get-the-debugger))
-	 (cmd-set (oref debugger cmd-set))
-	 (launch-cmd (oref cmd-set launch-applet))
-	 (debug-buf-name (concat "*debug-" applet-class "*"))
-	 (applet-doc (file-name-nondirectory applet-doc-path))
-	 (applet-doc-directory (file-name-directory applet-doc-path))
-	 (source-directory default-directory)
-	 (working-directory
-	  (if applet-doc-directory
-	      applet-doc-directory
-	    source-directory)))
+         (cmd-set (oref debugger cmd-set))
+         (launch-cmd (oref cmd-set launch-applet))
+         (debug-buf-name (concat "*debug-" applet-class "*"))
+         (applet-doc (file-name-nondirectory applet-doc-path))
+         (applet-doc-directory (file-name-directory applet-doc-path))
+         (source-directory default-directory)
+         (working-directory
+          (if applet-doc-directory
+              applet-doc-directory
+            source-directory)))
 
     (jdee-db-create-debuggee-applet debugger applet-doc-path)
 
@@ -1640,12 +1640,12 @@ buffer. This command creates a command buffer for the debug session."
     ;; Forward to the debugger any breakpoint requests made
     ;; by the user before launching the application.
     (if jdee-db-breakpoints
-	(let ((bp-cmd (oref (oref debugger cmd-set) set-bp)))
-	  (oset
-	   bp-cmd
-	   breakpoints
-	   (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
-	  (jdee-db-exec-cmds debugger (list launch-cmd bp-cmd)))
+        (let ((bp-cmd (oref (oref debugger cmd-set) set-bp)))
+          (oset
+           bp-cmd
+           breakpoints
+           (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
+          (jdee-db-exec-cmds debugger (list launch-cmd bp-cmd)))
       (jdee-db-exec-cmd debugger launch-cmd))))
 
 
@@ -1654,12 +1654,12 @@ buffer. This command creates a command buffer for the debug session."
 (defun jdee-debug-applet-internal (applet-doc)
   (let ((applet-class jdee-run-application-class))
     (if (or
-	 (not applet-class)
-	 (string= applet-class ""))
-	(setq applet-class
-	      (concat (jdee-parse-get-package)
-		      (file-name-sans-extension
-		       (file-name-nondirectory (buffer-file-name))))))
+         (not applet-class)
+         (string= applet-class ""))
+        (setq applet-class
+              (concat (jdee-parse-get-package)
+                      (file-name-sans-extension
+                       (file-name-nondirectory (buffer-file-name))))))
     (jdee-debug-applet-init applet-class  applet-doc)))
 
 ;;;###autoload
@@ -1680,14 +1680,14 @@ file in the current buffer."
      (list (read-file-name "Applet doc: " nil nil nil jdee-run-applet-last-doc))))
   (setq jdee-run-applet-last-doc doc)
   (let ((applet-doc-path
-	 (if doc
-	     doc
-	   (if (and jdee-run-applet-doc
-		    (not (string= jdee-run-applet-doc "")))
-	       jdee-run-applet-doc
-	     (car (jdee-run-find-html-files))))))
+         (if doc
+             doc
+           (if (and jdee-run-applet-doc
+                    (not (string= jdee-run-applet-doc "")))
+               jdee-run-applet-doc
+             (car (jdee-run-find-html-files))))))
     (if applet-doc-path
-	(jdee-debug-applet-internal applet-doc-path)
+        (jdee-debug-applet-internal applet-doc-path)
       (signal 'error "Could not find html document to display applet."))))
 
 
@@ -1697,18 +1697,18 @@ file in the current buffer."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status running-p))
-	(error "Application %s is already running."
-	       (oref debuggee main-class))
+             (oref debuggee-status running-p))
+        (error "Application %s is already running."
+               (oref debuggee main-class))
       (let* ((cmd-set (oref debugger cmd-set))
-	     (run (oref cmd-set run)))
-	(oset debuggee-status running-p t)
-	(oset debuggee-status stopped-p nil)
-	(oset debuggee-status suspended-p nil)
-	(jdee-db-exec-cmd debugger run)))))
+             (run (oref cmd-set run)))
+        (oset debuggee-status running-p t)
+        (oset debuggee-status stopped-p nil)
+        (oset debuggee-status suspended-p nil)
+        (jdee-db-exec-cmd debugger run)))))
 
 
 (defun jdee-debug-cont ()
@@ -1717,19 +1717,19 @@ stopping point."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (or
-	      (oref debuggee-status stopped-p)
-	      (oref debuggee-status suspended-p)))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (cont (oref cmd-set cont)))
-	  (oset debuggee-status stopped-p nil)
-	  (oset debuggee-status suspended-p nil)
-	  (jdee-db-exec-cmd debugger cont))
+             (or
+              (oref debuggee-status stopped-p)
+              (oref debuggee-status suspended-p)))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (cont (oref cmd-set cont)))
+          (oset debuggee-status stopped-p nil)
+          (oset debuggee-status suspended-p nil)
+          (jdee-db-exec-cmd debugger cont))
       (let ((class (oref debuggee main-class)))
-	(message "Application %s is not stopped" class)))))
+        (message "Application %s is not stopped" class)))))
 
 
 (defun jdee-debug-quit ()
@@ -1737,63 +1737,63 @@ stopping point."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status running-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (quit (oref cmd-set quit)))
-	  (jdee-db-exec-cmd debugger quit))
+             (oref debuggee-status running-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (quit (oref cmd-set quit)))
+          (jdee-db-exec-cmd debugger quit))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not running" class)))))
+        (error "Application %s is not running" class)))))
 
 (defun jdee-debug-step-over ()
   "Step to the next line in the current stack frame."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (step-over (oref cmd-set step-over)))
-	  (oset debuggee-status stopped-p nil)
-	  (jdee-db-exec-cmd debugger step-over))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (step-over (oref cmd-set step-over)))
+          (oset debuggee-status stopped-p nil)
+          (jdee-db-exec-cmd debugger step-over))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-debug-step-into ()
   "Step to the next line in the current program."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (step-into (oref cmd-set step-into)))
-	  (oset debuggee-status stopped-p nil)
-	  (jdee-db-exec-cmd debugger step-into))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (step-into (oref cmd-set step-into)))
+          (oset debuggee-status stopped-p nil)
+          (jdee-db-exec-cmd debugger step-into))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-debug-step-out ()
   "Continue execution to the end of the current method."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (step-out (oref cmd-set step-out)))
-	  (oset debuggee-status stopped-p nil)
-	  (jdee-db-exec-cmd debugger step-out))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (step-out (oref cmd-set step-out)))
+          (oset debuggee-status stopped-p nil)
+          (jdee-db-exec-cmd debugger step-out))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 
 (defun jdee-debug-up ()
@@ -1801,45 +1801,45 @@ stopping point."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (up (oref cmd-set up)))
-	  (jdee-db-exec-cmd debugger up))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (up (oref cmd-set up)))
+          (jdee-db-exec-cmd debugger up))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-debug-down ()
   "Move down the stack."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (down (oref cmd-set down)))
-	  (jdee-db-exec-cmd debugger down))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (down (oref cmd-set down)))
+          (jdee-db-exec-cmd debugger down))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-debug-where ()
   "Show current stopping point."
   (interactive)
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       (where (oref cmd-set where)))
-	  (jdee-db-exec-cmd debugger where))
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               (where (oref cmd-set where)))
+          (jdee-db-exec-cmd debugger where))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-db-spec-breakpoint ()
   "Creates a specification for the breakpoint at the
@@ -1847,60 +1847,60 @@ current line in the current file. Returns an object of
 type `jdee-db-breakpoint'."
   (let ((file (buffer-file-name)))
     (setq jdee-db-breakpoint-id-counter
-	  (1+ jdee-db-breakpoint-id-counter))
+          (1+ jdee-db-breakpoint-id-counter))
     (jdee-db-breakpoint
      (format "breakpoint: %s %d"
-	     (file-name-nondirectory file)
-	     jdee-db-breakpoint-id-counter)
+             (file-name-nondirectory file)
+             jdee-db-breakpoint-id-counter)
      :id   jdee-db-breakpoint-id-counter
      :file file
      :class (concat (jdee-parse-get-package)
-		    (jdee-parse-get-class)))))
+                    (jdee-parse-get-class)))))
 
 (defun jdee-debug-set-breakpoint ()
   "Ask debugger to set a breakpoint at the current line
 in the current buffer."
   (interactive)
   (let* ((file (buffer-file-name))
-	 (line (jdee-get-line-at-point))
-	 (bp (jdee-db-find-breakpoint file line)))
+         (line (jdee-get-line-at-point))
+         (bp (jdee-db-find-breakpoint file line)))
     (unless bp
       (setq bp (jdee-db-spec-breakpoint))
       (oset bp line line)
       (jdee-db-breakpoints-add bp)
       (if (jdee-db-debuggee-running-p)
-	  (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-		 (bp-cmd (oref (oref debugger cmd-set) set-bp)))
-	    (oset bp-cmd breakpoints (list bp))
-	    (jdee-db-exec-cmd debugger bp-cmd))))))
+          (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                 (bp-cmd (oref (oref debugger cmd-set) set-bp)))
+            (oset bp-cmd breakpoints (list bp))
+            (jdee-db-exec-cmd debugger bp-cmd))))))
 
 (defun jdee-debug-clear-breakpoint()
   "Clear the breakpoint at the current line in the current buffer."
   (interactive)
   (jdee-assert-source-buffer)
   (let* ((file (buffer-file-name))
-	 (line (jdee-get-line-at-point))
-	 (bp (jdee-db-find-breakpoint file line)))
+         (line (jdee-get-line-at-point))
+         (bp (jdee-db-find-breakpoint file line)))
     (if bp
-	(if (jdee-db-debuggee-running-p)
-	    (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-		   (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
-	      (oset bp-cmd breakpoints (list bp))
-	      (jdee-db-exec-cmd debugger bp-cmd))
-	  (jdee-db-delete-breakpoint bp)))))
+        (if (jdee-db-debuggee-running-p)
+            (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                   (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
+              (oset bp-cmd breakpoints (list bp))
+              (jdee-db-exec-cmd debugger bp-cmd))
+          (jdee-db-delete-breakpoint bp)))))
 
 (defun jdee-debug-toggle-breakpoint ()
   "Sets or clears a breakpoint at the current line."
   (interactive)
   (assert (eq major-mode 'jdee-mode) nil
-	  "This command works only in a Java source buffer.")
+          "This command works only in a Java source buffer.")
   (let*  ((file (buffer-file-name))
-	  (line (jdee-get-line-at-point))
-	  (bp (jdee-db-find-breakpoint file line)))
+          (line (jdee-get-line-at-point))
+          (bp (jdee-db-find-breakpoint file line)))
     (assert (jdee-db-src-dir-matches-file-p file) nil
-	    "You cannot set a breakpoint in a file that is not in `jdee-sourcepath'.")
+            "You cannot set a breakpoint in a file that is not in `jdee-sourcepath'.")
     (if bp
-	(jdee-debug-clear-breakpoint)
+        (jdee-debug-clear-breakpoint)
       (jdee-debug-set-breakpoint))))
 
 (defun jdee-debug-clear-breakpoints()
@@ -1908,18 +1908,18 @@ in the current buffer."
   (interactive)
   (if jdee-db-breakpoints
       (if (jdee-db-debuggee-running-p)
-	  (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-		 (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
-	    (oset
-	     bp-cmd
-	     breakpoints
-	     (mapcar
-	      (lambda (assoc-x) (cdr assoc-x))
-	      jdee-db-breakpoints))
-	    (jdee-db-exec-cmd debugger bp-cmd))
-	(loop for bp-assoc in jdee-db-breakpoints do
-	      (let ((bp (cdr bp-assoc)))
-		(jdee-db-delete-breakpoint bp))))))
+          (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                 (bp-cmd (oref (oref debugger cmd-set) clear-bp)))
+            (oset
+             bp-cmd
+             breakpoints
+             (mapcar
+              (lambda (assoc-x) (cdr assoc-x))
+              jdee-db-breakpoints))
+            (jdee-db-exec-cmd debugger bp-cmd))
+        (loop for bp-assoc in jdee-db-breakpoints do
+              (let ((bp (cdr bp-assoc)))
+                (jdee-db-delete-breakpoint bp))))))
 
 
 (defvar jdee-db-minibuffer-local-map nil
@@ -1939,19 +1939,19 @@ in the current buffer."
   (if jdee-db-read-vm-args
       (jdee-run-parse-args
        (read-from-minibuffer
-	"Vm args: "
-	(car jdee-db-interactive-vm-arg-history)
-	nil nil
-	'jdee-db-interactive-vm-arg-history))))
+        "Vm args: "
+        (car jdee-db-interactive-vm-arg-history)
+        nil nil
+        'jdee-db-interactive-vm-arg-history))))
 
 (defun jdee-db-get-app-args-from-user ()
   (if jdee-db-read-app-args
       (jdee-run-parse-args
        (read-from-minibuffer
-	"Application args: "
-	(car jdee-db-interactive-app-arg-history)
-	nil nil
-	'jdee-db-interactive-app-arg-history))))
+        "Application args: "
+        (car jdee-db-interactive-app-arg-history)
+        nil nil
+        'jdee-db-interactive-app-arg-history))))
 
 (defun jdee-db-src-dir-matches-file-p (file)
   "Return non-nill if one of `jdee-sourcepath' matches `FILE'."

--- a/jdee-dbo.el
+++ b/jdee-dbo.el
@@ -69,10 +69,10 @@
 
 (defun jdee-dbo-make-thread-obj (thread-spec)
   (jdee-dbo-thread "thread"
-		  :id     (nth 1 thread-spec)
-		  :name   (nth 2 thread-spec)
-		  :state  (nth 3 thread-spec)
-		  :status (nth 4 thread-spec)))
+                  :id     (nth 1 thread-spec)
+                  :name   (nth 2 thread-spec)
+                  :state  (nth 3 thread-spec)
+                  :status (nth 4 thread-spec)))
 
 
 (defun jdee-dbo-command-result (id &rest args)
@@ -111,17 +111,17 @@ of optional error data."
   "Notifies resolution of breakpoint, watchpoint, or
 exception spec."
   (let* ((proc (jdee-dbs-get-process proc-id))
-	 (bpspec (if proc (jdee-dbs-proc-get-bpspec proc spec-id)))
-	 (bp (if bpspec (oref bpspec breakpoint)))
-	 (file (if bp (oref bp file)))
-	 (line (if bp (jdee-db-breakpoint-get-line bp))))
+         (bpspec (if proc (jdee-dbs-proc-get-bpspec proc spec-id)))
+         (bp (if bpspec (oref bpspec breakpoint)))
+         (file (if bp (oref bp file)))
+         (line (if bp (jdee-db-breakpoint-get-line bp))))
     (and proc file line
-	 (progn
-	   (oset bp status 'active)
-	   (jdee-db-mark-breakpoint-active file line)
-	   (jdee-dbs-proc-display-debug-message
-	    proc
-	    (format "Resolved breakpoint set in %s at line %s." file line))))))
+         (progn
+           (oset bp status 'active)
+           (jdee-db-mark-breakpoint-active file line)
+           (jdee-dbs-proc-display-debug-message
+            proc
+            (format "Resolved breakpoint set in %s at line %s." file line))))))
 
 (defun jdee-dbo-error (proc-id message)
   (jdee-dbs-display-debug-message proc-id message))
@@ -136,24 +136,24 @@ exception spec."
 
 (defun jdee-dbo-vm-start-event (process-id process-status process-state)
   (let* ((process (jdee-dbs-get-process process-id))
-	 (thread-id (nth 1 process-state))
-	 (thread-name (nth 2 process-state))
-	 (state (nth 3 process-state))
-	 (reason (nth 4 process-state)))
+         (thread-id (nth 1 process-state))
+         (thread-name (nth 2 process-state))
+         (state (nth 3 process-state))
+         (reason (nth 4 process-state)))
     (if process
-	(let ((state-info (oref process state-info)))
-	  (jdee-dbs-proc-state-info-set state-info state reason thread-id thread-name)
-	  (oset process startupp t)
-	  (jdee-dbs-proc-display-debug-message process "vm started...")
-	  (cond
-	   ((string= process-status "all")
-	    (jdee-dbs-proc-display-debug-message process "All threads suspended...")))
-	  ;; Sometimes the debugger is tardy responding to a launch command and thus the JDE thinks the
-	  ;; process is dead. In this case, move the process back to the registry and
-	  ;; make it the target process.
-	  (when (jdee-dbs-proc-set-contains-p jdee-dbs-the-process-morgue process)
-	    (jdee-dbs-proc-move-to-registry process)
-	    (oset jdee-dbs-the-process-registry :target-process process)))
+        (let ((state-info (oref process state-info)))
+          (jdee-dbs-proc-state-info-set state-info state reason thread-id thread-name)
+          (oset process startupp t)
+          (jdee-dbs-proc-display-debug-message process "vm started...")
+          (cond
+           ((string= process-status "all")
+            (jdee-dbs-proc-display-debug-message process "All threads suspended...")))
+          ;; Sometimes the debugger is tardy responding to a launch command and thus the JDE thinks the
+          ;; process is dead. In this case, move the process back to the registry and
+          ;; make it the target process.
+          (when (jdee-dbs-proc-set-contains-p jdee-dbs-the-process-morgue process)
+            (jdee-dbs-proc-move-to-registry process)
+            (oset jdee-dbs-the-process-registry :target-process process)))
       (message "Start Event Error: can't find process object for process id %d" process-id))))
 
 (defvar jdee-dbo-current-process nil "Used to keep track of the process
@@ -163,14 +163,14 @@ used in the last breakpoint hit event, and watch point hit event.")
 used in the last breakpoint hit event, and watch point hit event.")
 
 (defun jdee-dbo-break (process state-info state reason thread-id thread-name
-			      message proc-id class file line-no)
+                              message proc-id class file line-no)
   (jdee-dbs-proc-state-info-set state-info state reason
-			       thread-id thread-name)
+                               thread-id thread-name)
   (setq jdee-dbo-current-process process)
   (setq jdee-dbo-current-thread-id thread-id)
   (if jdee-bug-local-variables
     (jdee-dbo-update-locals-buf process
-			       thread-id 0))
+                               thread-id 0))
   (if jdee-bug-stack-info (jdee-dbo-update-stack process thread-id))
   (oset process steppablep t)
   (jdee-dbs-display-debug-message proc-id message)
@@ -195,11 +195,11 @@ used in the last breakpoint hit event, and watch point hit event.")
 Called after each folding/unfolding of the `tree-widget' TREE.
 See also the hook `tree-widget-after-toggle-fucntions'."
   (let ((node-name (widget-get tree :node-name))
-	(open      (widget-get tree :open)))
+        (open      (widget-get tree :open)))
     (if open
-	(add-to-list 'jdee-dbo-locals-open-nodes node-name)
+        (add-to-list 'jdee-dbo-locals-open-nodes node-name)
       (setq jdee-dbo-locals-open-nodes
-	    (delete node-name jdee-dbo-locals-open-nodes)))))
+            (delete node-name jdee-dbo-locals-open-nodes)))))
 
 
 (defun jdee-dbo-update-locals-buf (process thread frame)
@@ -208,34 +208,34 @@ See also the hook `tree-widget-after-toggle-fucntions'."
                :process process
                :thread-id thread
                :stack-frame-index frame))
-	 (locals (jdee-dbs-cmd-exec cmd))
-	 var)
+         (locals (jdee-dbs-cmd-exec cmd))
+         var)
 
     (with-current-buffer (oref process locals-buf)
       (kill-all-local-variables)
       (let ((inhibit-read-only t))
-	(erase-buffer))
+        (erase-buffer))
 
       (let ((all (overlay-lists)))
         (mapc 'delete-overlay (car all))
         (mapc 'delete-overlay (cdr all)))
 
       (add-hook 'tree-widget-after-toggle-functions
-		'jdee-dbo-locals-update-open-nodes nil t)
+                'jdee-dbo-locals-update-open-nodes nil t)
 
       (goto-char (point-min))
 
       ;; Insert the this object for this stack frame.
       (let* ((cmd (jdee-dbs-get-this
-		   "get this"
-		   :process process
-		   :thread-id thread
-		   :stack-frame-index frame))
-	     (this-obj (jdee-dbs-cmd-exec cmd)))
-	(if (not (typep this-obj 'jdee-dbs-java-null))
-	    (progn
-	      (let* ((id (oref this-obj :id))
-		     (open (concat "this" (number-to-string id))))
+                   "get this"
+                   :process process
+                   :thread-id thread
+                   :stack-frame-index frame))
+             (this-obj (jdee-dbs-cmd-exec cmd)))
+        (if (not (typep this-obj 'jdee-dbs-java-null))
+            (progn
+              (let* ((id (oref this-obj :id))
+                     (open (concat "this" (number-to-string id))))
                 (widget-create 'jdee-widget-java-obj
                                :tag "this"
                                :node-name open
@@ -245,99 +245,99 @@ See also the hook `tree-widget-after-toggle-fucntions'."
 
       ;; Insert the local variables for this stack frame.
       (dolist (local-var locals)
-	(jdee-dbo-view-var-in-buf (oref local-var value)
+        (jdee-dbo-view-var-in-buf (oref local-var value)
                                   (oref local-var name) process
                                   'jdee-dbo-locals-open-p (current-buffer))))))
 
 (defun jdee-dbo-update-stack (process thread-id)
   (let* ((cmd  (jdee-dbs-get-thread "get_thread"
-				   :process process
-				   :thread-id thread-id))
-	 (thread-info (jdee-dbs-cmd-exec cmd))
-	 (stack (nth 5 thread-info)))
+                                   :process process
+                                   :thread-id thread-id))
+         (thread-info (jdee-dbs-cmd-exec cmd))
+         (stack (nth 5 thread-info)))
     (oset process :stack stack)
     (oset process :stack-ptr 0)))
 
 (defun jdee-dbo-breakpoint-hit-event (process-id process-status process-state spec-id location a2 a3)
   (let ((process (jdee-dbs-get-process process-id)))
     (if process
-	(let ((class (nth 0 location))
-	      (file (nth 1 location))
-	      (line-no (nth 2 location))
-	      (thread-id (nth 1 process-state))
-	      (thread-name (nth 2 process-state))
-	      (state (nth 3 process-state))
-	      (reason (nth 4 process-state))
-	      (state-info (oref process state-info)))
-	  (if state-info
-	      (jdee-dbo-break process state-info state reason thread-id
-			     thread-name
-			     (format "Breakpoint hit at line %d in %s (%s) on thread %s. All threads suspended." line-no class file thread-name)
-			     process-id class file line-no)
-	    (message "Breakpoint hit event error: state info object missing for process %d." process-id)))
+        (let ((class (nth 0 location))
+              (file (nth 1 location))
+              (line-no (nth 2 location))
+              (thread-id (nth 1 process-state))
+              (thread-name (nth 2 process-state))
+              (state (nth 3 process-state))
+              (reason (nth 4 process-state))
+              (state-info (oref process state-info)))
+          (if state-info
+              (jdee-dbo-break process state-info state reason thread-id
+                             thread-name
+                             (format "Breakpoint hit at line %d in %s (%s) on thread %s. All threads suspended." line-no class file thread-name)
+                             process-id class file line-no)
+            (message "Breakpoint hit event error: state info object missing for process %d." process-id)))
       (message "Breakpoint hit event error: process object for process %d is missing." process-id))))
 
 (defun jdee-dbo-step-event (proc-id status process-state location)
   "Handler for step events."
   (let ((process (jdee-dbs-get-process proc-id)))
     (if process
-	(let ((class (nth 0 location))
-	      (file (nth 1 location))
-	      (line-no (nth 2 location))
-	      (thread-id (nth 1 process-state))
-	      (thread-name (nth 2 process-state))
-	      (state (nth 3 process-state))
-	      (reason (nth 4 process-state))
-	      (state-info (oref process state-info)))
-	  (if state-info
-	    (jdee-dbo-break process state-info state reason thread-id
-			   thread-name
-			   (format "Stepped to line %d in %s (%s) on thread %s. All threads suspended."
-				   line-no class file thread-name)
-			   proc-id class file line-no)
-	    (message "Step event error: state info missing for process %d" proc-id)))
+        (let ((class (nth 0 location))
+              (file (nth 1 location))
+              (line-no (nth 2 location))
+              (thread-id (nth 1 process-state))
+              (thread-name (nth 2 process-state))
+              (state (nth 3 process-state))
+              (reason (nth 4 process-state))
+              (state-info (oref process state-info)))
+          (if state-info
+            (jdee-dbo-break process state-info state reason thread-id
+                           thread-name
+                           (format "Stepped to line %d in %s (%s) on thread %s. All threads suspended."
+                                   line-no class file thread-name)
+                           proc-id class file line-no)
+            (message "Step event error: state info missing for process %d" proc-id)))
       (message "Step event error: could not find process %d." proc-id))))
 
 
 (defun jdee-dbo-exception-event (proc-id status process-state spec-id exception-spec a3)
   (let ((process (jdee-dbs-get-process proc-id)))
     (if process
-	(let ((exception-class (nth 0 exception-spec))
-	      (exception-object (nth 1 exception-spec))
-	      (thread-id (nth 1 process-state))
-	      (thread-name (nth 2 process-state))
-	      (state (nth 3 process-state))
-	      (reason (nth 4 process-state))
-	      (location (nth 5 process-state))
-	      (state-info (oref process state-info)))
-	  (if (not (equal status "none"))
-	    ;; Then it's a break, not a trace
-	    (let ((class (nth 1 (car location)))
-		  (file (nth 2 (car location)))
-		  (line-no (nth 3 (car location))))
-		  (if state-info
-		    (jdee-dbo-break process state-info state reason thread-id
-				   thread-name
-				   (format "Exception encountered at line %d in %s (%s) on thread %s. All threads suspended."
-					   line-no class file thread-name)
-				   proc-id class file line-no)
-		    (message "Exception event error: state info missing for process %d" proc-id)))
-	  (jdee-dbs-display-debug-message
-	   proc-id
-	   (format "Exception of class %s occurred on thread %s"
-			 exception-class thread-name)))))))
+        (let ((exception-class (nth 0 exception-spec))
+              (exception-object (nth 1 exception-spec))
+              (thread-id (nth 1 process-state))
+              (thread-name (nth 2 process-state))
+              (state (nth 3 process-state))
+              (reason (nth 4 process-state))
+              (location (nth 5 process-state))
+              (state-info (oref process state-info)))
+          (if (not (equal status "none"))
+            ;; Then it's a break, not a trace
+            (let ((class (nth 1 (car location)))
+                  (file (nth 2 (car location)))
+                  (line-no (nth 3 (car location))))
+                  (if state-info
+                    (jdee-dbo-break process state-info state reason thread-id
+                                   thread-name
+                                   (format "Exception encountered at line %d in %s (%s) on thread %s. All threads suspended."
+                                           line-no class file thread-name)
+                                   proc-id class file line-no)
+                    (message "Exception event error: state info missing for process %d" proc-id)))
+          (jdee-dbs-display-debug-message
+           proc-id
+           (format "Exception of class %s occurred on thread %s"
+                         exception-class thread-name)))))))
 
 
 (defun jdee-dbo-vm-disconnected-event (process-id process-status thread)
   (let ((process (jdee-dbs-get-process process-id)))
     (when process
-	(jdee-dbs-proc-display-debug-message process "vm disconnected...")
-	(setq overlay-arrow-position nil)
-	(jdee-db-set-all-breakpoints-specified)
-	(jdee-dbs-proc-set-state process "vm disconnected")
-	(when (jdee-dbs-proc-set-contains-p jdee-dbs-the-process-registry process)
-	  (jdee-dbs-proc-move-to-morgue process)
-	  (slot-makeunbound jdee-dbs-the-process-registry :target-process)))))
+        (jdee-dbs-proc-display-debug-message process "vm disconnected...")
+        (setq overlay-arrow-position nil)
+        (jdee-db-set-all-breakpoints-specified)
+        (jdee-dbs-proc-set-state process "vm disconnected")
+        (when (jdee-dbs-proc-set-contains-p jdee-dbs-the-process-registry process)
+          (jdee-dbs-proc-move-to-morgue process)
+          (slot-makeunbound jdee-dbs-the-process-registry :target-process)))))
 
 (defun jdee-dbo-invalid-break (process-id arg2 reason)
   (jdee-dbs-proc-display-debug-message
@@ -346,7 +346,7 @@ See also the hook `tree-widget-after-toggle-fucntions'."
 
 (defun jdee-dbo-vm-death-event (process-id process-status thread)
   (let* ((process (jdee-dbs-get-process process-id))
-	 (main-class (oref process main-class)))
+         (main-class (oref process main-class)))
     (jdee-dbs-proc-display-debug-message
      process
      (format "%s process ended." main-class))
@@ -357,146 +357,146 @@ See also the hook `tree-widget-after-toggle-fucntions'."
 
 (defclass jdee-dbo-method ()
   ((class    :initarg :class
-	     :type string)
+             :type string)
    (name     :initarg :name
-	     :type string)
+             :type string)
    (returns  :initarg :returns
-	     :type string)
+             :type string)
    (args     :initarg :args
-	     :type list)
+             :type list)
    (kind     :initarg :kind
-	     :type string))
+             :type string))
   "Method")
 
 (defmethod jdee-dbo-to-string ((this jdee-dbo-method))
   (format "<%s %s.%s(%s)>"
-	  (oref this :returns)
-	  (oref this :class)
-	  (oref this :name)
-	  (mapconcat (lambda (x) x) (oref this :args) ",")))
+          (oref this :returns)
+          (oref this :class)
+          (oref this :name)
+          (mapconcat (lambda (x) x) (oref this :args) ",")))
 
 (defun jdee-dbo-make-method (spec)
   (let ((m
-	 (jdee-dbo-method "method"
-			 :class   (nth 0 spec)
-			 :name    (nth 1 spec)
-			 :returns (nth 2 spec)
-			 :args    (nth 3 spec))))
+         (jdee-dbo-method "method"
+                         :class   (nth 0 spec)
+                         :name    (nth 1 spec)
+                         :returns (nth 2 spec)
+                         :args    (nth 3 spec))))
     (if (nth 4 spec)
-	(oset m :kind (nth 4 spec)))
+        (oset m :kind (nth 4 spec)))
     m))
 
 (defun jdee-dbo-class-prepare-event (process-id process-status thread-spec class-name)
   (let* ((thread (jdee-dbo-make-thread-obj thread-spec))
-	 (process (jdee-dbs-get-process process-id)))
+         (process (jdee-dbs-get-process process-id)))
     (jdee-dbs-proc-display-debug-message
      process
      (format "Preparing class %s.\n  Thread: %s. Status: %s.\n"
-	     class-name
-	     (oref thread name)
-	     (oref thread status)))))
+             class-name
+             (oref thread name)
+             (oref thread status)))))
 
 (defun jdee-dbo-class-unload-event (process-id process-status thread-spec class-name)
   (let* ((thread (jdee-dbo-make-thread-obj thread-spec))
-	 (process (jdee-dbs-get-process process-id)))
+         (process (jdee-dbs-get-process process-id)))
     (jdee-dbs-proc-display-debug-message
      process
      (format "Unloading class %s.\n  Thread: %s. Status: %s.\n"
-	     class-name
-	     (oref thread name)
-	     (oref thread status)))))
+             class-name
+             (oref thread name)
+             (oref thread status)))))
 
 (defun jdee-dbo-method-entry-event (process-id process-status thread-spec method-spec)
   (let* ((thread (jdee-dbo-make-thread-obj thread-spec))
-	 (method (jdee-dbo-make-method method-spec))
-	 (method-sig (jdee-dbo-to-string method))
-	 (process (jdee-dbs-get-process process-id)))
+         (method (jdee-dbo-make-method method-spec))
+         (method-sig (jdee-dbo-to-string method))
+         (process (jdee-dbs-get-process process-id)))
     (jdee-dbs-proc-display-debug-message
      process
      (format "Entering %s.%s\n  Thread: %s\n  Signature: %s\n"
-	     (oref method class)
-	     (oref method name)
-	     (oref thread name)
-	     method-sig))))
+             (oref method class)
+             (oref method name)
+             (oref thread name)
+             method-sig))))
 
 (defun jdee-dbo-method-exit-event (process-id process-status thread-spec method-spec)
   (let* ((thread (jdee-dbo-make-thread-obj thread-spec))
-	 (method (jdee-dbo-make-method method-spec))
-	 (method-sig (jdee-dbo-to-string method))
-	 (process (jdee-dbs-get-process process-id)))
+         (method (jdee-dbo-make-method method-spec))
+         (method-sig (jdee-dbo-to-string method))
+         (process (jdee-dbs-get-process process-id)))
     (jdee-dbs-proc-display-debug-message
      process
      (format "Exiting %s.%s\n  Thread: %s\n  Signature: %s\n"
-	     (oref method class)
-	     (oref method name)
-	     (oref thread name)
-	     method-sig))))
+             (oref method class)
+             (oref method name)
+             (oref thread name)
+             method-sig))))
 
 (defun jdee-dbo-watchpoint-hit-event (process-id process-status thread-spec request-id &rest data)
   (let ((process (jdee-dbs-get-process process-id)))
     (if process
-	(let* ((thread (jdee-dbo-make-thread-obj thread-spec))
-	       (thread-id (oref thread id))
-	       (thread-name (oref thread name))
-	       (thread-state (oref thread state))
-	       (thread-status (oref thread status))
+        (let* ((thread (jdee-dbo-make-thread-obj thread-spec))
+               (thread-id (oref thread id))
+               (thread-name (oref thread name))
+               (thread-state (oref thread state))
+               (thread-status (oref thread status))
 
-	       ;; Object whose field was accessed or modified.
-	       (obj-spec (nth 0 data))
-	       (obj-class (nth 0 obj-spec))
-	       (obj-id (nth 1 obj-spec))
-	       (obj-gc-flag  (nth 2 obj-spec))
-	       ;; Field that was accessed or modified.
-	       (field-spec (nth 1 data))
-	       (field-decl (nth 0 field-spec))
-	       (field-name (nth 0 field-decl))
-	       (field-type (nth 1 field-decl))
-	       (field-qual (if (> (length field-decl) 3) (nth 2 field-decl)))
-	       (field-value-type (nth 1 field-spec))
-	       (field-value (nth 2 field-spec))
-	       ;; Breakpoint data
-	       (breakpoint-spec (nth 2 data))
-	       (breakpoint-class (nth 0 breakpoint-spec))
-	       (breakpoint-file (nth 1 breakpoint-spec))
-	       (breakpoint-line (nth 2 breakpoint-spec))
-	       ;; Object match data
-	       (obj-match (nth 3 data))
-	       ;; Thread match data
-	       (thread-match (nth 4 data))
-	       ;; Expression true data
-	       (expression-true (nth 5 data)))
+               ;; Object whose field was accessed or modified.
+               (obj-spec (nth 0 data))
+               (obj-class (nth 0 obj-spec))
+               (obj-id (nth 1 obj-spec))
+               (obj-gc-flag  (nth 2 obj-spec))
+               ;; Field that was accessed or modified.
+               (field-spec (nth 1 data))
+               (field-decl (nth 0 field-spec))
+               (field-name (nth 0 field-decl))
+               (field-type (nth 1 field-decl))
+               (field-qual (if (> (length field-decl) 3) (nth 2 field-decl)))
+               (field-value-type (nth 1 field-spec))
+               (field-value (nth 2 field-spec))
+               ;; Breakpoint data
+               (breakpoint-spec (nth 2 data))
+               (breakpoint-class (nth 0 breakpoint-spec))
+               (breakpoint-file (nth 1 breakpoint-spec))
+               (breakpoint-line (nth 2 breakpoint-spec))
+               ;; Object match data
+               (obj-match (nth 3 data))
+               ;; Thread match data
+               (thread-match (nth 4 data))
+               ;; Expression true data
+               (expression-true (nth 5 data)))
 
-	  (jdee-dbs-proc-display-debug-message
-	   process
-	   (format "<%s:%s> accessed or modified at line %s in %s.\n  Watched field: %s %s %s = %s\n"
-		   obj-class obj-id breakpoint-line breakpoint-file
-		   (if field-qual field-qual "") field-type field-name field-value))
+          (jdee-dbs-proc-display-debug-message
+           process
+           (format "<%s:%s> accessed or modified at line %s in %s.\n  Watched field: %s %s %s = %s\n"
+                   obj-class obj-id breakpoint-line breakpoint-file
+                   (if field-qual field-qual "") field-type field-name field-value))
 
-	  (if (string= thread-status "suspended by debugger")
-	      (let ((state-info (oref process state-info)))
-		(if state-info
-		    (progn
-		      (jdee-dbs-proc-state-info-set
-		       state-info thread-state
-		       thread-status thread-id thread-name)
-		      (setq jdee-dbo-current-process process)
-		      (setq jdee-dbo-current-thread-id thread-id)
-		      (if jdee-bug-local-variables
-			  (jdee-dbo-update-locals-buf process
-						     thread-id 0))
-		      (if jdee-bug-stack-info (jdee-dbo-update-stack process
-								   thread-id))
-		      (oset process steppablep t)
-		      (jdee-db-set-debug-cursor breakpoint-class breakpoint-file
-					 breakpoint-line)
-		      (when jdee-bug-raise-frame-p (raise-frame))
+          (if (string= thread-status "suspended by debugger")
+              (let ((state-info (oref process state-info)))
+                (if state-info
+                    (progn
+                      (jdee-dbs-proc-state-info-set
+                       state-info thread-state
+                       thread-status thread-id thread-name)
+                      (setq jdee-dbo-current-process process)
+                      (setq jdee-dbo-current-thread-id thread-id)
+                      (if jdee-bug-local-variables
+                          (jdee-dbo-update-locals-buf process
+                                                     thread-id 0))
+                      (if jdee-bug-stack-info (jdee-dbo-update-stack process
+                                                                   thread-id))
+                      (oset process steppablep t)
+                      (jdee-db-set-debug-cursor breakpoint-class breakpoint-file
+                                         breakpoint-line)
+                      (when jdee-bug-raise-frame-p (raise-frame))
 
-		      (jdee-dbs-display-debug-message
-		       process-id
-		       (format "Stopping at line %d in %s (%s) on thread %s."
-			       breakpoint-line breakpoint-class breakpoint-file thread-name)))
-		  (message "Watchpoint event error: state info object missing for process %d."
-			   process-id)))))
+                      (jdee-dbs-display-debug-message
+                       process-id
+                       (format "Stopping at line %d in %s (%s) on thread %s."
+                               breakpoint-line breakpoint-class breakpoint-file thread-name)))
+                  (message "Watchpoint event error: state info object missing for process %d."
+                           process-id)))))
       (message "Watchpoint event error: process object for process %d is missing." process-id))))
 
 
@@ -507,13 +507,13 @@ The remaining elements are arguments to pass to the handler."
    (mapc
     (lambda (event)
       (let ((handler (car event))
-	   (args (cdr event)))
-	(apply handler
-	       (append (list process-id process-status thread) args))))
+           (args (cdr event)))
+        (apply handler
+               (append (list process-id process-status thread) args))))
     events))
 
 (defun jdee-dbo-view-var-in-buf (var-value name process open buf
-					  &optional clear)
+                                          &optional clear)
   "Create a tree-widget representing variable VAR-VALUE (a
   jdee-dbs-java-null/primitive/udci type), whose name is NAME and in
   process PROCESS, and place that tree-widget in buffer BUF.  OPEN is
@@ -526,53 +526,53 @@ The remaining elements are arguments to pass to the handler."
     (when clear
       (erase-buffer))
     (let* ((var-tag (format "%s %s [id: %s]" (oref var-value jtype) name
-			   (if (or (typep var-value 'jdee-dbs-java-primitive)
-				    (typep var-value 'jdee-dbs-java-null))
-			     "-"
-			     (oref var-value id))))
-	  (openp (if (functionp open)
-		   (funcall open var-tag)
-		   open)))
+                           (if (or (typep var-value 'jdee-dbs-java-primitive)
+                                    (typep var-value 'jdee-dbs-java-null))
+                             "-"
+                             (oref var-value id))))
+          (openp (if (functionp open)
+                   (funcall open var-tag)
+                   open)))
       (cond
-	((typep var-value 'jdee-dbs-java-udci)
-	  (if (string= (oref var-value :jtype) "java.lang.String")
-	    (let* ((cmd (jdee-dbs-get-string
-			 "get string"
-			 :process process
-			 :object-id (oref var-value id)))
-		   (str-val (jdee-dbs-cmd-exec cmd)))
-	      (widget-create 'tree-widget
-			     :tag var-tag
-			     :node-name var-tag
-			     :open openp
-			     :value t
-			     (list 'tree-widget :tag str-val)))
-	    (widget-create 'jdee-widget-java-obj
-			   :tag var-tag
-			   :node-name var-tag
-			   :open openp
-			   :process process
-			   :object-id (oref var-value :id))))
-	   ((typep var-value 'jdee-dbs-java-array)
-	    (widget-create 'jdee-widget-java-array
-			   :tag var-tag
-			   :node-name var-tag
-			   :open openp
-			   :process process
-			   :object var-value))
-	   ((typep var-value 'jdee-dbs-java-primitive)
-	    (widget-create 'tree-widget
-			   :tag var-tag
-			   :node-name var-tag
-			   :open openp
-			   :value t
-			   (list 'tree-widget
-				 :tag (format "%s" (oref var-value value)))))
-	   ((typep var-value 'jdee-dbs-java-null)
-	    (widget-create 'tree-widget :tag var-tag :value t
-			   (list 'tree-widget :tag "null")))
-	   (t
-	    (error "Unidentified type of variable: %s" var-tag))))
+        ((typep var-value 'jdee-dbs-java-udci)
+          (if (string= (oref var-value :jtype) "java.lang.String")
+            (let* ((cmd (jdee-dbs-get-string
+                         "get string"
+                         :process process
+                         :object-id (oref var-value id)))
+                   (str-val (jdee-dbs-cmd-exec cmd)))
+              (widget-create 'tree-widget
+                             :tag var-tag
+                             :node-name var-tag
+                             :open openp
+                             :value t
+                             (list 'tree-widget :tag str-val)))
+            (widget-create 'jdee-widget-java-obj
+                           :tag var-tag
+                           :node-name var-tag
+                           :open openp
+                           :process process
+                           :object-id (oref var-value :id))))
+           ((typep var-value 'jdee-dbs-java-array)
+            (widget-create 'jdee-widget-java-array
+                           :tag var-tag
+                           :node-name var-tag
+                           :open openp
+                           :process process
+                           :object var-value))
+           ((typep var-value 'jdee-dbs-java-primitive)
+            (widget-create 'tree-widget
+                           :tag var-tag
+                           :node-name var-tag
+                           :open openp
+                           :value t
+                           (list 'tree-widget
+                                 :tag (format "%s" (oref var-value value)))))
+           ((typep var-value 'jdee-dbs-java-null)
+            (widget-create 'tree-widget :tag var-tag :value t
+                           (list 'tree-widget :tag "null")))
+           (t
+            (error "Unidentified type of variable: %s" var-tag))))
     (use-local-map widget-keymap)
     (widget-setup)))
 

--- a/jdee-dbs.el
+++ b/jdee-dbs.el
@@ -92,28 +92,28 @@ debugger is starting and nil when it is quitting.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-proc-set ()
   ((proc-alist     :initarg :proc-alist
-		   :type list
-		   :initform nil
-		   :documentation
-		   "List of active debugee processes"))
+                   :type list
+                   :initform nil
+                   :documentation
+                   "List of active debugee processes"))
   "Class of debuggee process sets.")
 
 (defmethod jdee-dbs-proc-set-add ((this jdee-dbs-proc-set) process)
   "Adds a process to this debuggee process set."
   (oset this :proc-alist
-	(cons
-	 (cons (oref process :id) process)
-	 (oref this :proc-alist))))
+        (cons
+         (cons (oref process :id) process)
+         (oref this :proc-alist))))
 
 (defmethod jdee-dbs-proc-set-remove ((this jdee-dbs-proc-set) process)
   (oset this :proc-alist
-	(cl-remove-if
-	 (lambda (assoc-x)
-	   (let* ((xproc (cdr assoc-x))
-		  (xid (oref xproc id))
-		  (id (oref process id)))
-	     (equal xid id)))
-	 (oref this proc-alist))))
+        (cl-remove-if
+         (lambda (assoc-x)
+           (let* ((xproc (cdr assoc-x))
+                  (xid (oref xproc id))
+                  (id (oref process id)))
+             (equal xid id)))
+         (oref this proc-alist))))
 
 (defmethod jdee-dbs-proc-set-get-proc ((this jdee-dbs-proc-set) id)
   (cdr (assq id (oref this :proc-alist))))
@@ -122,10 +122,10 @@ debugger is starting and nil when it is quitting.")
   "Finds the process in the set whose FIELD is equal to VALUE."
   (if (slot-boundp this :proc-alist)
       (cdr (cl-find-if
-	(lambda (assoc-x)
-	  (let ((process-x (cdr assoc-x)))
-	    (equal (eieio-oref process-x field) value)))
-	(oref this :proc-alist)))))
+        (lambda (assoc-x)
+          (let ((process-x (cdr assoc-x)))
+            (equal (eieio-oref process-x field) value)))
+        (oref this :proc-alist)))))
 
 (defmethod jdee-dbs-proc-set-contains-p ((this jdee-dbs-proc-set) process)
   (assq (oref process :id) (oref this :proc-alist)))
@@ -144,9 +144,9 @@ debugger is starting and nil when it is quitting.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-proc-registry (jdee-dbs-proc-set)
   ((target-process :initarg :target-process
-		   :type jdee-dbs-proc
-		   :documentation
-		   "Process that currently has the debugger command focus."))
+                   :type jdee-dbs-proc
+                   :documentation
+                   "Process that currently has the debugger command focus."))
   "Class of process registries.")
 
 
@@ -154,18 +154,18 @@ debugger is starting and nil when it is quitting.")
   "Sets process specified by ID to be the target process. If ID is not specified, the first
 registered process becomes the target process"
   (let ((target-process
-	  (if id
-	      (let ((process (jdee-dbs-proc-set-get-proc this id)))
-		(if process
-		    (if (jdee-dbs-proc-set-contains-p this process)
-			process
-		      (message "Error: process %s is dead." id)
-		      nil)
-		  (message "Error: process %s does not exist." id)
-		  nil))
-	    (let ((existing-processes
-		   (oref jdee-dbs-the-process-registry :proc-alist)))
-	      (if existing-processes (cdr (nth 0 existing-processes)))))))
+          (if id
+              (let ((process (jdee-dbs-proc-set-get-proc this id)))
+                (if process
+                    (if (jdee-dbs-proc-set-contains-p this process)
+                        process
+                      (message "Error: process %s is dead." id)
+                      nil)
+                  (message "Error: process %s does not exist." id)
+                  nil))
+            (let ((existing-processes
+                   (oref jdee-dbs-the-process-registry :proc-alist)))
+              (if existing-processes (cdr (nth 0 existing-processes)))))))
     (when target-process
       (oset this target-process target-process)
       (set-window-configuration (oref target-process win-cfg)))
@@ -196,10 +196,10 @@ concerning them." )
   (mapc
    (lambda (dead-proc-assoc)
      (let* ((dead-proc (cdr dead-proc-assoc))
-	    (cli-buffer (if (slot-boundp dead-proc 'cli-buf) (oref dead-proc cli-buf)))
-	    (msg-buffer (if (slot-boundp dead-proc 'msg-buf) (oref dead-proc msg-buf)))
-	    (locals-buffer (if (slot-boundp dead-proc 'locals-buf) (oref dead-proc locals-buf)))
-	    (threads-buffer (if (slot-boundp dead-proc 'threads-buf) (oref dead-proc threads-buf))))
+            (cli-buffer (if (slot-boundp dead-proc 'cli-buf) (oref dead-proc cli-buf)))
+            (msg-buffer (if (slot-boundp dead-proc 'msg-buf) (oref dead-proc msg-buf)))
+            (locals-buffer (if (slot-boundp dead-proc 'locals-buf) (oref dead-proc locals-buf)))
+            (threads-buffer (if (slot-boundp dead-proc 'threads-buf) (oref dead-proc threads-buf))))
        (if cli-buffer (kill-buffer cli-buffer))
        (if msg-buffer (kill-buffer msg-buffer))
        (if locals-buffer (kill-buffer locals-buffer))
@@ -220,9 +220,9 @@ the debugger ceases sending messages concerning them.")
 "Get the process whose id is ID. This function looks first in the process registry
 and then in the process morgue for the process."
   (let ((process
-	 (jdee-dbs-proc-set-get-proc jdee-dbs-the-process-registry id)))
+         (jdee-dbs-proc-set-get-proc jdee-dbs-the-process-registry id)))
     (if (not process)
-	(setq process (jdee-dbs-proc-set-get-proc jdee-dbs-the-process-morgue id)))
+        (setq process (jdee-dbs-proc-set-get-proc jdee-dbs-the-process-morgue id)))
     process))
 
 
@@ -241,7 +241,7 @@ and then in the process morgue for the process."
 
 
 (defmethod jdee-dbs-proc-state-info-set ((this jdee-dbs-proc-state-info)
-					state reason thread-id thread-name)
+                                        state reason thread-id thread-name)
   (oset this reason reason)
   (oset this state state)
   (oset this thread-id thread-id)
@@ -256,13 +256,13 @@ and then in the process morgue for the process."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-proc-bpspec ()
   ((id         :initarg :id
-	       :type integer
-	       :documentation
-	       "Id assigned to this breakpoint by the debugger.")
+               :type integer
+               :documentation
+               "Id assigned to this breakpoint by the debugger.")
    (breakpoint :initarg :breakpoint
-	       :type jdee-db-breakpoint
-	       :documentation
-	       "Instance of `jdee-db-breakpoint'.")
+               :type jdee-db-breakpoint
+               :documentation
+               "Instance of `jdee-db-breakpoint'.")
    (resolved   :initarg :resolved))
   (:allow-nil-initform t)
   "Class of breakpoint specifications. A breakpoint specification contains
@@ -282,8 +282,8 @@ process-specific information about a breakpoint")
 (defun jdee-dbs-proc-bpspecs-remove (bpspecs bpspec)
   "Removes BPSPEC from BPSPECS"
   (cl-remove-if (lambda (x)
-	       (equal (car x) (oref bpspec id) ))
-	     bpspecs))
+               (equal (car x) (oref bpspec id) ))
+             bpspecs))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                                            ;;
@@ -292,26 +292,26 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-request ()
   ((id                  :initarg :id
-			:type integer
-			:documentation
-			"Trace request id")
+                        :type integer
+                        :documentation
+                        "Trace request id")
    (suspend-policy      :initarg :suspend-policy
-			:type string
-			:initform "none"
-			:documentation
-			"Valid values are all (all threads), thread (current thread), or none")
+                        :type string
+                        :initform "none"
+                        :documentation
+                        "Valid values are all (all threads), thread (current thread), or none")
    (inclusion-filters   :initarg :inclusion-filters
-			:type list
-			:documentation
-			"List of regular expressions specifying classes to include in trace.")
+                        :type list
+                        :documentation
+                        "List of regular expressions specifying classes to include in trace.")
    (exclusion-filters   :initarg :exclusion-filters
-			:type list
-			:documentation
-			"List of regular expressions specifying classes to exclude from trace.")
+                        :type list
+                        :documentation
+                        "List of regular expressions specifying classes to exclude from trace.")
    (cancel-command      :initarg :cancel-command
-			:type string
-			:documentation
-			"Name of command used to cancel this request.")
+                        :type string
+                        :documentation
+                        "Name of command used to cancel this request.")
    )
 "Super class of trace requests."
 )
@@ -324,14 +324,14 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-methods-request (jdee-dbs-trace-request)
    ((trace-type         :initarg :trace-type
-			:type string
-			:initform "entry"
-			:documentation
-			"Entry or exit.")
+                        :type string
+                        :initform "entry"
+                        :documentation
+                        "Entry or exit.")
    (thread-restriction  :initarg :thread-restriction
-			:type string
-			:documentation
-			"Thread to trace."))
+                        :type string
+                        :documentation
+                        "Thread to trace."))
    "Trace methods request."
 )
 
@@ -348,10 +348,10 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-classes-request (jdee-dbs-trace-request)
    ((trace-type         :initarg :trace-type
-			:type string
-			:initform "preparation"
-			:documentation
-			"Valid values are preparation or unloading."))
+                        :type string
+                        :initform "preparation"
+                        :documentation
+                        "Valid values are preparation or unloading."))
    "Trace classes request."
 )
 
@@ -368,14 +368,14 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-exceptions-request (jdee-dbs-trace-request)
   ((exception-class    :initarg :exception-class
-		       :type string
-		       :documentation
-		       "Class of exceptions to trace. Can be a wild card pattern.")
+                       :type string
+                       :documentation
+                       "Class of exceptions to trace. Can be a wild card pattern.")
    (trace-type         :initarg :trace-type
-		       :type string
-		       :initform "both"
-		       :documentation
-			"Valid values are caught, uncaught, or both."))
+                       :type string
+                       :initform "both"
+                       :documentation
+                        "Valid values are caught, uncaught, or both."))
    "Trace exceptions request."
 )
 
@@ -392,25 +392,25 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-watch-field-request (jdee-dbs-trace-request)
   ((watch-type         :initarg :watch-type
-		       :type string
-		       :documentation
-		       "Valid values are \"access\" and \"modification\".")
+                       :type string
+                       :documentation
+                       "Valid values are \"access\" and \"modification\".")
    (object-class       :initarg :object-class
-		       :type string
-		       :documentation
-		       "Class of object to watch. Can be a wild card pattern.")
+                       :type string
+                       :documentation
+                       "Class of object to watch. Can be a wild card pattern.")
    (field-name         :initarg :field-name
-		       :type string
-		       :documentation
-			"Name of field to watch.")
+                       :type string
+                       :documentation
+                        "Name of field to watch.")
    (expression         :initarg :expression
-		       :type string
-		       :documentation
-		       "Boolean expression that must be satisfied to suspend execution.")
+                       :type string
+                       :documentation
+                       "Boolean expression that must be satisfied to suspend execution.")
    (object-id          :initarg :object-id
-		       :type string
-		       :documentation
-		       "Id of object to watch."))
+                       :type string
+                       :documentation
+                       "Id of object to watch."))
    "Watch field request."
 )
 
@@ -423,15 +423,15 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-proc-status (jdee-db-debuggee-status)
    ((startup-p     :initarg :startupp
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "Non-nil if this process is in the startup state.")
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "Non-nil if this process is in the startup state.")
     (steppable-p  :initarg :steppablep
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "Non-nil if this process can be single-stepped."))
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "Non-nil if this process can be single-stepped."))
   "Status of process being debugged with JDEbug.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -441,87 +441,87 @@ process-specific information about a breakpoint")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-proc (jdee-db-debuggee-app)
   ((id            :initarg :id
-		  :type integer
-		  :documentation
-		  "Id assigned by the JDE.")
+                  :type integer
+                  :documentation
+                  "Id assigned by the JDE.")
    (cli-socket    :initarg :cli-socket
-		  :type integer
-		  :documentation
-		  "Number of socket used by the process's command line interface.")
+                  :type integer
+                  :documentation
+                  "Number of socket used by the process's command line interface.")
    (cli-buf       :initarg :cli-buf
-		  :type buffer
-		  :documentation
-		  "Buffer for the process's command-line interface.")
+                  :type buffer
+                  :documentation
+                  "Buffer for the process's command-line interface.")
    (msg-buf       :initarg :msf-buf
-		  :type buffer
-		  :documentation
-		  "Buffer used to display debugger output for this process")
+                  :type buffer
+                  :documentation
+                  "Buffer used to display debugger output for this process")
    (threads-buf   :initarg :threads-buf
-		  :type buffer
-		  :documentation
-		  "Buffer used to display threads.")
+                  :type buffer
+                  :documentation
+                  "Buffer used to display threads.")
    (locals-buf    :initarg :locals-buf
-		  :type buffer
-		  :documentation
-		  "Buffer used to display local variables.")
+                  :type buffer
+                  :documentation
+                  "Buffer used to display local variables.")
    (startupp       :initarg :startupp
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "non-nil if this process is in the startup state.")
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "non-nil if this process is in the startup state.")
    (suspendedp    :initarg :suspendedp
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "non-nil if this process has been suspended by the debugger.")
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "non-nil if this process has been suspended by the debugger.")
    (steppablep    :initarg :steppablep
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "non-nil if this process can be single-stepped.")
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "non-nil if this process can be single-stepped.")
    (state-info    :initarg :state-info
-		  :type jdee-dbs-proc-state-info
-		  :documentation
-		  "Process state information.")
+                  :type jdee-dbs-proc-state-info
+                  :documentation
+                  "Process state information.")
    (stack         :initarg :stack
-		  :type list
-		  :documentation
-		  "Lists stack frames for thread of current step or breakpoint.")
+                  :type list
+                  :documentation
+                  "Lists stack frames for thread of current step or breakpoint.")
    (stack-ptr     :initarg :stack-ptr
-		  :type integer
-		  :initform 0
-		  :documentation
-		  "Points to the current frame on the stack.")
+                  :type integer
+                  :initform 0
+                  :documentation
+                  "Points to the current frame on the stack.")
    (trace-req     :initarg :trace-req
-		  :type list
-		  :documentation
-		  "List of outstanding trace requests.")
+                  :type list
+                  :documentation
+                  "List of outstanding trace requests.")
    (watch-req     :initarg :watch-req
-		  :type list
-		  :documentation
-		  "List of outstanding watch field requests.")
+                  :type list
+                  :documentation
+                  "List of outstanding watch field requests.")
    (object-refs   :initarg :object-refs
-		  :type list
-		  :initform nil
-		  :documentation
-		  "IDs of debuggee objects currently referenced by the debugger.")
+                  :type list
+                  :initform nil
+                  :documentation
+                  "IDs of debuggee objects currently referenced by the debugger.")
    (bpspecs       :initarg :bpspecs
-		  :type list
-		  :documentation
-		  "Breakpoints set in this process.")
+                  :type list
+                  :documentation
+                  "Breakpoints set in this process.")
    (last-cmd      :initarg :last-cmd
-		  :type jdee-dbs-cmd
-		  :documentation
-		  "Most recent command targeting this process.")
+                  :type jdee-dbs-cmd
+                  :documentation
+                  "Most recent command targeting this process.")
    (win-cfg       :initarg :win-cfg
-		  :type window-configuration
-		  :documentation
-		  "Desired window configuration for this process.")
+                  :type window-configuration
+                  :documentation
+                  "Desired window configuration for this process.")
    (attachedp     :initarg :attachedp
-		  :type boolean
-		  :initform nil
-		  :documentation
-		  "Non-nil if the debugger was attached to this process."))
+                  :type boolean
+                  :initform nil
+                  :documentation
+                  "Non-nil if the debugger was attached to this process."))
   (:allow-nil-initform t)
   "Class of debuggee processes.")
 
@@ -531,33 +531,33 @@ process-specific information about a breakpoint")
 
   (if (not (slot-boundp this 'state-info))
       (oset this state-info
-	    (jdee-dbs-proc-state-info
-	     (format "State Info %d" (oref this id)))))
+            (jdee-dbs-proc-state-info
+             (format "State Info %d" (oref this id)))))
 
   (assert (slot-boundp this 'main-class))
   (assert (slot-boundp this 'id))
 
   (oset this msg-buf (get-buffer-create
-		      (format "*Process %s(%d)*"
-			      (oref this main-class)
-			      (oref this id))))
+                      (format "*Process %s(%d)*"
+                              (oref this main-class)
+                              (oref this id))))
   (with-current-buffer (oref this msg-buf)
     (erase-buffer)
     (goto-char (point-min))
     (insert
        (format "*** Debugger Output for Process %s(%d) ***\n\n"
-	       (oref this main-class)
-	       (oref this id))))
+               (oref this main-class)
+               (oref this id))))
 
   (oset this locals-buf (get-buffer-create
-			 (format "*%s(%d) Local Variables*"
-				 (oref this main-class)
-				 (oref this id))))
+                         (format "*%s(%d) Local Variables*"
+                                 (oref this main-class)
+                                 (oref this id))))
 
   (oset this threads-buf (get-buffer-create
-			  (format "*%s(%d) Threads*"
-				  (oref this main-class)
-				  (oref this id)))))
+                          (format "*%s(%d) Threads*"
+                                  (oref this main-class)
+                                  (oref this id)))))
 
 
 (defmethod jdee-dbs-proc-set-state ((this jdee-dbs-proc) state)
@@ -575,31 +575,31 @@ process-specific information about a breakpoint")
   (oref (oref this state-info) reason))
 
 (defmethod jdee-dbs-proc-display-debug-message ((this jdee-dbs-proc)
-					       message
-					       &optional pop-buffer)
+                                               message
+                                               &optional pop-buffer)
   (let ((buffer
-	 (oref this msg-buf)))
+         (oref this msg-buf)))
     (if buffer
-	(save-excursion
-	  (let ((source-window (selected-window))
-		(currbuffp (equal buffer (current-buffer)))
-		win)
-	    (if (not currbuffp) (other-window -1))
-	    (set-buffer buffer)
-	    (goto-char (point-max))
-	    (insert (concat message "\n"))
-	    (goto-char (point-max))
-	    (if (not currbuffp) (other-window 1))
-	    (if (and pop-buffer (one-window-p))
-		(progn
-		  (setq win (split-window source-window))
-		  (set-window-buffer win buffer)))
-	    (if pop-buffer
-		(progn
-		  (set-window-buffer (next-window source-window) buffer)
-		  (select-window source-window))
-	      (if (not currbuffp)
-		  (message message))))))))
+        (save-excursion
+          (let ((source-window (selected-window))
+                (currbuffp (equal buffer (current-buffer)))
+                win)
+            (if (not currbuffp) (other-window -1))
+            (set-buffer buffer)
+            (goto-char (point-max))
+            (insert (concat message "\n"))
+            (goto-char (point-max))
+            (if (not currbuffp) (other-window 1))
+            (if (and pop-buffer (one-window-p))
+                (progn
+                  (setq win (split-window source-window))
+                  (set-window-buffer win buffer)))
+            (if pop-buffer
+                (progn
+                  (set-window-buffer (next-window source-window) buffer)
+                  (select-window source-window))
+              (if (not currbuffp)
+                  (message message))))))))
 
 (defmethod jdee-dbs-proc-move-to-morgue ((this jdee-dbs-proc))
   "Moves this process from the process registry to the process morgue."
@@ -618,15 +618,15 @@ an instance of `jdee-db-breakpoint' or the debugger-assigned id
 for the breakpoint."
   (if (slot-boundp this 'bpspecs)
       (let ((bpspecs (oref this bpspecs)))
-	(if (and (object-p bp) (jdee-db-breakpoint-p bp))
-	    (let* ((jdee-id (oref bp id)))
-	      (cdr
-	       (cl-find-if
-		(lambda (assoc-x)
-		  (let ((spec (cdr assoc-x)))
-		    (equal (oref (oref spec breakpoint) id) jdee-id)))
-		bpspecs)))
-	  (cdr (assoc bp bpspecs))))))
+        (if (and (object-p bp) (jdee-db-breakpoint-p bp))
+            (let* ((jdee-id (oref bp id)))
+              (cdr
+               (cl-find-if
+                (lambda (assoc-x)
+                  (let ((spec (cdr assoc-x)))
+                    (equal (oref (oref spec breakpoint) id) jdee-id)))
+                bpspecs)))
+          (cdr (assoc bp bpspecs))))))
 
 (defmethod jdee-dbs-proc-runnable-p ((this jdee-dbs-proc))
   (or
@@ -647,7 +647,7 @@ for the breakpoint."
 (defun jdee-dbs-display-debug-message (proc-id message)
   (let ((process (jdee-dbs-get-process proc-id)))
     (if process
-	(jdee-dbs-proc-display-debug-message process message)
+        (jdee-dbs-proc-display-debug-message process message)
       (message message))))
 
 (defvar jdee-dbs-proc-counter 0
@@ -661,9 +661,9 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-java-obj ()
   ((jtype  :initarg :jtype
-	   :type string
-	   :documentation
-	   "Type of this object."))
+           :type string
+           :documentation
+           "Type of this object."))
   "Superclass of Java objects.")
 
 (defmethod jdee-dbs-java-obj-to-string ((this jdee-dbs-java-obj))
@@ -672,9 +672,9 @@ for the breakpoint."
 
 (defclass jdee-dbs-java-primitive (jdee-dbs-java-obj)
   ((value :initarg :value
-	  :type (or string number)
-	  :documentation
-	  "Value of this primitive object."))
+          :type (or string number)
+          :documentation
+          "Value of this primitive object."))
   "Class of Java primitives.")
 
 (defmethod jdee-dbs-java-obj-to-string ((this jdee-dbs-java-primitive))
@@ -703,24 +703,24 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-java-variable ()
   ((name         :initarg :name
-		 :type string
-		 :documentation
-		 "Name of this variable")
+                 :type string
+                 :documentation
+                 "Name of this variable")
    (jtype        :initarg :jtype
-		 :type string
-		 :documentation
-		 "Type of this variable.")
+                 :type string
+                 :documentation
+                 "Type of this variable.")
    (value        :initarg :value
-		 :type jdee-dbs-java-obj
-		 :documentation
-		 "Value of this variable."))
+                 :type jdee-dbs-java-obj
+                 :documentation
+                 "Value of this variable."))
   "Class that defines the JDE's representation of a Java variable.")
 
 (defmethod jdee-dbs-java-variable-to-string ((this jdee-dbs-java-variable))
   (format "%s %s = %s"
-	  (oref this jtype)
-	  (oref this name)
-	  (jdee-dbs-java-obj-to-string (oref this value))))
+          (oref this jtype)
+          (oref this name)
+          (jdee-dbs-java-obj-to-string (oref this value))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -730,13 +730,13 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-java-class-instance (jdee-dbs-java-obj)
   ((id           :initarg :id
-		 :type integer
-		 :documentation
-		 "Id assigned to this object by the debugger.")
+                 :type integer
+                 :documentation
+                 "Id assigned to this object by the debugger.")
    (gc-flag      :initarg :gc-flag
-		 :type boolean
-		 :documentation
-		 "t if this object has been garbage collected."))
+                 :type boolean
+                 :documentation
+                 "t if this object has been garbage collected."))
   "Instance of a Java class accessed via the debugger.")
 
 
@@ -747,40 +747,40 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-java-array (jdee-dbs-java-class-instance)
   ((length     :initarg :length
-	       :type integer
-	       :documentation
-	       "Length of this array.")
+               :type integer
+               :documentation
+               "Length of this array.")
    (elements   :initarg :elements
-	       :type list
-	       :initform nil
-	       :documentation
-	       "Elements of this array."))
+               :type list
+               :initform nil
+               :documentation
+               "Elements of this array."))
   "Class of Lisp objects representing instances of Java arrays.")
 
 
 
 (defmethod jdee-dbs-java-obj-to-string ((this jdee-dbs-java-array))
   (let ((str (format "<%s:%d%s> %d"
-		     (if (slot-boundp this :jtype)
-			 (oref this jtype))
-		     (if (slot-boundp this :id)
-			 (oref this id))
-		     (if (slot-boundp this :gc-flag)
-			 (if (oref this gc-flag) ":gc" ""))
-		     (if (slot-boundp this :length)
-			 (oref this length)
-		       0)))
-	(elements (if (slot-boundp this :elements)
-		      (oref this elements))))
+                     (if (slot-boundp this :jtype)
+                         (oref this jtype))
+                     (if (slot-boundp this :id)
+                         (oref this id))
+                     (if (slot-boundp this :gc-flag)
+                         (if (oref this gc-flag) ":gc" ""))
+                     (if (slot-boundp this :length)
+                         (oref this length)
+                       0)))
+        (elements (if (slot-boundp this :elements)
+                      (oref this elements))))
     (if elements
-	(let ((sep "\n |- "))
-	  (concat
-	   str
-	   sep
-	   (mapconcat
-	    (lambda (element)
-	      (jdee-dbs-java-obj-to-string element))
-	    elements sep)))
+        (let ((sep "\n |- "))
+          (concat
+           str
+           sep
+           (mapconcat
+            (lambda (element)
+              (jdee-dbs-java-obj-to-string element))
+            elements sep)))
       str)))
 
 
@@ -792,33 +792,33 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-java-udci (jdee-dbs-java-class-instance)
   ((fields       :initarg :fields
-		 :type list
-		 :initform nil
-		 :documentation
-		 "Fields of this object."))
+                 :type list
+                 :initform nil
+                 :documentation
+                 "Fields of this object."))
   "Class of Lisp objects representing instances of user-defined Java classes.")
 
 
 (defmethod jdee-dbs-java-udci-add-field ((this jdee-dbs-java-udci) field)
   (oset this fields
-	(nconc (oref this fields) (list (cons (oref field name) field)))))
+        (nconc (oref this fields) (list (cons (oref field name) field)))))
 
 
 (defmethod jdee-dbs-java-obj-to-string ((this jdee-dbs-java-udci))
   (let ((str (format "<%s:%d%s>"
-		     (oref this jtype)
-		     (oref this id)
-		     (if (oref this gc-flag) ":gc" "")))
-	(fields (oref this fields)))
+                     (oref this jtype)
+                     (oref this id)
+                     (if (oref this gc-flag) ":gc" "")))
+        (fields (oref this fields)))
     (if fields
-	(let ((sep "\n |- "))
-	  (concat
-	   str
-	   sep
-	   (mapconcat
-	    (lambda (assoc-x)
-	      (jdee-dbs-java-variable-to-string (cdr assoc-x)))
-	    fields sep)))
+        (let ((sep "\n |- "))
+          (concat
+           str
+           sep
+           (mapconcat
+            (lambda (assoc-x)
+              (jdee-dbs-java-variable-to-string (cdr assoc-x)))
+            fields sep)))
       str)))
 
 
@@ -830,10 +830,10 @@ for the breakpoint."
 (defclass jdee-dbs-debugger (jdee-db-debugger)
   ((comint-filter :initarg :comint-filter)
    (started-p     :initarg :started-p
-		  :initform nil
-		  :type boolean
-		  :documentation
-		  "True if debugger started successfully."))
+                  :initform nil
+                  :type boolean
+                  :documentation
+                  "True if debugger started successfully."))
   "Class of JDEbug debuggers.")
 
 (defmethod initialize-instance ((this jdee-dbs-debugger) &rest fields)
@@ -850,116 +850,116 @@ for the breakpoint."
 (defmethod jdee-dbs-debugger-display-message ((debugger jdee-dbs-debugger) message)
   "Displays message in the debugger process buffer."
  (let ((buffer
-	 (oref debugger buffer)))
+         (oref debugger buffer)))
     (if buffer
-	(with-current-buffer buffer
-	  (goto-char (process-mark (get-buffer-process buffer)))
-	  (insert-before-markers (concat message "\n"))))))
+        (with-current-buffer buffer
+          (goto-char (process-mark (get-buffer-process buffer)))
+          (insert-before-markers (concat message "\n"))))))
 
 (defmethod jdee-dbs-debugger-start ((this jdee-dbs-debugger))
   "Starts the debugger."
   (if (jdee-dbs-debugger-running-p)
       (progn
-	(message "An instance of the debugger is running.")
-	(pop-to-buffer (jdee-dbs-get-app-buffer-name))
-	nil)
+        (message "An instance of the debugger is running.")
+        (pop-to-buffer (jdee-dbs-get-app-buffer-name))
+        nil)
     (let* ((debugger-buffer-name
-	      (oref this buffer-name))
-	     (debugger-buffer
-	      (let ((old-buf (get-buffer debugger-buffer-name)))
-		    (if old-buf (kill-buffer old-buf))
-		    (get-buffer-create debugger-buffer-name)))
-	     (win32-p (eq system-type 'windows-nt))
-	     (w32-quote-process-args ?\")
-	     (win32-quote-process-args ?\") ;; XEmacs
-	     (source-directory default-directory)
-	     (working-directory
-	      (if (and
-		   jdee-run-working-directory
-		   (not (string= jdee-run-working-directory "")))
-		  (jdee-normalize-path 'jdee-run-working-directory)
-		source-directory))
-	     (vm (oref (jdee-run-get-vm) :path))
-	     (vm-args
-		(let (args)
-		  (setq args
-			(append
-			 args
-			 (list
-			  "-classpath"
-			  (jdee-build-classpath
-			       (list
+              (oref this buffer-name))
+             (debugger-buffer
+              (let ((old-buf (get-buffer debugger-buffer-name)))
+                    (if old-buf (kill-buffer old-buf))
+                    (get-buffer-create debugger-buffer-name)))
+             (win32-p (eq system-type 'windows-nt))
+             (w32-quote-process-args ?\")
+             (win32-quote-process-args ?\") ;; XEmacs
+             (source-directory default-directory)
+             (working-directory
+              (if (and
+                   jdee-run-working-directory
+                   (not (string= jdee-run-working-directory "")))
+                  (jdee-normalize-path 'jdee-run-working-directory)
+                source-directory))
+             (vm (oref (jdee-run-get-vm) :path))
+             (vm-args
+                (let (args)
+                  (setq args
+                        (append
+                         args
+                         (list
+                          "-classpath"
+                          (jdee-build-classpath
+                               (list
                                  jdee-server-dir
-				 (if (jdee-bug-vm-includes-jpda-p)
-				   (jdee-get-tools-jar)
-				   (expand-file-name
-				    "lib/jpda.jar" (jdee-normalize-path
-						    'jdee-bug-jpda-directory))))))))
-		  (if jdee-bug-debug
-		      (setq args
-			    (append args
-			     (list "-Xdebug"
-				   "-Xnoagent"
-				   "-Xrunjdwp:transport=dt_socket,address=2112,server=y,suspend=n"))))
-		  (setq args (append args (list "jde.debugger.Main")))
-		  args))
-	     (command-string
-	      (concat
-	       vm " "
-	       (jdee-run-make-arg-string
-		vm-args)
-	       "\n\n"))
-	     debugger-process)
-	(run-hook-with-args 'jdee-dbs-debugger-hook t)
-	(oset this started-p nil)
-	(setq jdee-dbs-debugger-output nil)
+                                 (if (jdee-bug-vm-includes-jpda-p)
+                                   (jdee-get-tools-jar)
+                                   (expand-file-name
+                                    "lib/jpda.jar" (jdee-normalize-path
+                                                    'jdee-bug-jpda-directory))))))))
+                  (if jdee-bug-debug
+                      (setq args
+                            (append args
+                             (list "-Xdebug"
+                                   "-Xnoagent"
+                                   "-Xrunjdwp:transport=dt_socket,address=2112,server=y,suspend=n"))))
+                  (setq args (append args (list "jde.debugger.Main")))
+                  args))
+             (command-string
+              (concat
+               vm " "
+               (jdee-run-make-arg-string
+                vm-args)
+               "\n\n"))
+             debugger-process)
+        (run-hook-with-args 'jdee-dbs-debugger-hook t)
+        (oset this started-p nil)
+        (setq jdee-dbs-debugger-output nil)
 
 
-	(with-current-buffer debugger-buffer
-	  (erase-buffer)
-	  ;; Set working directory
-	  (if (and
-	       (file-exists-p working-directory)
-	       (file-directory-p working-directory))
-	      (cd working-directory)
-	    (error "Invalid working directory: %s" working-directory))
-	  (insert (concat "cd " working-directory "\n"))
-	  (insert command-string)
-	  (jdee-run-mode))
+        (with-current-buffer debugger-buffer
+          (erase-buffer)
+          ;; Set working directory
+          (if (and
+               (file-exists-p working-directory)
+               (file-directory-p working-directory))
+              (cd working-directory)
+            (error "Invalid working directory: %s" working-directory))
+          (insert (concat "cd " working-directory "\n"))
+          (insert command-string)
+          (jdee-run-mode))
 
-	(save-w32-show-window
-	 (comint-exec debugger-buffer debugger-buffer-name vm nil vm-args)
-	 (setq debugger-process (get-process debugger-buffer-name))
-	 (oset this process debugger-process)
-	 (oset this buffer debugger-buffer)
-	 (oset this comint-filter (process-filter debugger-process))
-	 (jdee-dbs-debugger-register-process-filter this 'jdee-dbs-asynch-output-listener)
-	 )
+        (save-w32-show-window
+         (comint-exec debugger-buffer debugger-buffer-name vm nil vm-args)
+         (setq debugger-process (get-process debugger-buffer-name))
+         (oset this process debugger-process)
+         (oset this buffer debugger-buffer)
+         (oset this comint-filter (process-filter debugger-process))
+         (jdee-dbs-debugger-register-process-filter this 'jdee-dbs-asynch-output-listener)
+         )
 
-	(cd source-directory)
+        (cd source-directory)
 
-	(bury-buffer debugger-buffer)
+        (bury-buffer debugger-buffer)
 
-	(setq jdee-dbs-proc-counter 0)
+        (setq jdee-dbs-proc-counter 0)
 
-	(setq jdee-dbs-cmd-counter 0)
+        (setq jdee-dbs-cmd-counter 0)
 
-	;; Wait for response from debugger
-	(if (not (accept-process-output debugger-process jdee-bug-debugger-command-timeout 0))
-	    (progn
-	      (message "Error: debugger failed to start.")
-	      nil)
-	  (oref this started-p))
+        ;; Wait for response from debugger
+        (if (not (accept-process-output debugger-process jdee-bug-debugger-command-timeout 0))
+            (progn
+              (message "Error: debugger failed to start.")
+              nil)
+          (oref this started-p))
 
-	;; Create a process registry for registering debuggee processes
-	;; started by the debugger.
-	(setq jdee-dbs-the-process-registry
-	      (jdee-dbs-proc-registry "Process Registry"))
+        ;; Create a process registry for registering debuggee processes
+        ;; started by the debugger.
+        (setq jdee-dbs-the-process-registry
+              (jdee-dbs-proc-registry "Process Registry"))
 
-	;; Create a registry for debuggee processes that have died but
-	;; still may be getting messages from the debugger.
-	(setq jdee-dbs-the-process-morgue
-	      (jdee-dbs-proc-morgue "Process Morgue")))))
+        ;; Create a registry for debuggee processes that have died but
+        ;; still may be getting messages from the debugger.
+        (setq jdee-dbs-the-process-morgue
+              (jdee-dbs-proc-morgue "Process Morgue")))))
 
 
 
@@ -991,27 +991,27 @@ for the breakpoint."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-cmd (jdee-db-cmd)
   ((process    :initarg :process
-	       :type jdee-dbs-proc
-	       :documentation
-	       "Process that this command targets.")
+               :type jdee-dbs-proc
+               :documentation
+               "Process that this command targets.")
    (id         :initarg :id
-	       :type integer
-	       :documentation
-	       "Command id.")
+               :type integer
+               :documentation
+               "Command id.")
    (name       :initarg :name
-	       :type string
-	       :documentation
-	       "Name of command.")
+               :type string
+               :documentation
+               "Name of command.")
    (result     :initarg :result
-	       :documentation
-	       "Result of executing command.")
+               :documentation
+               "Result of executing command.")
    (data       :initarg :data
-	       :documentation
-	       "Data returned by command.")
+               :documentation
+               "Data returned by command.")
    (msg        :initarg :msg
-	       :type string
-	       :documentation
-	       "Message to display to user in debug buffer.")
+               :type string
+               :documentation
+               "Message to display to user in debug buffer.")
    )
   "Super class of debugger commands.")
 
@@ -1028,9 +1028,9 @@ the process id, command id, and command name. If there is no
 process, specifies the process id as -1. Derived classes can
 extend this method to specify command arguments."
   (let* ((process (oref this process))
-	 (process-id (if process (oref process id) -1))
-	 (command-id (oref this id))
-	 (command-name (oref this name)))
+         (process-id (if process (oref process id) -1))
+         (command-id (oref this id))
+         (command-name (oref this name)))
     (format "%s %s %s" process-id command-id command-name)))
 
 (defvar jdee-dbs-debugger-output nil
@@ -1048,27 +1048,27 @@ extend this method to specify command arguments."
     (error
      (let* ((process (jdee-dbs-get-target-process)))
        (if process
-	   (jdee-dbs-proc-display-debug-message
-	    process
-	    (concat
-	     "Error: evaluating debugger output caused a Lisp error.\n"
-	     "  See *messages* buffer for details.")))
+           (jdee-dbs-proc-display-debug-message
+            process
+            (concat
+             "Error: evaluating debugger output caused a Lisp error.\n"
+             "  See *messages* buffer for details.")))
        (message "Error: evaluating output from the debugger caused a Lisp error.")
        (message "Debugger output: %s." lisp-form)
        (message "Lisp error: %s" error-desc)))))
 
 (defun jdee-dbs-extract-exception (debugger-output)
   (let ((lisp-form "")
-	(remainder "")
-	(output-length (length debugger-output))
-	(re "\\(.*Exception:.*[\n]\\)+\\(.*at[^\n]*[\n]\\)+"))
+        (remainder "")
+        (output-length (length debugger-output))
+        (re "\\(.*Exception:.*[\n]\\)+\\(.*at[^\n]*[\n]\\)+"))
     (if (string-match re debugger-output)
-	(let ((start (match-beginning 0))
-	      (end (match-end 0)))
-	  (setq lisp-form (format "(jdee-dbo-unknown-exception \"%s\")"
-				  (substring debugger-output 0 end)))
-	  (if (< end output-length)
-	      (setq remainder (substring debugger-output end output-length))))
+        (let ((start (match-beginning 0))
+              (end (match-end 0)))
+          (setq lisp-form (format "(jdee-dbo-unknown-exception \"%s\")"
+                                  (substring debugger-output 0 end)))
+          (if (< end output-length)
+              (setq remainder (substring debugger-output end output-length))))
       (setq remainder debugger-output))
     (cons lisp-form remainder)))
 
@@ -1078,14 +1078,14 @@ Returns (FORM . REMAINDER) where FORM is the Lisp form
 or the null string and REMAINDER is the remainder of the
 debugger output following the Lisp form."
   (let ((lisp-form "")
-	(remainder "")
-	(level 0)
-	in-string-p
-	in-escape-p
-	(curr-pos 1)
-	(output-length (length debugger-output))
-	command-end
-	lisp-form-end)
+        (remainder "")
+        (level 0)
+        in-string-p
+        in-escape-p
+        (curr-pos 1)
+        (output-length (length debugger-output))
+        command-end
+        lisp-form-end)
     (setq
      lisp-form-end
      (catch 'found-lisp-form
@@ -1095,57 +1095,57 @@ debugger output following the Lisp form."
 
        (while (< curr-pos output-length)
 
-	 (cond
+         (cond
 
-	  ;; Current character = left slash (escape)
-	  ((equal (aref debugger-output curr-pos) ?\\)
-	   (if in-string-p
-	       (setq in-escape-p (not in-escape-p))))
+          ;; Current character = left slash (escape)
+          ((equal (aref debugger-output curr-pos) ?\\)
+           (if in-string-p
+               (setq in-escape-p (not in-escape-p))))
 
-	  ;; Current character = quotation mark
-	  ((equal (aref debugger-output curr-pos) ?\")
-	   (if in-string-p
-	       (if in-escape-p
-		   (progn
-		     (setq in-escape-p nil)
-		     (setq in-string-p nil))
-		 (setq in-string-p nil))
-	     (setq in-string-p t)))
+          ;; Current character = quotation mark
+          ((equal (aref debugger-output curr-pos) ?\")
+           (if in-string-p
+               (if in-escape-p
+                   (progn
+                     (setq in-escape-p nil)
+                     (setq in-string-p nil))
+                 (setq in-string-p nil))
+             (setq in-string-p t)))
 
-	  ;; Current character = right paren
-	  ((and
-	    (not in-string-p)
-	    (equal (aref debugger-output curr-pos) ?\)))
-	   (if (= level 0)
-	       (throw 'found-lisp-form curr-pos)
-	     (setq level (1- level))
-	     (if (< level 0)
-		 (error "Error parsing debugger output.")))
-	   ;; (prin1 (format ") lev = %d pos = %d" level curr-pos) (current-buffer))
-	   )
+          ;; Current character = right paren
+          ((and
+            (not in-string-p)
+            (equal (aref debugger-output curr-pos) ?\)))
+           (if (= level 0)
+               (throw 'found-lisp-form curr-pos)
+             (setq level (1- level))
+             (if (< level 0)
+                 (error "Error parsing debugger output.")))
+           ;; (prin1 (format ") lev = %d pos = %d" level curr-pos) (current-buffer))
+           )
 
-	  ;; Current character = left paren
-	  ((and
-	    (not in-string-p)
-	    (equal (aref debugger-output curr-pos) ?\()
-	       (setq level (1+ level)))
-	   ;; (prin1 (format "( lev = %d pos = %d" level curr-pos) (current-buffer))
-	   )
-	  (t
-	   (if in-escape-p
-	       (setq in-escape-p nil))))
+          ;; Current character = left paren
+          ((and
+            (not in-string-p)
+            (equal (aref debugger-output curr-pos) ?\()
+               (setq level (1+ level)))
+           ;; (prin1 (format "( lev = %d pos = %d" level curr-pos) (current-buffer))
+           )
+          (t
+           (if in-escape-p
+               (setq in-escape-p nil))))
 
-	 (setq curr-pos (1+ curr-pos)))
+         (setq curr-pos (1+ curr-pos)))
 
        -1))
     (if (> lisp-form-end 1)
-	(progn
-	  (setq lisp-form (substring debugger-output 0 (1+ lisp-form-end)))
-	  (when (< lisp-form-end (1- output-length))
-	    (setq remainder (substring debugger-output (1+ lisp-form-end) output-length))
-	    (if (string-match "(" remainder)
-		(setq remainder (substring remainder (string-match "(" remainder)))
-	      (setq remainder ""))))
+        (progn
+          (setq lisp-form (substring debugger-output 0 (1+ lisp-form-end)))
+          (when (< lisp-form-end (1- output-length))
+            (setq remainder (substring debugger-output (1+ lisp-form-end) output-length))
+            (if (string-match "(" remainder)
+                (setq remainder (substring remainder (string-match "(" remainder)))
+              (setq remainder ""))))
       (setq remainder debugger-output))
     (cons lisp-form remainder)))
 
@@ -1166,41 +1166,41 @@ debugger output following the Lisp form."
 `jdee-dbs-pending-command'."
   ;; (message "entering command reply listener")
   (let* ((combined-output (concat jdee-dbs-debugger-output output))
-	 (parsed-output
-	  (if (string-match "^[\n\t ]*(" combined-output)
-	      (jdee-dbs-extract-lisp-form combined-output)
-	    (jdee-dbs-extract-exception combined-output)))
-	 (form (car parsed-output))
-	 (remainder (cdr parsed-output)))
+         (parsed-output
+          (if (string-match "^[\n\t ]*(" combined-output)
+              (jdee-dbs-extract-lisp-form combined-output)
+            (jdee-dbs-extract-exception combined-output)))
+         (form (car parsed-output))
+         (remainder (cdr parsed-output)))
 
     ;; (message "form: %s" form)
     ;; (message "remainder: %s" remainder)
 
     ;; Insert debugger output into the *JDEbug* buffer.
     (funcall (oref jdee-dbs-the-debugger  comint-filter)
-	 process output)
+         process output)
 
     ;; Process the Lisp forms extracted from the debugger output.
     (while (not (string= form ""))
 
       (if (jdee-dbs-reply-p form)
 
-	  ;; The current form is a reply to a debugger command.
-	  (progn
-	    (setq jdee-dbs-command-reply form)
-	    (setq jdee-dbs-reply-received t))
+          ;; The current form is a reply to a debugger command.
+          (progn
+            (setq jdee-dbs-command-reply form)
+            (setq jdee-dbs-reply-received t))
 
-	;; The form is an event. Postpone processing the event
-	;; until we receive a reply to the last command.
-	;; (message "   appending %s to pending event queue" form)
-	(setq jdee-dbs-pending-event-queue
-	      (append jdee-dbs-pending-event-queue (list form))))
+        ;; The form is an event. Postpone processing the event
+        ;; until we receive a reply to the last command.
+        ;; (message "   appending %s to pending event queue" form)
+        (setq jdee-dbs-pending-event-queue
+              (append jdee-dbs-pending-event-queue (list form))))
 
       ;; Extract the next Lisp form from the debugger output.
       ;; The car of parsed-output is the next form. The cdr
       ;; is the remaining unprocessed debugger output.
       (setq parsed-output
-	    (jdee-dbs-extract-lisp-form remainder))
+            (jdee-dbs-extract-lisp-form remainder))
 
       (setq form (car parsed-output))
       (setq remainder (cdr parsed-output))) ;; End of form processing loop.
@@ -1208,51 +1208,51 @@ debugger output following the Lisp form."
     (setq jdee-dbs-debugger-output remainder)
 
     (if (not jdee-dbs-reply-received)
-	(when (not (accept-process-output process jdee-bug-debugger-command-timeout 0))
-	    (message "No response to command %d. (process = %s; timeout = %s sec.)"
-		     jdee-dbs-pending-command
-		     (if (jdee-dbs-get-target-process)
-			 (oref (jdee-dbs-get-target-process) id)
-		       "?")
-		     jdee-bug-debugger-command-timeout)
-		    (setq jdee-dbs-command-reply nil)))))
+        (when (not (accept-process-output process jdee-bug-debugger-command-timeout 0))
+            (message "No response to command %d. (process = %s; timeout = %s sec.)"
+                     jdee-dbs-pending-command
+                     (if (jdee-dbs-get-target-process)
+                         (oref (jdee-dbs-get-target-process) id)
+                       "?")
+                     jdee-bug-debugger-command-timeout)
+                    (setq jdee-dbs-command-reply nil)))))
 
 (defun jdee-dbs-asynch-output-listener (process output)
   "Listens for asynchronous debugger output."
   (let* ((combined-output (concat jdee-dbs-debugger-output output))
-	 (parsed-output
-	  (if (string-match "^[\n\t ]*(" combined-output)
-	      (jdee-dbs-extract-lisp-form combined-output)
-	    (jdee-dbs-extract-exception combined-output)))
-	 (lisp-form (car parsed-output))
-	 (remainder (cdr parsed-output))
-	 events)
+         (parsed-output
+          (if (string-match "^[\n\t ]*(" combined-output)
+              (jdee-dbs-extract-lisp-form combined-output)
+            (jdee-dbs-extract-exception combined-output)))
+         (lisp-form (car parsed-output))
+         (remainder (cdr parsed-output))
+         events)
 
     ;; (message "asynch form: %s" lisp-form)
     ;; (message "asynch remainder: %s" remainder)
 
     (funcall (oref  jdee-dbs-the-debugger comint-filter)
-	     process output)
+             process output)
     ;; Extract events from debugger output.
     (while (not (string= lisp-form ""))
       ;; (message "   evaluating %s" lisp-form)
       ;; (jdee-dbs-eval-debugger-output lisp-form)
       (setq events (append events (list lisp-form)))
       (setq parsed-output
-	    (jdee-dbs-extract-lisp-form remainder))
+            (jdee-dbs-extract-lisp-form remainder))
       (setq lisp-form (car parsed-output))
       (setq remainder (cdr parsed-output)))
     (setq jdee-dbs-debugger-output remainder)
     (if events
-	(mapc (lambda (event) (jdee-dbs-eval-debugger-output event))
-	      events))))
+        (mapc (lambda (event) (jdee-dbs-eval-debugger-output event))
+              events))))
 
 (defun jdee-dbs-do-command (vm command)
   "Posts the specified command to the debugger and returns its response."
   (let* ((debugger-process
-	  (oref jdee-dbs-the-debugger process))
-	 (previous-listener (process-filter debugger-process))
-	 cmd)
+          (oref jdee-dbs-the-debugger process))
+         (previous-listener (process-filter debugger-process))
+         cmd)
     (setq jdee-dbs-debugger-output "")
     (setq jdee-dbs-command-reply "")
     (setq jdee-dbs-reply-received nil)
@@ -1264,17 +1264,17 @@ debugger output following the Lisp form."
     (set-process-filter debugger-process 'jdee-dbs-command-reply-listener)
     (process-send-string debugger-process cmd)
     (when (not (accept-process-output debugger-process jdee-bug-debugger-command-timeout 0))
-		(message "Error: debugger didn't respond to command:\n%s" cmd)
-		(setq jdee-dbs-command-reply nil))
+                (message "Error: debugger didn't respond to command:\n%s" cmd)
+                (setq jdee-dbs-command-reply nil))
     (set-process-filter debugger-process previous-listener)
     (if jdee-dbs-command-reply
-	(let ((result (jdee-dbs-eval-debugger-output jdee-dbs-command-reply)))
-	  ;; evaluate any events that occurred between issuance and
-	  ;; acknowledgement of this command
-	  (mapc (lambda (event) (jdee-dbs-eval-debugger-output event))
-		jdee-dbs-pending-event-queue)
-	  (setq jdee-dbs-pending-event-queue nil)
-	  result))))
+        (let ((result (jdee-dbs-eval-debugger-output jdee-dbs-command-reply)))
+          ;; evaluate any events that occurred between issuance and
+          ;; acknowledgement of this command
+          (mapc (lambda (event) (jdee-dbs-eval-debugger-output event))
+                jdee-dbs-pending-event-queue)
+          (setq jdee-dbs-pending-event-queue nil)
+          result))))
 
 
 
@@ -1302,16 +1302,16 @@ debugger output following the Lisp form."
     ;; as a result of processing these events.
     (setq jdee-dbs-pending-event-queue nil)
     (mapc (lambda (event) (jdee-dbs-eval-debugger-output event))
-		events)))
+                events)))
 
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-cmd))
   "Posts the specified command to the debugger and returns its response."
   (let* ((debugger-process
-	  (oref jdee-dbs-the-debugger process))
-	 (previous-listener (process-filter debugger-process))
-	 (target-process (oref this process))
-	 (command-line (format "%s\n" (jdee-dbs-cmd-make-command-line this))))
+          (oref jdee-dbs-the-debugger process))
+         (previous-listener (process-filter debugger-process))
+         (target-process (oref this process))
+         (command-line (format "%s\n" (jdee-dbs-cmd-make-command-line this))))
 
     (setq jdee-dbs-debugger-output "")
     (setq jdee-dbs-command-reply "")
@@ -1326,28 +1326,28 @@ debugger output following the Lisp form."
     (process-send-string debugger-process "\n")
 
     (when (not (accept-process-output debugger-process jdee-bug-debugger-command-timeout 0))
-		(message "Error: debugger didn't respond to command:\n%s" command-line)
-		(setq jdee-dbs-command-reply nil))
+                (message "Error: debugger didn't respond to command:\n%s" command-line)
+                (setq jdee-dbs-command-reply nil))
 
     (process-send-string debugger-process "\n")
 
     (set-process-filter debugger-process previous-listener)
 
     (if jdee-dbs-command-reply
-	(let ((result (jdee-dbs-eval-debugger-output jdee-dbs-command-reply)))
+        (let ((result (jdee-dbs-eval-debugger-output jdee-dbs-command-reply)))
 
-	  (oset this :result result)
+          (oset this :result result)
 
-	  (oset this :data (car (jdee-dbo-command-result-data (oref this result))))
+          (oset this :data (car (jdee-dbo-command-result-data (oref this result))))
 
-	  (if (jdee-dbo-command-succeeded-p result)
-	      (jdee-dbs-cmd-success-action this)
-	    (jdee-dbs-cmd-failure-action this))
+          (if (jdee-dbo-command-succeeded-p result)
+              (jdee-dbs-cmd-success-action this)
+            (jdee-dbs-cmd-failure-action this))
 
-	  (jdee-dbs-cmd-display-response this)
+          (jdee-dbs-cmd-display-response this)
 
-	  (jdee-dbs-cmd-execute-pending-events this)
-	  (oref this :result)))))
+          (jdee-dbs-cmd-execute-pending-events this)
+          (oref this :result)))))
 
 (defvar jdee-dbs-cmd-counter 0
  "Count of the number of commands issued in this session.")
@@ -1360,28 +1360,28 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-launch-process (jdee-dbs-cmd)
   ((main-class  :initarg :main-class
-		:type string
-		:documentation
-		"Class containing this process's main method.")
+                :type string
+                :documentation
+                "Class containing this process's main method.")
    (jre-home    :initarg :jre-home
-		:type string
-		:documentation
-		"Home directory of JRE used to launch this process.")
+                :type string
+                :documentation
+                "Home directory of JRE used to launch this process.")
    (vmexec     :initarg :vmexec
-		:type string
-		:initform "java"
-		:documentation
-		"Name of vm executable used to run process.")
+                :type string
+                :initform "java"
+                :documentation
+                "Name of vm executable used to run process.")
    (vm-args     :initarg :args
-		:type string
-		:initform ""
-		:documentation
-		"Command line arguments to be passed to vm's main method.")
+                :type string
+                :initform ""
+                :documentation
+                "Command line arguments to be passed to vm's main method.")
    (app-args    :initarg :app-args
-		:type string
-		:initform ""
-		:documentation
-		"Command line arguments to be passed to app's main method."))
+                :type string
+                :initform ""
+                :documentation
+                "Command line arguments to be passed to app's main method."))
   "Command to launch a debuggee process.")
 
 (defun jdee-dbs-get-app-buffer-name ()
@@ -1402,65 +1402,65 @@ debugger output following the Lisp form."
   ;; Set main class.
   (if (not (slot-boundp this :main-class))
     (oset this :main-class
-	  (oref (oref this :process) :main-class)))
+          (oref (oref this :process) :main-class)))
 
   ;; Set vm.
   ;; (oset this vm (jdee-dbs-choose-vm))
 
   ;; Set vm args
   (oset this vm-args
-	(concat (mapconcat (lambda (s) s) (jdee-db-get-vm-args jdee-dbs-the-debugger) " ")
-		" "
-		(mapconcat (lambda (s) s) (jdee-db-get-vm-args-from-user) " ")))
+        (concat (mapconcat (lambda (s) s) (jdee-db-get-vm-args jdee-dbs-the-debugger) " ")
+                " "
+                (mapconcat (lambda (s) s) (jdee-db-get-vm-args-from-user) " ")))
 
 
   ;; Set application arguments.
   (oset this app-args
-	(concat
-	 (if jdee-db-option-application-args
-	     (mapconcat (lambda (s) s) jdee-db-option-application-args " ")
-	   "")
-	 " "
-	 (mapconcat (lambda (s) s) (jdee-db-get-app-args-from-user) " "))))
+        (concat
+         (if jdee-db-option-application-args
+             (mapconcat (lambda (s) s) jdee-db-option-application-args " ")
+           "")
+         " "
+         (mapconcat (lambda (s) s) (jdee-db-get-app-args-from-user) " "))))
 
 
 
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-launch-process))
   "Creates the command line for the launch command."
   (let ((cmd (format "-1 %s %s %s -vmexec %s"
-		     (oref this id)                    ;; cid
-		     (oref this name)                  ;; launch
-		     (oref (oref this process) id)     ;; pid
-		     (oref this vmexec))))
+                     (oref this id)                    ;; cid
+                     (oref this name)                  ;; launch
+                     (oref (oref this process) id)     ;; pid
+                     (oref this vmexec))))
 
     (if (slot-boundp this 'jre-home)
-	(setq cmd (concat cmd " -home " (oref this jre-home))))
+        (setq cmd (concat cmd " -home " (oref this jre-home))))
 
     (setq cmd
-	  (format "%s %s %s %s"
-		  cmd
-		  (oref this vm-args)            ;; vm args
-		  (oref this main-class)         ;; main class
-		  (oref this app-args)))         ;; command line args
+          (format "%s %s %s %s"
+                  cmd
+                  (oref this vm-args)            ;; vm args
+                  (oref this main-class)         ;; main class
+                  (oref this app-args)))         ;; command line args
 
     (oset this msg
-	  (format "Launch command line:\n  %s %s %s %s\n"
-		  (oref this vmexec)
-		  (oref this vm-args)            ;; vm args
-		  (oref this main-class)         ;; main class
-		  (oref this app-args)))         ;; command line args
+          (format "Launch command line:\n  %s %s %s %s\n"
+                  (oref this vmexec)
+                  (oref this vm-args)            ;; vm args
+                  (oref this main-class)         ;; main class
+                  (oref this app-args)))         ;; command line args
     cmd))
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-launch-process))
   (call-next-method)
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (main-class (oref this main-class))
-	 (source-buffer (current-buffer))
-	 (cli-socket
-	  (car (jdee-dbo-command-result-data (oref this result))))
-	 (cli-buffer-name
-	  (format "%s(%d) CLI" main-class (oref process id))))
+         (main-class (oref this main-class))
+         (source-buffer (current-buffer))
+         (cli-socket
+          (car (jdee-dbo-command-result-data (oref this result))))
+         (cli-buffer-name
+          (format "%s(%d) CLI" main-class (oref process id))))
 
     (oset process cli-socket cli-socket)
 
@@ -1475,10 +1475,10 @@ debugger output following the Lisp form."
       (cons jdee-bug-debugger-host-address cli-socket)))
 
     (oset this msg
-	  (format "%s\nEmacs connected to standard IO port %d for process %s."
-		  (oref this msg)
-		  cli-socket
-		  (oref this main-class)))
+          (format "%s\nEmacs connected to standard IO port %d for process %s."
+                  (oref this msg)
+                  cli-socket
+                  (oref this main-class)))
 
     (pop-to-buffer (oref process msg-buf))
     (pop-to-buffer source-buffer)
@@ -1488,12 +1488,12 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-launch-process))
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (source-buffer (current-buffer)))
+         (source-buffer (current-buffer)))
     (oset this  msg
-	  (format "%s\nError: debugger unable to launch %s.\n  Reason: %s"
-		  (oref this msg)
-		  (oref this main-class)
-		  (oref this data)))
+          (format "%s\nError: debugger unable to launch %s.\n  Reason: %s"
+                  (oref this msg)
+                  (oref this main-class)
+                  (oref this data)))
       (split-window-vertically)
       (pop-to-buffer (oref process msg-buf))
       (pop-to-buffer source-buffer)
@@ -1506,9 +1506,9 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-attach-shmem (jdee-dbs-cmd)
   ((process-name  :initarg :process-name
-		  :type string
-		  :documentation
-		  "Name of process to attach."))
+                  :type string
+                  :documentation
+                  "Name of process to attach."))
   "Attach debugger to a running process via shared memory.")
 
 (defmethod initialize-instance ((this jdee-dbs-attach-shmem) &rest fields)
@@ -1527,20 +1527,20 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-attach-shmem))
   "Creates the command line for the attach_shmem command."
   (format "-1 %s %s %s %s"
-	  (oref this id)
-	  (oref this name)                 ;; command name
-	  (oref (oref this process) id)    ;; process id
-	  (oref this process-name)))       ;; process name
+          (oref this id)
+          (oref this name)                 ;; command name
+          (oref (oref this process) id)    ;; process id
+          (oref this process-name)))       ;; process name
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-attach-shmem))
   (call-next-method)
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (source-buffer (current-buffer)))
+         (source-buffer (current-buffer)))
     (oset process :attachedp t)
     (oset process :startupp t)
     (oset this msg  (format "Attached to process %s."
-			    (oref this process-name)))
+                            (oref this process-name)))
     (split-window-vertically)
     (pop-to-buffer (oref process msg-buf))
     (pop-to-buffer source-buffer)
@@ -1549,11 +1549,11 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-attach-shmem))
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (source-buffer (current-buffer)))
+         (source-buffer (current-buffer)))
     (oset this  msg
      (format "Error: cannot attach process %s.\n Reason: %s."
-		    (oref this process-name)
-		    (oref this data)))
+                    (oref this process-name)
+                    (oref this data)))
       (split-window-vertically)
       (pop-to-buffer (oref process msg-buf))
       (pop-to-buffer source-buffer)
@@ -1567,13 +1567,13 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-attach-socket (jdee-dbs-cmd)
   ((port  :initarg :port
-	  :type string
-	  :documentation
-	  "Name of port on which existing process is listening.")
+          :type string
+          :documentation
+          "Name of port on which existing process is listening.")
    (host  :initarg :host
-	  :type string
-	  :documentation
-	  "Name of host on which existing process is listening."))
+          :type string
+          :documentation
+          "Name of host on which existing process is listening."))
   "Attach debugger to a running process via a socket connection.")
 
 (defmethod initialize-instance ((this jdee-dbs-attach-socket) &rest fields)
@@ -1592,27 +1592,27 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-attach-socket))
   "Creates the command line for the attach_socket command."
   (let ((cmd
-	 (format "-1 %s %s %s -port %s"
-	  (oref this id)
-	  (oref this name)                 ;; command name
-	  (oref (oref this process) id)    ;; process id
-	  (oref this port))))              ;; process name
+         (format "-1 %s %s %s -port %s"
+          (oref this id)
+          (oref this name)                 ;; command name
+          (oref (oref this process) id)    ;; process id
+          (oref this port))))              ;; process name
     (if (slot-boundp this 'host)
-	(setq cmd (format "%s -host %s" cmd (oref this host))))
+        (setq cmd (format "%s -host %s" cmd (oref this host))))
     cmd))
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-attach-socket))
   (call-next-method)
   (delete-other-windows)
   (let* ((process (oref this process))
-	(source-buffer (current-buffer)))
+        (source-buffer (current-buffer)))
     (oset process attachedp t)
     (oset process startupp t)
     (oset this msg  (format "Attached to process on port %s of %s."
-			    (oref this port)
-			    (if (slot-boundp this 'host)
-				(oref this host)
-			      "local host")))
+                            (oref this port)
+                            (if (slot-boundp this 'host)
+                                (oref this host)
+                              "local host")))
     (split-window-vertically)
     (pop-to-buffer (oref process msg-buf))
     (pop-to-buffer source-buffer)
@@ -1621,14 +1621,14 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-attach-socket))
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (source-buffer (current-buffer)))
+         (source-buffer (current-buffer)))
     (oset this  msg
      (format "Error: cannot attach to process on port %s of %s.\n Reason: %s."
-	     (oref this port)
-	     (if (slot-boundp this 'host)
-		 (oref this host)
-	       "local host")
-	     (oref this data)))
+             (oref this port)
+             (if (slot-boundp this 'host)
+                 (oref this host)
+               "local host")
+             (oref this data)))
       (split-window-vertically)
       (pop-to-buffer (oref process msg-buf))
       (pop-to-buffer source-buffer)
@@ -1641,14 +1641,14 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-listen-for-process (jdee-dbs-cmd)
   ((address   :initarg :address
-	      :type string
-	      :documentation
-	      "Address at which to listen for a debuggee process.")
+              :type string
+              :documentation
+              "Address at which to listen for a debuggee process.")
    (transport :initarg :transport
-	      :type string
-	      :initform "shmem"
-	      :documentation
-	      "Transport mechanism used to interact with debuggee process."))
+              :type string
+              :initform "shmem"
+              :documentation
+              "Transport mechanism used to interact with debuggee process."))
   "Listen for a process requesting debugger services.")
 
 (defmethod initialize-instance ((this jdee-dbs-listen-for-process) &rest fields)
@@ -1662,32 +1662,32 @@ debugger output following the Lisp form."
   (assert (slot-boundp this 'address))
 
   (assert (not
-	   (and
-	    (not (eq system-type 'windows-nt))
-	    (string= (oref this transport) "shmem"))))
+           (and
+            (not (eq system-type 'windows-nt))
+            (string= (oref this transport) "shmem"))))
 
   ;; Set command name.
   (oset this name
-	(concat "listen_"
-		(oref this transport))))
+        (concat "listen_"
+                (oref this transport))))
 
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-listen-for-process))
   "Creates the command line for the listen command."
   (format "-1 %s %s %s %s"
-	  (oref this id)
-	  (oref this name)                 ;; command name
-	  (oref (oref this process) id)    ;; process id
-	  (oref this address)))            ;; process address
+          (oref this id)
+          (oref this name)                 ;; command name
+          (oref (oref this process) id)    ;; process id
+          (oref this address)))            ;; process address
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-listen-for-process))
   (call-next-method)
   (delete-other-windows)
   (let* ((process (oref this process))
-	(source-buffer (current-buffer)))
+        (source-buffer (current-buffer)))
     (oset this msg  (format "Listening for process at %s address: %s."
-			    (if (string= (oref this transport) "shmem")
-				"shared memory" "socket")
-			    (oref this address)))
+                            (if (string= (oref this transport) "shmem")
+                                "shared memory" "socket")
+                            (oref this address)))
     (oset process startupp t)
     (split-window-vertically)
     (pop-to-buffer (oref process msg-buf))
@@ -1697,13 +1697,13 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-listen-for-process))
   (delete-other-windows)
   (let* ((process (oref this process))
-	 (source-buffer (current-buffer)))
+         (source-buffer (current-buffer)))
     (oset this  msg
      (format "Error: cannot listen for process at %s address: %s.\n Reason: %s."
-	     (if (string= (oref this transport) "shmem")
-		 "shared memory" "socket")
-	     (oref this address)
-	     (oref this data)))
+             (if (string= (oref this transport) "shmem")
+                 "shared memory" "socket")
+             (oref this address)
+             (oref this data)))
       (split-window-vertically)
       (pop-to-buffer (oref process msg-buf))
       (pop-to-buffer source-buffer)
@@ -1734,13 +1734,13 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-run-process))
   (call-next-method)
   (oset this msg (format "Running %s."
-			 (oref (oref this process)  main-class))))
+                         (oref (oref this process)  main-class))))
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-run-process))
   (oset this msg
-	(format "Error: unable to run %s..\n  Reason: %s."
-		(oref (oref this process) main-class)
-		(oref this result))))
+        (format "Error: unable to run %s..\n  Reason: %s."
+                (oref (oref this process) main-class)
+                (oref this result))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1765,17 +1765,17 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-finish-process))
   "Executes the finish process command."
   (let* ((process (oref this :process))
-	 (main-class (oref process :main-class))
-	 (result (call-next-method)))
+         (main-class (oref process :main-class))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(progn
-	  (jdee-dbs-proc-display-debug-message process
-	   (concat "Terminating " main-class)))
+        (progn
+          (jdee-dbs-proc-display-debug-message process
+           (concat "Terminating " main-class)))
       (jdee-dbs-proc-display-debug-message process
        (concat "Error: debugger unable to terminate: "
-	       main-class
-	       ".\n  Reason: "
-	       (car (jdee-dbo-command-result-data result))))
+               main-class
+               ".\n  Reason: "
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -1786,9 +1786,9 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-set-breakpoint (jdee-dbs-cmd)
   ((breakpoint    :initarg :breakpoint
-		  :type jdee-db-breakpoint
-		  :documentation
-		  "Breakpoint specification."))
+                  :type jdee-db-breakpoint
+                  :documentation
+                  "Breakpoint specification."))
   "Set breakpoint command.")
 
 (defmethod initialize-instance ((this jdee-dbs-set-breakpoint) &rest fields)
@@ -1806,34 +1806,34 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-set-breakpoint))
   "Creates the command line for the set breakpoint command."
   (let* ((bp-spec (oref this breakpoint))
-	 (file (file-name-nondirectory (oref bp-spec file)))
-	 (line (jdee-db-breakpoint-get-line bp-spec)))
+         (file (file-name-nondirectory (oref bp-spec file)))
+         (line (jdee-db-breakpoint-get-line bp-spec)))
     (format "%s %s %s"
-	    (call-next-method)
-	    file     ;; File
-	    line)))  ;; Line number
+            (call-next-method)
+            file     ;; File
+            line)))  ;; Line number
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-set-breakpoint))
   (call-next-method)
   (let*  ((process (oref this process))
-	  (bp-procid (oref this data))
-	  (bp-spec (oref this breakpoint))
-	  (file (oref bp-spec file))
-	  (line (jdee-db-breakpoint-get-line bp-spec))
-	  (bpspec (jdee-dbs-proc-bpspec "spec" :id bp-procid :breakpoint bp-spec))
-	  (bpspecs (if (slot-boundp process :bpspecs) (oref process :bpspecs))))
+          (bp-procid (oref this data))
+          (bp-spec (oref this breakpoint))
+          (file (oref bp-spec file))
+          (line (jdee-db-breakpoint-get-line bp-spec))
+          (bpspec (jdee-dbs-proc-bpspec "spec" :id bp-procid :breakpoint bp-spec))
+          (bpspecs (if (slot-boundp process :bpspecs) (oref process :bpspecs))))
     (if bpspecs
-	(oset process bpspecs (jdee-dbs-proc-bpspecs-add bpspecs bpspec))
+        (oset process bpspecs (jdee-dbs-proc-bpspecs-add bpspecs bpspec))
       (oset process bpspecs (jdee-dbs-proc-bpspecs-add nil bpspec)))
     (oset this msg (format "Setting breakpoint at line %s in %s." line file))))
 
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-set-breakpoint))
   (let* ((bp-spec (oref this breakpoint))
-	 (file (oref bp-spec file))
-	 (line (jdee-db-breakpoint-get-line bp-spec)))
+         (file (oref bp-spec file))
+         (line (jdee-db-breakpoint-get-line bp-spec)))
     (oset this msg  (format "Error: cannot set breakpoint at line %s in file %s.\n  Reason: %s"
-			    file line (oref this data)))))
+                            file line (oref this data)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                                            ;;
@@ -1842,9 +1842,9 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-clear-breakpoint (jdee-dbs-cmd)
   ((breakpoint    :initarg :breakpoint
-		  :type jdee-db-breakpoint
-		  :documentation
-		  "Breakpoint specification."))
+                  :type jdee-db-breakpoint
+                  :documentation
+                  "Breakpoint specification."))
   "Set breakpoint command.")
 
 (defmethod initialize-instance ((this jdee-dbs-clear-breakpoint) &rest fields)
@@ -1862,37 +1862,37 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-clear-breakpoint))
   "Creates the command line for the clear breakpoint command."
   (let* ((process (oref this process))
-	 (breakpoint (oref this breakpoint))
-	 (bpspec (jdee-dbs-proc-get-bpspec process breakpoint))
-	 (bp-procid (oref bpspec id)))
+         (breakpoint (oref this breakpoint))
+         (bpspec (jdee-dbs-proc-get-bpspec process breakpoint))
+         (bp-procid (oref bpspec id)))
     (format "%s %s"              ;; PID CID clear BPID
-	    (call-next-method)
-	    bp-procid)))         ;; Id assigned by debugger to this breakpoint
+            (call-next-method)
+            bp-procid)))         ;; Id assigned by debugger to this breakpoint
 
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-clear-breakpoint))
   "Execute clear breakpoint command."
   (let* ((process (oref this process))
-	 (breakpoint (oref this breakpoint))
-	 (file (oref breakpoint file))
-	 (line (jdee-db-breakpoint-get-line breakpoint))
-	 (proc-id (oref process id))
-	 (bpspec (jdee-dbs-proc-get-bpspec process breakpoint)))
+         (breakpoint (oref this breakpoint))
+         (file (oref breakpoint file))
+         (line (jdee-db-breakpoint-get-line breakpoint))
+         (proc-id (oref process id))
+         (bpspec (jdee-dbs-proc-get-bpspec process breakpoint)))
     (if bpspec
-	(let ((bp-procid (oref bpspec id))
-	      (result (call-next-method)))
-	  (if (jdee-dbo-command-succeeded-p result)
-	      (let ((bpspecs (oref process bpspecs)))
-		(oset process bpspecs
-		      (jdee-dbs-proc-bpspecs-remove bpspecs bpspec))
-		(jdee-dbs-proc-display-debug-message
-		 process
-		 (format "Cleared breakpoint at line %s in file %s" line file)))
-	    (jdee-dbs-proc-display-debug-message
-	     process
-	     (format "Error: cannot clear breakpoint at line %s in file %s.\n Reason: %s."
-		     line file (car (jdee-dbo-command-result-data result))))
-	    nil)))))
+        (let ((bp-procid (oref bpspec id))
+              (result (call-next-method)))
+          (if (jdee-dbo-command-succeeded-p result)
+              (let ((bpspecs (oref process bpspecs)))
+                (oset process bpspecs
+                      (jdee-dbs-proc-bpspecs-remove bpspecs bpspec))
+                (jdee-dbs-proc-display-debug-message
+                 process
+                 (format "Cleared breakpoint at line %s in file %s" line file)))
+            (jdee-dbs-proc-display-debug-message
+             process
+             (format "Error: cannot clear breakpoint at line %s in file %s.\n Reason: %s."
+                     line file (car (jdee-dbo-command-result-data result))))
+            nil)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                                            ;;
@@ -1902,10 +1902,10 @@ debugger output following the Lisp form."
 
 (defclass jdee-dbs-step (jdee-dbs-cmd)
   ((step-type :initarg :step-type
-	      :type string
-	      :initform "over"
-	      :documentation
-	      "Type of step operation: over, into, into-all, out"))
+              :type string
+              :initform "over"
+              :documentation
+              "Type of step operation: over, into, into-all, out"))
   "Step command.")
 
 (defmethod initialize-instance ((this jdee-dbs-step) &rest fields)
@@ -1923,13 +1923,13 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-step))
   "Creates the command line for the step command."
   (format "%s %d" (call-next-method)
-	  (oref (oref (oref this process) state-info) thread-id)))
+          (oref (oref (oref this process) state-info) thread-id)))
 
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-step))
   (oset this msg
-	(format "Error: unable to step %s.\n Reason: %s"
-		(oref this step-type) (oref this data))))
+        (format "Error: unable to step %s.\n Reason: %s"
+                (oref this step-type) (oref this data))))
 
 
 
@@ -1940,13 +1940,13 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defmethod jdee-dbs-proc-step-into ((this jdee-dbs-proc))
   (let* ((proc-id (oref this id))
-	 (thread-id
-	  (oref (oref this state-info) thread-id))
-	 (result (jdee-dbs-do-command proc-id  (format "step into %s" thread-id))))
+         (thread-id
+          (oref (oref this state-info) thread-id))
+         (result (jdee-dbs-do-command proc-id  (format "step into %s" thread-id))))
     (when (not (jdee-dbo-command-succeeded-p result))
       (jdee-dbs-proc-display-debug-message this
        (format "Error: unable to step into... .\n  Reason: %s"
-	       (car (jdee-dbo-command-result-data result))))
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1956,13 +1956,13 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defmethod jdee-dbs-proc-step-out ((this jdee-dbs-proc))
   (let* ((proc-id (oref this id))
-	 (thread-id
-	  (oref (oref this state-info) thread-id))
-	 (result (jdee-dbs-do-command proc-id  (format "step out %s" thread-id))))
+         (thread-id
+          (oref (oref this state-info) thread-id))
+         (result (jdee-dbs-do-command proc-id  (format "step out %s" thread-id))))
     (when (not (jdee-dbo-command-succeeded-p result))
       (jdee-dbs-proc-display-debug-message this
        (format "Error: unable to step into... .\n  Reason: %s"
-	       (car (jdee-dbo-command-result-data result))))
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1972,13 +1972,13 @@ debugger output following the Lisp form."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-evaluate (jdee-dbs-cmd)
   ((expression    :initarg :expression
-		  ;; :type string
-		  :documentation
-		  "Expression to be evaluate. Required.")
+                  ;; :type string
+                  :documentation
+                  "Expression to be evaluate. Required.")
    (thread-id     :initarg :thread-id
-		  ;; :type integer
-		  :documentation
-		  "Id of thread that scopes this expression. Required."))
+                  ;; :type integer
+                  :documentation
+                  "Id of thread that scopes this expression. Required."))
   "Evaluate expression command.")
 
 (defmethod initialize-instance ((this jdee-dbs-evaluate) &rest fields)
@@ -1997,9 +1997,9 @@ debugger output following the Lisp form."
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-evaluate))
   "Creates the command line for the clear breakpoint command."
     (format "%s %s 0 \"%s\""         ;; PID CID evaluate THREAD-ID 0 "EXPRESSION"
-	    (call-next-method)       ;; PID CID evaluate
-	    (oref this thread-id)    ;; thread id
-	    (oref this expression))) ;; expression to be evaluated.
+            (call-next-method)       ;; PID CID evaluate
+            (oref this thread-id)    ;; thread id
+            (oref this expression))) ;; expression to be evaluated.
 
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-evaluate))
@@ -2008,14 +2008,14 @@ debugger output following the Lisp form."
 VALUE is the value, and GCFLAG is t if the result has been
 garbage collected."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(car (jdee-dbo-command-result-data result))
+        (car (jdee-dbo-command-result-data result))
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot evaluate \"%s\".\n Reason: %s."
-	       (oref this expression)
-	       (car (jdee-dbo-command-result-data result))))
+               (oref this expression)
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2026,16 +2026,16 @@ garbage collected."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-get-array (jdee-dbs-cmd)
   ((array    :initarg :array
-	     :type jdee-dbs-java-array
-	     :documentation
-	     "Object to represent the array. Required.")
+             :type jdee-dbs-java-array
+             :documentation
+             "Object to represent the array. Required.")
    (index    :initarg :index
-	     :type integer
-	     :documentation
-	     "Index of array slice to be returned.")
+             :type integer
+             :documentation
+             "Index of array slice to be returned.")
    (length   :initarg :length
-	     :type integer
-	     :documentation "Length of slice to be returned."))
+             :type integer
+             :documentation "Length of slice to be returned."))
   "Get a slice of the array object specified by ARRAY. INDEX and LENGTH are
 the index and length of the slice to be returned. If omitted, this command returns
 the length of the first slice of the array. Note that each element of this array
@@ -2060,14 +2060,14 @@ can be another array or some other object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-get-array))
   "Creates the command line for the get-object command."
   (let ((cl
-	 (format "%s %d" (call-next-method) (oref (oref this array) id)))
-	(index (if (slot-boundp this :index) (oref this :index))))
+         (format "%s %d" (call-next-method) (oref (oref this array) id)))
+        (index (if (slot-boundp this :index) (oref this :index))))
     (if index
-	(setq cl
-	      (format "%s %d %d"                ;; PID CID get_array OBJ-ID INDEX LENGTH
-		      cl
-		      index                     ;; index of slice to be returned.
-		      (oref this length))))    ;; length of slice to be returned.
+        (setq cl
+              (format "%s %d %d"                ;; PID CID get_array OBJ-ID INDEX LENGTH
+                      cl
+                      index                     ;; index of slice to be returned.
+                      (oref this length))))    ;; length of slice to be returned.
     cl))
 
 
@@ -2076,32 +2076,32 @@ can be another array or some other object.")
 returns the slice as a list of elements. Otherwise, return
 the length of the array."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((array (oref this array))
-	       (data   (nth 0 (jdee-dbo-command-result-data result)))
-	       (type (nth 0 data))
-	       (id (nth 1 data))
-	       (gc-flag (nth 2 data))
-	       (length (nth 3 data))
-	       (elements (if (> (length data) 4)
-			     (cdr (cdr (cdr (cdr data)))))))
-	  (or elements length)
-	  (oset array jtype type)
-	  (oset array id id)
-	  (oset array gc-flag gc-flag)
-	  (oset array length length)
-	  (oset array elements
-		(mapcar
-		 (lambda (element)
-		   (jdee-dbs-objectify-value element))
-		 elements))
-	  array)
+        (let* ((array (oref this array))
+               (data   (nth 0 (jdee-dbo-command-result-data result)))
+               (type (nth 0 data))
+               (id (nth 1 data))
+               (gc-flag (nth 2 data))
+               (length (nth 3 data))
+               (elements (if (> (length data) 4)
+                             (cdr (cdr (cdr (cdr data)))))))
+          (or elements length)
+          (oset array jtype type)
+          (oset array id id)
+          (oset array gc-flag gc-flag)
+          (oset array length length)
+          (oset array elements
+                (mapcar
+                 (lambda (element)
+                   (jdee-dbs-objectify-value element))
+                 elements))
+          array)
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot get array %d.\n Reason: %s."
-	       (oref this object-id)
-	       (car (jdee-dbo-command-result-data result))))
+               (oref this object-id)
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2112,9 +2112,9 @@ the length of the array."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-abstract-get-object (jdee-dbs-cmd)
   ((object-id     :initarg :object-id
-		  :type integer
-		  :documentation
-		  "Id of object. Required."))
+                  :type integer
+                  :documentation
+                  "Id of object. Required."))
   "Parent class of get object commands.")
 
 
@@ -2153,7 +2153,7 @@ the object.")
 
 (defun jdee-dbs-objectify-value (value-form)
   (let ((lvf        (length value-form))
-	(value-type (car value-form)))
+        (value-type (car value-form)))
     (cond
      ((and (= lvf 1) (string= value-type "null"))
       (jdee-dbs-java-null "null"))
@@ -2164,23 +2164,23 @@ the object.")
        :value  (nth 1 value-form)))
      ((= lvf 3)
       (if (string-match "\\[\\]" value-type)
-	  (jdee-dbs-java-array
-	   (format "array %d" (nth 1 value-form))
-	   :jtype value-type
-	   :id (nth 1 value-form)
-	   :gc-flag (nth 2 value-form))
-	(jdee-dbs-java-udci
-	 (format "obj %d" (nth 1 value-form))
-	 :jtype    value-type
-	 :id       (nth 1 value-form)
-	 :gc-flag  (nth 2 value-form)))))))
+          (jdee-dbs-java-array
+           (format "array %d" (nth 1 value-form))
+           :jtype value-type
+           :id (nth 1 value-form)
+           :gc-flag (nth 2 value-form))
+        (jdee-dbs-java-udci
+         (format "obj %d" (nth 1 value-form))
+         :jtype    value-type
+         :id       (nth 1 value-form)
+         :gc-flag  (nth 2 value-form)))))))
 
 (defun jdee-dbs-objectify-variable (variable-form)
   (let* ((var-name   (car (car variable-form)))
-	 (var-type   (cdr (car variable-form)))
-	 (value-form (cdr variable-form))
-	 (value      (jdee-dbs-objectify-value
-		      value-form)))
+         (var-type   (cdr (car variable-form)))
+         (value-form (cdr variable-form))
+         (value      (jdee-dbs-objectify-value
+                      value-form)))
     (jdee-dbs-java-variable
      (format "variable %s" var-name)
      :name var-name
@@ -2191,32 +2191,32 @@ the object.")
   "Executes the get-object command. Returns a Lisp object of type
 `jdee-dbs-java-class-instance' that represents the Java object."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((obj     (car (jdee-dbo-command-result-data result)))
-	       (type    (nth 0 obj))
-	       (id      (nth 1 obj))
-	       (gc-flag (nth 2 obj))
-	       (fields  (if (> (length obj) 3)
-			    (nth 3 obj)))
-	       (object  (jdee-dbs-java-udci
-			 (format "obj %d" id)
-			 :jtype type
-			 :id id
-			 :gc-flag gc-flag)))
-	  (if fields
-	      (mapc
-	       (lambda (variable-form)
-		 (let ((field
-			(jdee-dbs-objectify-variable variable-form)))
-		   (jdee-dbs-java-udci-add-field object field)))
-	       fields))
-	  object)
+        (let* ((obj     (car (jdee-dbo-command-result-data result)))
+               (type    (nth 0 obj))
+               (id      (nth 1 obj))
+               (gc-flag (nth 2 obj))
+               (fields  (if (> (length obj) 3)
+                            (nth 3 obj)))
+               (object  (jdee-dbs-java-udci
+                         (format "obj %d" id)
+                         :jtype type
+                         :id id
+                         :gc-flag gc-flag)))
+          (if fields
+              (mapc
+               (lambda (variable-form)
+                 (let ((field
+                        (jdee-dbs-objectify-variable variable-form)))
+                   (jdee-dbs-java-udci-add-field object field)))
+               fields))
+          object)
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot get object %d.\n Reason: %s."
-	       (oref this object-id)
-	       (car (jdee-dbo-command-result-data result))))
+               (oref this object-id)
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2240,14 +2240,14 @@ the object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-string))
   "Executes the get_string command. Returns the string."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(nth 3 (car (jdee-dbo-command-result-data result)))
+        (nth 3 (car (jdee-dbo-command-result-data result)))
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot get string %d.\n Reason: %s."
-	       (oref this object-id)
-	       (car (jdee-dbo-command-result-data result))))
+               (oref this object-id)
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2257,14 +2257,14 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-get-locals (jdee-dbs-cmd)
   ((thread-id         :initarg :thread-id
-		      :type integer
-		      :documentation
-		      "ID of thread whose local variables are being queried.")
+                      :type integer
+                      :documentation
+                      "ID of thread whose local variables are being queried.")
    (stack-frame-index :initarg :stack-frame-index
-		      :type integer
-		      :initform 0
-		      :documentation
-		      "Index of stack frame containing requested local variables."))
+                      :type integer
+                      :initform 0
+                      :documentation
+                      "Index of stack frame containing requested local variables."))
   "Get variables local to a specified thread and stack frame.")
 
 
@@ -2283,28 +2283,28 @@ the object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-get-locals))
   "Creates the command line for the get-locals command."
   (format "%s %d %d"
-	  (call-next-method)
-	  (oref this thread-id)
-	  (oref this stack-frame-index)))
+          (call-next-method)
+          (oref this thread-id)
+          (oref this stack-frame-index)))
 
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-locals))
   "Executes the get-locals command. Returns a list of Lisp objects of type
 `jdee-dbs-java-variable' that represents the local variables."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((variable-forms (car (jdee-dbo-command-result-data result)))
-	       (variables      (if variable-forms
-				   (mapcar
-				    (lambda (variable-form)
-					(jdee-dbs-objectify-variable variable-form))
-				    variable-forms))))
-	  variables)
+        (let* ((variable-forms (car (jdee-dbo-command-result-data result)))
+               (variables      (if variable-forms
+                                   (mapcar
+                                    (lambda (variable-form)
+                                        (jdee-dbs-objectify-variable variable-form))
+                                    variable-forms))))
+          variables)
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot get local variables.\n Reason: %s."
-	       (car (jdee-dbo-command-result-data result))))
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2315,14 +2315,14 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-get-this (jdee-dbs-cmd)
   ((thread-id         :initarg :thread-id
-		      :type integer
-		      :documentation
-		      "ID of thread of stack frame whose this object is required.")
+                      :type integer
+                      :documentation
+                      "ID of thread of stack frame whose this object is required.")
    (stack-frame-index :initarg :stack-frame-index
-		      :type integer
-		      :initform 0
-		      :documentation
-		      "Index of stack frame whose this object is required."))
+                      :type integer
+                      :initform 0
+                      :documentation
+                      "Index of stack frame whose this object is required."))
   "Get this object of a specified stack frame.")
 
 
@@ -2342,9 +2342,9 @@ the object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-get-this))
   "Creates the command line for the get_this command."
   (format "%s %d %d"
-	  (call-next-method)
-	  (oref this thread-id)
-	  (oref this stack-frame-index)))
+          (call-next-method)
+          (oref this thread-id)
+          (oref this stack-frame-index)))
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-get-this))
   (call-next-method)
@@ -2353,11 +2353,11 @@ the object.")
      this
      :result
      (if (string= (nth 0 this-obj) "null")
-	 (jdee-dbs-java-null "null")
+         (jdee-dbs-java-null "null")
        (jdee-dbs-java-udci
-	  "this object"
-	  :jtype (nth 0 this-obj)
-	  :id (nth 1 this-obj))))))
+          "this object"
+          :jtype (nth 0 this-obj)
+          :id (nth 1 this-obj))))))
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-get-this))
  (oset
@@ -2392,17 +2392,17 @@ the object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-loaded-classes))
   "Executes the get_loaded_classes command."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let ((classes (car (jdee-dbo-command-result-data result))))
-	  (jdee-dbs-proc-display-debug-message
-	   process
-	   (format "Loaded classes:\n  %s."
-		   (mapconcat (lambda (x) x) classes "\n  ")) t)
-	  t)
+        (let ((classes (car (jdee-dbo-command-result-data result))))
+          (jdee-dbs-proc-display-debug-message
+           process
+           (format "Loaded classes:\n  %s."
+                   (mapconcat (lambda (x) x) classes "\n  ")) t)
+          t)
       (jdee-dbs-proc-display-debug-message process
-	     (format "Error: unable to list loaded classes.\n  Reason: %s."
-		     (car (jdee-dbo-command-result-data result))))
+             (format "Error: unable to list loaded classes.\n  Reason: %s."
+                     (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2428,24 +2428,24 @@ the object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-path-info))
   "Executes the get_path_info command."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((data (jdee-dbo-command-result-data result))
-	       (base-dir (nth 0 data))
-	       (boot-classpath (nth 1 data))
-	       (classpath (nth 2 data)))
-	  (jdee-dbs-proc-display-debug-message
-	   process
-	   (format (concat
-		    "\nPath information\n\n  Base directory:\n    %s\n\n  "
-		    "Boot classpath:\n    %s\n\n  Application Classpath:\n    %s\n")
-		   base-dir
-		   (mapconcat (lambda (x) x) boot-classpath "\n    ")
-		   (mapconcat (lambda (x) x) classpath "\n    ")))
-	  t)
+        (let* ((data (jdee-dbo-command-result-data result))
+               (base-dir (nth 0 data))
+               (boot-classpath (nth 1 data))
+               (classpath (nth 2 data)))
+          (jdee-dbs-proc-display-debug-message
+           process
+           (format (concat
+                    "\nPath information\n\n  Base directory:\n    %s\n\n  "
+                    "Boot classpath:\n    %s\n\n  Application Classpath:\n    %s\n")
+                   base-dir
+                   (mapconcat (lambda (x) x) boot-classpath "\n    ")
+                   (mapconcat (lambda (x) x) classpath "\n    ")))
+          t)
       (jdee-dbs-proc-display-debug-message process
-	     (format "Error: unable to display path information.\n  Reason: %s."
-		     (car (jdee-dbo-command-result-data result))))
+             (format "Error: unable to display path information.\n  Reason: %s."
+                     (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2470,17 +2470,17 @@ the object.")
 
 (defun jdee-dbs-map-thread-to-tree (thread)
   (list (quote tree-widget) :tag (concat (nth 2 thread) " thread")
-	:value nil
-	(list (quote tree-widget) :tag (concat "id: " (number-to-string (nth 1 thread))))
-	(list (quote tree-widget) :tag (concat "status: " (nth 3 thread)))
-	(list (quote tree-widget) :tag (concat "state: " (nth 4 thread)))
-	(jdee-dbs-map-stack-to-tree (nth 5 thread))))
+        :value nil
+        (list (quote tree-widget) :tag (concat "id: " (number-to-string (nth 1 thread))))
+        (list (quote tree-widget) :tag (concat "status: " (nth 3 thread)))
+        (list (quote tree-widget) :tag (concat "state: " (nth 4 thread)))
+        (jdee-dbs-map-stack-to-tree (nth 5 thread))))
 
 
 (defun jdee-dbs-map-threadgroup-to-tree (threadgroup)
   (nconc
    (list (quote tree-widget) :tag (concat (nth 2 threadgroup) " thread group")
-	:value nil)
+        :value nil)
    (mapcar
     (lambda (x)
       (jdee-dbs-map-thread-to-tree x))
@@ -2495,50 +2495,50 @@ the object.")
    (list (quote tree-widget) :tag "Stack")
    (if (listp stack)
        (mapcar
-	(lambda (x)
-	  (list (quote tree-widget) :tag
-		(format "%s.%s(%s:%s)" (nth 1 x) (nth 4 x) (nth 2 x)
-			(nth 3 x))))
-	stack))))
+        (lambda (x)
+          (list (quote tree-widget) :tag
+                (format "%s.%s(%s:%s)" (nth 1 x) (nth 4 x) (nth 2 x)
+                        (nth 3 x))))
+        stack))))
 
 (defun jdee-dbs-map-threads-to-tree (threads)
   (nconc
    (list (quote tree-widget) :tag "Threads")
-	(mapcar
-	 (lambda (x)
-	   (if (string= (nth 0 x) "Thread")
-	       (jdee-dbs-map-thread-to-tree x)
-	     (if (string= (nth 0 x) "ThreadGroup")
-		 (jdee-dbs-map-threadgroup-to-tree x))))
-	 threads)))
+        (mapcar
+         (lambda (x)
+           (if (string= (nth 0 x) "Thread")
+               (jdee-dbs-map-thread-to-tree x)
+             (if (string= (nth 0 x) "ThreadGroup")
+                 (jdee-dbs-map-threadgroup-to-tree x))))
+         threads)))
 
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-threads))
   "Executes the get-threads command. Returns a list of thread information."
   (let* ((process (oref this process))
-	 (result (call-next-method)))
+         (result (call-next-method)))
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((thread-list (car (jdee-dbo-command-result-data result)))
-	       (buf (oref process threads-buf)))
-	  (set-window-configuration (oref process win-cfg))
-	  (set-window-buffer
-	   (next-window
-	    (frame-first-window))
-	   buf)
-	  (set-buffer buf)
-	  (kill-all-local-variables)
-	  (let ((inhibit-read-only t))
-	    (erase-buffer))
-	  (let ((all (overlay-lists)))
+        (let* ((thread-list (car (jdee-dbo-command-result-data result)))
+               (buf (oref process threads-buf)))
+          (set-window-configuration (oref process win-cfg))
+          (set-window-buffer
+           (next-window
+            (frame-first-window))
+           buf)
+          (set-buffer buf)
+          (kill-all-local-variables)
+          (let ((inhibit-read-only t))
+            (erase-buffer))
+          (let ((all (overlay-lists)))
             (mapc 'delete-overlay (car all))
             (mapc 'delete-overlay (cdr all)))
-	  (apply 'widget-create (jdee-dbs-map-threads-to-tree thread-list))
-	  (use-local-map widget-keymap)
-	  (widget-setup))
+          (apply 'widget-create (jdee-dbs-map-threads-to-tree thread-list))
+          (use-local-map widget-keymap)
+          (widget-setup))
       (jdee-dbs-proc-display-debug-message
        process
        (format "Error: cannot get local variables.\n Reason: %s."
-	       (car (jdee-dbo-command-result-data result))))
+               (car (jdee-dbo-command-result-data result))))
       nil)))
 
 
@@ -2549,9 +2549,9 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-get-thread (jdee-dbs-cmd)
   ((thread-id     :initarg :thread-id
-		  :type integer
-		  :documentation
-		  "Id of thread to be queried."))
+                  :type integer
+                  :documentation
+                  "Id of thread to be queried."))
   "Gets information about a thread, including the method call stack.")
 
 
@@ -2577,8 +2577,8 @@ the object.")
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-get-thread))
  (oset this msg (format "Error: unable to get info for thread %d.\n Reason: %s."
-			(oref this thread-id)
-			(oref this result))))
+                        (oref this thread-id)
+                        (oref this result))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2588,9 +2588,9 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-get-object-monitors (jdee-dbs-cmd)
   ((object-id     :initarg :object-id
-		  :type integer
-		  :documentation
-		  "Id of object. Required."))
+                  :type integer
+                  :documentation
+                  "Id of object. Required."))
   "Get threads that are monitoring the specified object.")
 
 
@@ -2613,56 +2613,56 @@ the object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-get-object-monitors))
   "Executes the get_object_monitors command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 msg)
+         (result (call-next-method))
+         msg)
     (if (jdee-dbo-command-succeeded-p result)
-	(let* ((data (car (jdee-dbo-command-result-data result)))
-	       (obj-id (nth 0 data))
-	       (obj-type (nth 1 data))
-	       (obj-gc (nth 2 data))
-	       (owner (nth 3 data))
-	       (waiting (nth 4 data)))
+        (let* ((data (car (jdee-dbo-command-result-data result)))
+               (obj-id (nth 0 data))
+               (obj-type (nth 1 data))
+               (obj-gc (nth 2 data))
+               (owner (nth 3 data))
+               (waiting (nth 4 data)))
 
-	  (setq msg (format "\nThe following threads are monitoring <%s:%s>:\n"
-			    obj-type obj-id))
+          (setq msg (format "\nThe following threads are monitoring <%s:%s>:\n"
+                            obj-type obj-id))
 
-	  (setq
-	   msg
-	   (concat
-	    msg
-	    "  Current owner:"
-	    (if (listp owner)
-		(concat
-		 "\n"
-		 "    Name:   " (nth 1 owner) "\n"
-		 "    Id:     " (nth 2 owner) "\n"
-		 "    Status: " (nth 3 owner) "\n"
-		 "    State:  " (nth 4 owner) "\n")
-	      (if (stringp owner)
-		  (concat " " owner)))))
+          (setq
+           msg
+           (concat
+            msg
+            "  Current owner:"
+            (if (listp owner)
+                (concat
+                 "\n"
+                 "    Name:   " (nth 1 owner) "\n"
+                 "    Id:     " (nth 2 owner) "\n"
+                 "    Status: " (nth 3 owner) "\n"
+                 "    State:  " (nth 4 owner) "\n")
+              (if (stringp owner)
+                  (concat " " owner)))))
 
-	  (if waiting
-	      (setq
-	       msg
-	       (concat
-		msg
-		"\n  Waiting threads:"
-		(if (listp waiting)
-		    (progn
-		      "\n"
-		      (mapconcat
-		      (lambda (thread)
-			(concat
-			 "    Name:   " (nth 1 thread) "\n"
-			 "    Id:     " (nth 2 thread) "\n"
-			 "    Status: " (nth 3 thread) "\n"
-			 "    State:  " (nth 4 thread) "\n"))
-		      waiting "\n"))
-		  (if (stringp waiting) (concat " " waiting "\n")))))))
+          (if waiting
+              (setq
+               msg
+               (concat
+                msg
+                "\n  Waiting threads:"
+                (if (listp waiting)
+                    (progn
+                      "\n"
+                      (mapconcat
+                      (lambda (thread)
+                        (concat
+                         "    Name:   " (nth 1 thread) "\n"
+                         "    Id:     " (nth 2 thread) "\n"
+                         "    Status: " (nth 3 thread) "\n"
+                         "    State:  " (nth 4 thread) "\n"))
+                      waiting "\n"))
+                  (if (stringp waiting) (concat " " waiting "\n")))))))
       (setq msg
-	    (format "Error: cannot get object monitors for  %d.\n Reason: %s."
-		    (oref this object-id)
-		    (car (jdee-dbo-command-result-data result)))))
+            (format "Error: cannot get object monitors for  %d.\n Reason: %s."
+                    (oref this object-id)
+                    (car (jdee-dbo-command-result-data result)))))
     (jdee-dbs-proc-display-debug-message process msg)
     nil))
 
@@ -2674,9 +2674,9 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-suspend-thread (jdee-dbs-cmd)
   ((thread-id     :initarg :thread-id
-		  :type integer
-		  :documentation
-		  "Id of thread or thread-group to be suspended. If omitted, all threads are suspended."))
+                  :type integer
+                  :documentation
+                  "Id of thread or thread-group to be suspended. If omitted, all threads are suspended."))
   "Suspend a thread of this process.")
 
 
@@ -2692,19 +2692,19 @@ the object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-suspend-thread))
   "Creates the command line for the suspend_thread command."
     (if (slot-boundp this 'thread-id)
-	(format "%s %d" (call-next-method) (oref this thread-id))
+        (format "%s %d" (call-next-method) (oref this thread-id))
       (call-next-method)))
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-suspend-thread))
   (call-next-method)
   (if (slot-boundp this 'thread-id)
-	(oset this msg (format "Thread %d suspended." (oref this thread-id)))
+        (oset this msg (format "Thread %d suspended." (oref this thread-id)))
     (oset this msg "All threads suspended.")
     (oset (oref this process) suspendedp t)))
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-suspend-thread))
  (oset this msg (format "Error: unable to suspend thread.\n Reason: %s."
-	       (oref this result))))
+               (oref this result))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                                            ;;
@@ -2713,9 +2713,9 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-resume-thread (jdee-dbs-cmd)
   ((thread-id     :initarg :thread-id
-		  :type integer
-		  :documentation
-		  "Id of thread or thread-group to be resumed. If omitted, all threads are resumed."))
+                  :type integer
+                  :documentation
+                  "Id of thread or thread-group to be resumed. If omitted, all threads are resumed."))
   "Resume a thread of this process.")
 
 
@@ -2731,20 +2731,20 @@ the object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-resume-thread))
   "Creates the command line for the resume_thread command."
     (if (slot-boundp this 'thread-id)
-	(format "%s %d" (call-next-method) (oref this thread-id))
+        (format "%s %d" (call-next-method) (oref this thread-id))
       (call-next-method)))
 
 (defmethod jdee-dbs-cmd-success-action ((this jdee-dbs-resume-thread))
   (call-next-method)
   (if (slot-boundp this 'thread-id)
-	(oset this msg (format "Thread %d resumed." (oref this thread-id)))
+        (oset this msg (format "Thread %d resumed." (oref this thread-id)))
     (oset this msg "All threads resumed.")
     (oset (oref this process) suspendedp nil)))
 
 (defmethod jdee-dbs-cmd-failure-action ((this jdee-dbs-resume-thread))
   (oset this msg
-	(format "Error: unable to resume thread.\n Reason: %s."
-		(oref this result))))
+        (format "Error: unable to resume thread.\n Reason: %s."
+                (oref this result))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                                                            ;;
@@ -2753,13 +2753,13 @@ the object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-stop-thread (jdee-dbs-cmd)
   ((thread-id     :initarg :thread-id
-		  :type integer
-		  :documentation
-		  "Id of thread to be stopped.")
+                  :type integer
+                  :documentation
+                  "Id of thread to be stopped.")
    (exception-id  :initarg :exception-id
-		  :type integer
-		  :documentation
-		  "Id of thread to be stopped."))
+                  :type integer
+                  :documentation
+                  "Id of thread to be stopped."))
   "Stops the specified thread in the target process and throw the specified
 exception. You can use the evaluate expression command to create the exception
 object.")
@@ -2781,20 +2781,20 @@ object.")
   "Creates the command line for the resume_thread command."
 
   (format "%s %d %d" (call-next-method) (oref this thread-id)
-	  (oref this exception-id)))
+          (oref this exception-id)))
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-stop-thread))
   "Executes the stop_thread command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Thread %d stopped." (oref this thread-id))
-	   (format "Error: unable to stop thread %d.\n Reason: %s."
-		   (oref this thread-id)
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Thread %d stopped." (oref this thread-id))
+           (format "Error: unable to stop thread %d.\n Reason: %s."
+                   (oref this thread-id)
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2804,9 +2804,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-interrupt-thread (jdee-dbs-cmd)
   ((thread-id     :initarg :thread-id
-		  :type integer
-		  :documentation
-		  "Id of thread to be interrupted."))
+                  :type integer
+                  :documentation
+                  "Id of thread to be interrupted."))
   "Interrupt a thread of this process. An interrupted thread cannot be resumed.")
 
 
@@ -2828,15 +2828,15 @@ object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-interrupt-thread))
   "Executes the interrupt_thread command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Thread %d interrupted." (oref this thread-id))
-	   (format "Error: unable to interrupt thread %d.\n Reason: %s."
-		   (oref this thread-id)
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Thread %d interrupted." (oref this thread-id))
+           (format "Error: unable to interrupt thread %d.\n Reason: %s."
+                   (oref this thread-id)
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 
@@ -2847,9 +2847,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-methods (jdee-dbs-cmd)
   ((trace-request  :initarg :trace-request
-		   :type jdee-dbs-trace-methods-request
-		   :documentation
-		   "Trace method request."))
+                   :type jdee-dbs-trace-methods-request
+                   :documentation
+                   "Trace method request."))
   "Trace method entries or exits.")
 
 
@@ -2860,8 +2860,8 @@ object.")
   (call-next-method)
 
  (assert (or
-	  (string= (oref (oref this trace-request) trace-type) "entry")
-	  (string= (oref (oref this trace-request) trace-type) "exit")))
+          (string= (oref (oref this trace-request) trace-type) "entry")
+          (string= (oref (oref this trace-request) trace-type) "exit")))
 
   ;; Set command name.
   (oset this name "trace_methods"))
@@ -2869,55 +2869,55 @@ object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-trace-methods))
   "Creates the command line for the trace_methods command."
   (let* ((request (oref this trace-request))
-	 (cmd (format "%s %s" (call-next-method) (oref request trace-type))))
+         (cmd (format "%s %s" (call-next-method) (oref request trace-type))))
 
     (if (slot-boundp request 'thread-restriction)
-	(setq cmd (format "%s -tname %s" cmd (oref request thread-restriction))))
+        (setq cmd (format "%s -tname %s" cmd (oref request thread-restriction))))
 
     (if (slot-boundp request 'suspend-policy)
-	(setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
+        (setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
 
     (if (slot-boundp request 'inclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cf \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cf \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
 
     (if (slot-boundp request 'exclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cef \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cef \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
 
     cmd))
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-trace-methods))
   "Executes the trace_methods command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result))
-	 (request (oref this trace-request))
-	 (request-id (car (jdee-dbo-command-result-data result))))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result))
+         (request (oref this trace-request))
+         (request-id (car (jdee-dbo-command-result-data result))))
 
     (when command-succeeded-p
       (oset request id request-id)
       (if (slot-boundp process 'trace-req)
-	  (oset
-	   process
-	   trace-req
-	   (nconc (oref process trace-req)
-		  (list (cons request-id request))))
-	(oset process trace-req (list (cons request-id request)))))
+          (oset
+           process
+           trace-req
+           (nconc (oref process trace-req)
+                  (list (cons request-id request))))
+        (oset process trace-req (list (cons request-id request)))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Trace method %s enabled. Use request id %s to cancel."
-		     (oref request trace-type) request-id)
-	   (format "Error: unable to enable trace.\n Reason: %s."
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Trace method %s enabled. Use request id %s to cancel."
+                     (oref request trace-type) request-id)
+           (format "Error: unable to enable trace.\n Reason: %s."
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2927,9 +2927,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-classes (jdee-dbs-cmd)
   ((trace-request  :initarg :trace-request
-		   :type jdee-dbs-trace-classes-request
-		   :documentation
-		   "Trace classes request."))
+                   :type jdee-dbs-trace-classes-request
+                   :documentation
+                   "Trace classes request."))
   "Trace class preparations or unloadings.")
 
 
@@ -2940,8 +2940,8 @@ object.")
   (call-next-method)
 
  (assert (or
-	  (string= (oref (oref this trace-request) trace-type) "preparation")
-	  (string= (oref (oref this trace-request) trace-type) "unloading")))
+          (string= (oref (oref this trace-request) trace-type) "preparation")
+          (string= (oref (oref this trace-request) trace-type) "unloading")))
 
   ;; Set command name.
   (oset this name "trace_classes"))
@@ -2949,52 +2949,52 @@ object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-trace-classes))
   "Creates the command line for the trace_methods command."
   (let* ((request (oref this trace-request))
-	 (cmd (format "%s %s" (call-next-method) (oref request trace-type))))
+         (cmd (format "%s %s" (call-next-method) (oref request trace-type))))
 
     (if (slot-boundp request 'suspend-policy)
-	(setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
+        (setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
 
     (if (slot-boundp request 'inclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cf \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cf \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
 
     (if (slot-boundp request 'exclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cef \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cef \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
 
     cmd))
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-trace-classes))
   "Executes the trace_classes command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result))
-	 (request (oref this trace-request))
-	 (request-id (car (jdee-dbo-command-result-data result))))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result))
+         (request (oref this trace-request))
+         (request-id (car (jdee-dbo-command-result-data result))))
 
     (when command-succeeded-p
       (oset request id request-id)
       (if (slot-boundp process 'trace-req)
-	  (oset
-	   process
-	   trace-req
-	   (nconc (oref process trace-req)
-		  (list (cons request-id request))))
-	(oset process trace-req (list (cons request-id request)))))
+          (oset
+           process
+           trace-req
+           (nconc (oref process trace-req)
+                  (list (cons request-id request))))
+        (oset process trace-req (list (cons request-id request)))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Trace class %s enabled. Use request id %s to cancel."
-		     (oref request trace-type) request-id)
-	   (format "Error: unable to enable trace.\n Reason: %s."
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Trace class %s enabled. Use request id %s to cancel."
+                     (oref request trace-type) request-id)
+           (format "Error: unable to enable trace.\n Reason: %s."
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 
@@ -3005,9 +3005,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-trace-exceptions (jdee-dbs-cmd)
   ((trace-request  :initarg :trace-request
-		   :type jdee-dbs-trace-exceptions-request
-		   :documentation
-		   "Trace exceptions request."))
+                   :type jdee-dbs-trace-exceptions-request
+                   :documentation
+                   "Trace exceptions request."))
   "Trace exceptions.")
 
 
@@ -3018,9 +3018,9 @@ object.")
   (call-next-method)
 
  (assert (or
-	  (string= (oref (oref this trace-request) trace-type) "both")
-	  (string= (oref (oref this trace-request) trace-type) "caught")
-	  (string= (oref (oref this trace-request) trace-type) "uncaught")))
+          (string= (oref (oref this trace-request) trace-type) "both")
+          (string= (oref (oref this trace-request) trace-type) "caught")
+          (string= (oref (oref this trace-request) trace-type) "uncaught")))
 
   ;; Set command name.
   (oset this name "trace_exceptions"))
@@ -3028,55 +3028,55 @@ object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-trace-exceptions))
   "Creates the command line for the trace_exceptions command."
   (let* ((request (oref this trace-request))
-	 (cmd (format "%s %s %s"
-		      (call-next-method)
-		      (oref request exception-class)
-		      (oref request trace-type))))
+         (cmd (format "%s %s %s"
+                      (call-next-method)
+                      (oref request exception-class)
+                      (oref request trace-type))))
 
     (if (slot-boundp request 'suspend-policy)
-	(setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
+        (setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
 
     (if (slot-boundp request 'inclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cf \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cf \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
 
     (if (slot-boundp request 'exclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cef \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cef \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
 
     cmd))
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-trace-exceptions))
   "Executes the trace_exceptions command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result))
-	 (request (oref this trace-request))
-	 (request-id (car (jdee-dbo-command-result-data result))))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result))
+         (request (oref this trace-request))
+         (request-id (car (jdee-dbo-command-result-data result))))
 
     (when command-succeeded-p
       (oset request id request-id)
       (if (slot-boundp process 'trace-req)
-	  (oset
-	   process
-	   trace-req
-	   (nconc (oref process trace-req)
-		  (list (cons request-id request))))
-	(oset process trace-req (list (cons request-id request)))))
+          (oset
+           process
+           trace-req
+           (nconc (oref process trace-req)
+                  (list (cons request-id request))))
+        (oset process trace-req (list (cons request-id request)))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Trace exception %s enabled. Use request id %s to cancel."
-		     (oref request exception-class) request-id)
-	   (format "Error: unable to enable trace.\n Reason: %s."
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Trace exception %s enabled. Use request id %s to cancel."
+                     (oref request exception-class) request-id)
+           (format "Error: unable to enable trace.\n Reason: %s."
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3086,9 +3086,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-cancel-trace (jdee-dbs-cmd)
   ((trace-request  :initarg :trace-request
-		   :type jdee-dbs-trace-request
-		   :documentation
-		   "Trace request."))
+                   :type jdee-dbs-trace-request
+                   :documentation
+                   "Trace request."))
   "Cancel a trace request.")
 
 
@@ -3112,28 +3112,28 @@ object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-cancel-trace))
   "Executes the cancel_trace command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
 
     (if command-succeeded-p
-	(let* ((canceled-request-id (oref (oref this trace-request) id))
-	       (requests
-		(cl-remove-if
-		 (lambda (r)
-		   (= (car r) canceled-request-id))
-		 (oref process trace-req))))
-	  (if requests
-	      (oset process trace-req requests)
-	    (slot-makeunbound process 'trace-req))))
+        (let* ((canceled-request-id (oref (oref this trace-request) id))
+               (requests
+                (cl-remove-if
+                 (lambda (r)
+                   (= (car r) canceled-request-id))
+                 (oref process trace-req))))
+          (if requests
+              (oset process trace-req requests)
+            (slot-makeunbound process 'trace-req))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Canceled trace request %s."
-		     (oref (oref this trace-request) id))
-	   (format "Error: unable to cancel trace %s.\n Reason: %s."
-		   (oref (oref this trace-request) id)
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Canceled trace request %s."
+                     (oref (oref this trace-request) id))
+           (format "Error: unable to cancel trace %s.\n Reason: %s."
+                   (oref (oref this trace-request) id)
+                   (car (jdee-dbo-command-result-data result)))))
 
     command-succeeded-p))
 
@@ -3145,9 +3145,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-watch-field (jdee-dbs-cmd)
   ((watch-request  :initarg :watch-request
-		   :type jdee-dbs-watch-field-request
-		   :documentation
-		   "Watch field request."))
+                   :type jdee-dbs-watch-field-request
+                   :documentation
+                   "Watch field request."))
   "Watch a field of an object or a specified class of objects.")
 
 
@@ -3160,8 +3160,8 @@ object.")
   (let ((request (oref this watch-request)))
 
     (assert (or
-	     (string= (oref request watch-type) "access")
-	     (string= (oref request watch-type) "modification")))
+             (string= (oref request watch-type) "access")
+             (string= (oref request watch-type) "modification")))
 
     (assert (slot-boundp request 'object-class))
     (assert (slot-boundp request 'field-name)))
@@ -3172,68 +3172,68 @@ object.")
 (defmethod jdee-dbs-cmd-make-command-line ((this jdee-dbs-watch-field))
   "Creates the command line for the watch-field command."
   (let* ((request (oref this watch-request))
-	 (cmd (format
-	       "%s %s %s %s"
-	       (call-next-method)
-	       (oref request object-class)
-	       (oref request field-name)
-	       (concat "for_" (oref request watch-type)))))
+         (cmd (format
+               "%s %s %s %s"
+               (call-next-method)
+               (oref request object-class)
+               (oref request field-name)
+               (concat "for_" (oref request watch-type)))))
 
     (if (slot-boundp request 'object-id)
-	(setq cmd (format "%s -oid %s" cmd (oref request object-id))))
+        (setq cmd (format "%s -oid %s" cmd (oref request object-id))))
 
     (if (slot-boundp request 'expression)
-	(setq cmd (format "%s -if %s" cmd (oref request expression))))
+        (setq cmd (format "%s -if %s" cmd (oref request expression))))
 
     (if (slot-boundp request 'suspend-policy)
-	(setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
+        (setq cmd (format "%s -sp %s" cmd (oref request suspend-policy))))
 
     (if (slot-boundp request 'inclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cf \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cf \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request inclusion-filters) " "))))
 
     (if (slot-boundp request 'exclusion-filters)
-	(setq cmd
-	      (format
-	       "%s -cef \"%s\""
-	       cmd
-	       (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
+        (setq cmd
+              (format
+               "%s -cef \"%s\""
+               cmd
+               (mapconcat (lambda (x) x) (oref request exclusion-filters) " "))))
 
     cmd))
 
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-watch-field))
   "Executes the watch-field command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result))
-	 (request (oref this watch-request))
-	 (request-id (car (jdee-dbo-command-result-data result))))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result))
+         (request (oref this watch-request))
+         (request-id (car (jdee-dbo-command-result-data result))))
 
     (when command-succeeded-p
       (oset request id request-id)
       (if (slot-boundp process 'watch-req)
-	  (oset
-	   process
-	   watch-req
-	   (nconc (oref process watch-req)
-		  (list (cons request-id request))))
-	(oset process watch-req (list (cons request-id request)))))
+          (oset
+           process
+           watch-req
+           (nconc (oref process watch-req)
+                  (list (cons request-id request))))
+        (oset process watch-req (list (cons request-id request)))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Watch request field for field %s of %s instance of class %s is enabled. Use request id %s to cancel."
-		     (oref request field-name)
-		     (if (slot-boundp request 'object-id)
-			 (oref request object-id)
-		       "any")
-		     (oref request object-class)
-		     request-id)
-	   (format "Error: unable to enable watch request.\n Reason: %s."
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Watch request field for field %s of %s instance of class %s is enabled. Use request id %s to cancel."
+                     (oref request field-name)
+                     (if (slot-boundp request 'object-id)
+                         (oref request object-id)
+                       "any")
+                     (oref request object-class)
+                     request-id)
+           (format "Error: unable to enable watch request.\n Reason: %s."
+                   (car (jdee-dbo-command-result-data result)))))
     command-succeeded-p))
 
 
@@ -3244,9 +3244,9 @@ object.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-dbs-cancel-watch (jdee-dbs-cmd)
   ((watch-request  :initarg :watch-request
-		   :type jdee-dbs-watch-field-request
-		   :documentation
-		   "Watch request."))
+                   :type jdee-dbs-watch-field-request
+                   :documentation
+                   "Watch request."))
   "Cancel a watch request.")
 
 
@@ -3270,28 +3270,28 @@ object.")
 (defmethod jdee-dbs-cmd-exec ((this jdee-dbs-cancel-watch))
   "Executes the cancel watch command."
   (let* ((process (oref this process))
-	 (result (call-next-method))
-	 (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
+         (result (call-next-method))
+         (command-succeeded-p (jdee-dbo-command-succeeded-p result)))
 
     (if command-succeeded-p
-	(let* ((canceled-request-id (oref (oref this watch-request) id))
-	       (requests
-		(cl-remove-if
-		 (lambda (r)
-		   (= (car r) canceled-request-id))
-		 (oref process watch-req))))
-	  (if requests
-	      (oset process watch-req requests)
-	    (slot-makeunbound process 'watch-req))))
+        (let* ((canceled-request-id (oref (oref this watch-request) id))
+               (requests
+                (cl-remove-if
+                 (lambda (r)
+                   (= (car r) canceled-request-id))
+                 (oref process watch-req))))
+          (if requests
+              (oset process watch-req requests)
+            (slot-makeunbound process 'watch-req))))
 
     (jdee-dbs-proc-display-debug-message
-	 process
-	 (if command-succeeded-p
-	     (format "Canceled watch request %s."
-		     (oref (oref this watch-request) id))
-	   (format "Error: unable to cancel watch request %s.\n Reason: %s."
-		   (oref (oref this watch-request) id)
-		   (car (jdee-dbo-command-result-data result)))))
+         process
+         (if command-succeeded-p
+             (format "Canceled watch request %s."
+                     (oref (oref this watch-request) id))
+           (format "Error: unable to cancel watch request %s.\n Reason: %s."
+                   (oref (oref this watch-request) id)
+                   (car (jdee-dbo-command-result-data result)))))
 
     command-succeeded-p))
 

--- a/jdee-ecj-flymake.el
+++ b/jdee-ecj-flymake.el
@@ -156,7 +156,7 @@ To use this funtion set the java line in `flymake-allowed-file-name-masks' to
                            temp-file
                            (file-name-directory buffer-file-name))))
         (list "java" (append  (list "-jar" (oref  (jdee-compile-get-ejc) path) "-noExit" "-Xemacs")
-			      (jdee-compile-classpath-arg (jdee-compile-get-the-compiler))
+                              (jdee-compile-classpath-arg (jdee-compile-get-the-compiler))
                               jdee-ecj-command-line-args
                               (list local-file))))))
 
@@ -305,10 +305,10 @@ the output stream."
   "Start syntax check process."
   (let* ((process nil))
     (condition-case err
-	(progn
-	  (when dir
-	    (let ((default-directory dir))
-	      (flymake-log 3 "starting process on dir %s" default-directory)))
+        (progn
+          (when dir
+            (let ((default-directory dir))
+              (flymake-log 3 "starting process on dir %s" default-directory)))
 
           (cond
            ((and (listp cmd) (processp (car cmd)))
@@ -327,24 +327,24 @@ the output stream."
                          (process-id process) (process-command process)
                          default-directory)))
 
-	  (set-process-filter process 'flymake-process-filter)
+          (set-process-filter process 'flymake-process-filter)
           (push process flymake-processes)
 
           (setq flymake-is-running t)
           (setq flymake-last-change-time nil)
           (setq flymake-check-start-time (flymake-float-time))
 
-	  (flymake-report-status nil "*")
+          (flymake-report-status nil "*")
 
-	  process)
+          process)
       (error
        (let* ((err-str (format "Failed to launch syntax check process  with args : %s"
-			       (error-message-string err)))
-	      (source-file-name buffer-file-name)
-	      (cleanup-f        (flymake-get-cleanup-function source-file-name)))
-	 (flymake-log 0 err-str)
-	 (funcall cleanup-f)
-	 (flymake-report-fatal-status "PROCERR" err-str))))))
+                               (error-message-string err)))
+              (source-file-name buffer-file-name)
+              (cleanup-f        (flymake-get-cleanup-function source-file-name)))
+         (flymake-log 0 err-str)
+         (funcall cleanup-f)
+         (flymake-report-fatal-status "PROCERR" err-str))))))
 
 
 (defun jdee-ecj-flymake-process-filter (process output)

--- a/jdee-ejb.el
+++ b/jdee-ejb.el
@@ -65,9 +65,9 @@ name portion of the filename string."
   :type 'string
   :group 'jdee-ejb
   :set '(lambda (sym val)
-	  (set-default 'jdee-ejb-home
-		      (file-name-sans-extension val))
-	  (set-default sym val)))
+          (set-default 'jdee-ejb-home
+                      (file-name-sans-extension val))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-ejb-local-format)
 (defcustom jdee-ejb-local-format "%sLocal.java"
@@ -75,9 +75,9 @@ name portion of the filename string."
   :type 'string
   :group 'jdee-ejb
   :set '(lambda (sym val)
-	  (set-default 'jdee-ejb-local
-		      (file-name-sans-extension val))
-	  (set-default sym val)))
+          (set-default 'jdee-ejb-local
+                      (file-name-sans-extension val))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-ejb-local-home-format)
 (defcustom jdee-ejb-local-home-format "%sLocalHome.java"
@@ -87,9 +87,9 @@ name portion of the filename string."
   :type 'string
   :group 'jdee-ejb
   :set '(lambda (sym val)
-	  (set-default 'jdee-ejb-local-home
-		      (file-name-sans-extension val))
-	  (set-default sym val)))
+          (set-default 'jdee-ejb-local-home
+                      (file-name-sans-extension val))
+          (set-default sym val)))
 
 
 ;; (makunbound 'jdee-ejb-class-format)
@@ -100,9 +100,9 @@ name portion of the filename string."
   :type 'string
   :group 'jdee-ejb
   :set '(lambda (sym val)
-	  (set-default 'jdee-ejb-class
-		      (file-name-sans-extension val))
-	  (set-default sym val)))
+          (set-default 'jdee-ejb-class
+                      (file-name-sans-extension val))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-ejb-descriptor-format)
 (defcustom jdee-ejb-descriptor-format "%sEJB.xml"
@@ -143,18 +143,18 @@ command `jdee-ejb-remote', as a side-effect."
     :group 'jdee-ejb
     :type '(repeat string)
     :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-remote
-	      (tempo-define-template "java-ejb-remote-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic Java class buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-remote
+              (tempo-define-template "java-ejb-remote-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic Java class buffer skeleton."))
+            (set-default sym val)))
 
   (defalias 'jdee-ejb-remote
     (tempo-define-template "java-ejb-remote-buffer-template"
-			   (jdee-gen-read-template jdee-ejb-remote-buffer-template)
-			   nil
-			   "Insert a generic Java class buffer skeleton."))
+                           (jdee-gen-read-template jdee-ejb-remote-buffer-template)
+                           nil
+                           "Insert a generic Java class buffer skeleton."))
   )
 
 ;; (makunbound 'jdee-ejb-home-buffer-template)
@@ -186,18 +186,18 @@ command `jdee-ejb-home', as a side-effect."
     :group 'jdee-ejb
     :type '(repeat string)
     :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-home
-	      (tempo-define-template "java-ejb-home-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic Java class buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-home
+              (tempo-define-template "java-ejb-home-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic Java class buffer skeleton."))
+            (set-default sym val)))
 
   (defalias 'jdee-ejb-home
     (tempo-define-template "java-ejb-home-buffer-template"
-			   (jdee-gen-read-template jdee-ejb-home-buffer-template)
-			   nil
-			   "Insert a generic Java class buffer skeleton."))
+                           (jdee-gen-read-template jdee-ejb-home-buffer-template)
+                           nil
+                           "Insert a generic Java class buffer skeleton."))
   )
 
 ;;;;;;; start - by yoonforh 2003-01-15 17:09:14
@@ -230,18 +230,18 @@ command `jdee-ejb-local', as a side-effect."
     :group 'jdee-ejb
     :type '(repeat string)
     :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-local
-	      (tempo-define-template "java-ejb-local-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic Java class buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-local
+              (tempo-define-template "java-ejb-local-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic Java class buffer skeleton."))
+            (set-default sym val)))
 
   (defalias 'jdee-ejb-local
     (tempo-define-template "java-ejb-local-buffer-template"
-			   (jdee-gen-read-template jdee-ejb-local-buffer-template)
-			   nil
-			   "Insert a generic Java class buffer skeleton."))
+                           (jdee-gen-read-template jdee-ejb-local-buffer-template)
+                           nil
+                           "Insert a generic Java class buffer skeleton."))
   )
 
 ;; (makunbound 'jdee-ejb-local-home-buffer-template)
@@ -273,18 +273,18 @@ command `jdee-ejb-local-home', as a side-effect."
     :group 'jdee-ejb
     :type '(repeat string)
     :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-local-home
-	      (tempo-define-template "java-ejb-local-home-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic Java class buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-local-home
+              (tempo-define-template "java-ejb-local-home-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic Java class buffer skeleton."))
+            (set-default sym val)))
 
   (defalias 'jdee-ejb-local-home
     (tempo-define-template "java-ejb-local-home-buffer-template"
-			   (jdee-gen-read-template jdee-ejb-local-home-buffer-template)
-			   nil
-			   "Insert a generic Java class buffer skeleton."))
+                           (jdee-gen-read-template jdee-ejb-local-home-buffer-template)
+                           nil
+                           "Insert a generic Java class buffer skeleton."))
   )
 
 
@@ -444,12 +444,12 @@ command `jdee-ejb-entity-bean', as a side-effect."
   :group 'jdee-ejb
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-ejb-entity-bean
-	    (tempo-define-template "java-ejb-entity-bean-template"
-				   (jdee-gen-read-template val)
-				   nil
-				   "Insert a generic Entity Bean skeleton."))
-	  (set-default sym val)))
+          (defalias 'jdee-ejb-entity-bean
+            (tempo-define-template "java-ejb-entity-bean-template"
+                                   (jdee-gen-read-template val)
+                                   nil
+                                   "Insert a generic Entity Bean skeleton."))
+          (set-default sym val)))
 
 
 ;; (makunbound 'jdee-ejb-session-bean-template)
@@ -579,12 +579,12 @@ command `jdee-ejb-session-bean', as a side-effect."
   :group 'jdee-ejb
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-ejb-session-bean
-	    (tempo-define-template "java-ejb-session-bean-template"
-				   (jdee-gen-read-template val)
-				   nil
-				   "Insert a generic Session Bean skeleton."))
-	  (set-default sym val)))
+          (defalias 'jdee-ejb-session-bean
+            (tempo-define-template "java-ejb-session-bean-template"
+                                   (jdee-gen-read-template val)
+                                   nil
+                                   "Insert a generic Session Bean skeleton."))
+          (set-default sym val)))
 
 
 ;; (makunbound 'jdee-ejb-session-descriptor-buffer-template)
@@ -631,12 +631,12 @@ command `jdee-ejb-session-descriptor', as a side-effect."
   :group 'jdee-ejb
   :type '(repeat string)
   :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-session-descriptor
-	      (tempo-define-template "java-ejb-session-descriptor-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic XML Deployment Descriptor buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-session-descriptor
+              (tempo-define-template "java-ejb-session-descriptor-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic XML Deployment Descriptor buffer skeleton."))
+            (set-default sym val)))
 
 ;; (makunbound 'jdee-ejb-entity-descriptor-buffer-template)
 (defcustom jdee-ejb-entity-descriptor-buffer-template
@@ -701,12 +701,12 @@ command `jdee-ejb-session-descriptor', as a side-effect."
   :group 'jdee-ejb
   :type '(repeat string)
   :set '(lambda (sym val)
-	    (defalias 'jdee-ejb-entity-descriptor
-	      (tempo-define-template "java-ejb-entity-descriptor-buffer-template"
-				     (jdee-gen-read-template val)
-				     nil
-				     "Insert a generic XML Deployment Descriptor buffer skeleton."))
-	    (set-default sym val)))
+            (defalias 'jdee-ejb-entity-descriptor
+              (tempo-define-template "java-ejb-entity-descriptor-buffer-template"
+                                     (jdee-gen-read-template val)
+                                     nil
+                                     "Insert a generic XML Deployment Descriptor buffer skeleton."))
+            (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-ejb-session-bean-buffer (ejb-name)
@@ -717,7 +717,7 @@ by the jdee-ejb templates.  This includes naming the files according
 to the EJB naming convention."
   (interactive
    (let* ((insert-default-directory t)
-	  (file (read-file-name "EJB Name (no extension): ")))
+          (file (read-file-name "EJB Name (no extension): ")))
      (setq jdee-ejb-dir  (file-name-directory file))
      (list (file-name-sans-extension (file-name-nondirectory file)))))
 
@@ -734,7 +734,7 @@ by the jdee-ejb templates.  This includes naming the files according
 to the EJB naming convention."
   (interactive
    (let* ((insert-default-directory t)
-	  (file (read-file-name "EJB Name (no extension): ")))
+          (file (read-file-name "EJB Name (no extension): ")))
      (setq jdee-ejb-dir  (file-name-directory file))
      (list (file-name-sans-extension (file-name-nondirectory file)))))
 

--- a/jdee-font-lock.el
+++ b/jdee-font-lock.el
@@ -273,7 +273,7 @@ to match and the complexity of each regexp."
   "Face name to use for javadocs (sans tags etc).")
 (defvar jdee-font-lock-modifier-face  'jdee-font-lock-modifier-face
   "Face name to use for modifiers.")
-(defvar jdee-font-lock-private-face	  'jdee-font-lock-private-face
+(defvar jdee-font-lock-private-face          'jdee-font-lock-private-face
   "Face name to use for private modifiers.")
 (defvar jdee-font-lock-protected-face 'jdee-font-lock-protected-face
   "Face name to use for protected modifiers.")
@@ -326,46 +326,46 @@ to match and the complexity of each regexp."
 (defconst jdee-font-lock-modifier-regexp
   (eval-when-compile
     (concat "\\<\\("
-	    (regexp-opt '("abstract"
-			  "const"
-			  "final"
-			  "native"
-			  ;;; removed after making each its own font -PaulL
-			  ;;"private"
-			  ;;"protected"
-			  ;;"public"
-			  "static"
-			  "strictfp"
-			  "synchronized"
-			  "transient"
-			  "volatile"
-			  ))
-	    "\\)\\>"))
+            (regexp-opt '("abstract"
+                          "const"
+                          "final"
+                          "native"
+                          ;;; removed after making each its own font -PaulL
+                          ;;"private"
+                          ;;"protected"
+                          ;;"public"
+                          "static"
+                          "strictfp"
+                          "synchronized"
+                          "transient"
+                          "volatile"
+                          ))
+            "\\)\\>"))
   "Regular expression to match Java modifiers.")
 
 (defconst jdee-font-lock-number-regexp
   (eval-when-compile
     ;; As of Java 7, underscores can appear anywhere _between_ digits
     (concat "\\("
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][0-9]\\([0-9_]*[0-9]\\)?\\([eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?\\)?[fFdD]?\\>"
-	    "\\|"
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?[fFdD]?\\>"
-	    "\\|"
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][fFdD]\\>"
-	    "\\|"
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?[.]"
-	    "\\|"
-	    "[.][0-9]\\([0-9_]*[0-9]\\)?\\([eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?\\)?[fFdD]?\\>"
-	    "\\|"
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?[eE][-+]?[0-9]+[fFdD]?\\>"
-	    "\\|"
-	    "\\<0[xX][0-9a-fA-F]\\([0-9a-fA-F_]*[0-9a-fA-F]\\)?[lL]?\\>"
-	    "\\|"
-	    "\\<0[bB][01]\\([01_]*[01]\\)?[lL]?\\>" ; Binary literal, introduced in Java 7
-	    "\\|"
-	    "\\<[0-9]\\([0-9_]*[0-9]\\)?+[lLfFdD]?\\>"
-	    "\\)"
-	    ))
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][0-9]\\([0-9_]*[0-9]\\)?\\([eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?\\)?[fFdD]?\\>"
+            "\\|"
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?[fFdD]?\\>"
+            "\\|"
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?[.][fFdD]\\>"
+            "\\|"
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?[.]"
+            "\\|"
+            "[.][0-9]\\([0-9_]*[0-9]\\)?\\([eE][-+]?[0-9]\\([0-9_]*[0-9]\\)?\\)?[fFdD]?\\>"
+            "\\|"
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?[eE][-+]?[0-9]+[fFdD]?\\>"
+            "\\|"
+            "\\<0[xX][0-9a-fA-F]\\([0-9a-fA-F_]*[0-9a-fA-F]\\)?[lL]?\\>"
+            "\\|"
+            "\\<0[bB][01]\\([01_]*[01]\\)?[lL]?\\>" ; Binary literal, introduced in Java 7
+            "\\|"
+            "\\<[0-9]\\([0-9_]*[0-9]\\)?+[lLfFdD]?\\>"
+            "\\)"
+            ))
   "Regular expression to match Java numbers.")
 
 (defconst jdee-font-lock-operator-regexp
@@ -375,8 +375,8 @@ to match and the complexity of each regexp."
 (defconst jdee-font-lock-capital-id-regexp
   (eval-when-compile
     (concat "\\(\\b[" jdee-font-lock-capital-letter
-	    "]+[" jdee-font-lock-capital-letter-or-digit
-	    "]*\\b\\)"))
+            "]+[" jdee-font-lock-capital-letter-or-digit
+            "]*\\b\\)"))
   "Regular expression to match capitalised identifiers.")
 
 ;;;;
@@ -389,16 +389,16 @@ to match and the complexity of each regexp."
 The string between <TAG> and </TAG> is the second parenthesized
 expression in the returned regexp.  ALIASES are other names for TAG."
     (let* ((tag-re (mapconcat
-		    #'(lambda (tag)
-			(mapconcat #'(lambda (c)
-				       (format "[%c%c]"
-					       (upcase c)
-					       (downcase c)))
-				   tag
-				   ""))
-		    (cons tag aliases)
-		    "\\|"))
-	   (hit-re "\\(.\\|[\r\n]\\)*?"))
+                    #'(lambda (tag)
+                        (mapconcat #'(lambda (c)
+                                       (format "[%c%c]"
+                                               (upcase c)
+                                               (downcase c)))
+                                   tag
+                                   ""))
+                    (cons tag aliases)
+                    "\\|"))
+           (hit-re "\\(.\\|[\r\n]\\)*?"))
       (format "<\\(%s\\)>\\(%s\\)</\\(%s\\)>" tag-re hit-re tag-re)
       )))
 
@@ -409,22 +409,22 @@ expression in the returned regexp.  ALIASES are other names for TAG."
 (defmacro jdee-font-lock-at-comment (pos)
   "Return non-nil if POS is in a comment."
   `(memq (get-text-property ,pos 'face)
-	 jdee-font-lock-comment-faces))
+         jdee-font-lock-comment-faces))
 
 (defsubst jdee-font-lock-search-in-comment (regexp end)
   "Search forward from point for regular expression REGEXP.
 Ensure matching occurs in a java comment.  Buffer position END bounds
 the search.  The match found must not extend after that position."
   (let ((here (point))
-	ok b p)
+        ok b p)
     (while (and (not ok)
-		(setq p (re-search-forward regexp end t)))
+                (setq p (re-search-forward regexp end t)))
       (setq b (match-beginning 0))
       (setq ok (and (jdee-font-lock-at-comment b)
-		    (< p (next-single-property-change
-			  b 'face nil (point-max))))))
+                    (< p (next-single-property-change
+                          b 'face nil (point-max))))))
     (if ok
-	(point)
+        (point)
       (goto-char here)
       nil)))
 
@@ -434,17 +434,17 @@ Ensure matching occurs in a javadoc comment.  Buffer position END
 bounds the search.  The match found must not extend after that
 position."
   (let ((here (point))
-	b c ok md p)
+        b c ok md p)
     (while (and (not ok) (setq p (re-search-forward regexp end t)))
       (setq b  (match-beginning 0)
-	    md (match-data)
-	    ok (and (re-search-backward "^\\s-*\\(/[*][*]\\)" nil t)
-		    (jdee-font-lock-at-comment
-		     (goto-char (setq c (match-beginning 1))))
-		    (forward-comment 1)
-		    (< p (point))
-		    (>= b c)
-		    (setq here p)))
+            md (match-data)
+            ok (and (re-search-backward "^\\s-*\\(/[*][*]\\)" nil t)
+                    (jdee-font-lock-at-comment
+                     (goto-char (setq c (match-beginning 1))))
+                    (forward-comment 1)
+                    (< p (point))
+                    (>= b c)
+                    (setq here p)))
       (goto-char p))
     (set-match-data md)
     (goto-char here)
@@ -479,7 +479,7 @@ Limit search to END position."
   `(
     ;; Fontify javadoc tags (including non official ones)
     (,(concat "^[ \t]*\\(/\\*\\*\\|\\*?\\)[ \t]*"
-	      "\\(@[" jdee-font-lock-letter-or-digit "]+\\)")
+              "\\(@[" jdee-font-lock-letter-or-digit "]+\\)")
      2 jdee-font-lock-doc-tag-face t)
     ;; Fontify @param variable name
     ("^[ \t]*\\(/\\*\\*\\|\\*?\\)[ \t]*@param\\>[ \t]*\\(\\sw+\\)?"
@@ -497,8 +497,8 @@ Limit search to END position."
      (2 jdee-font-lock-link-face t))
     ;; Fontify @see reference
     (,(concat "^[ \t]*\\(/\\*\\*\\|\\*?\\)[ \t]*"
-	      "@see\\>[ \t]*"
-	      "\\([.#" jdee-font-lock-letter-or-digit "]+\\)")
+              "@see\\>[ \t]*"
+              "\\([.#" jdee-font-lock-letter-or-digit "]+\\)")
      2 jdee-font-lock-code-face t)
     ;; Fontify the text of a HREF anchor
     ("<[Aa]\\s-+[Hh][Rr][Ee][Ff][^>]*>\\([^>]+\\)</[Aa]>"
@@ -528,11 +528,11 @@ That is those with \"@\" in their matcher regexp."
   (let (kw matcher)
     (while keywords
       (setq matcher  (car keywords)
-	    keywords (cdr keywords))
+            keywords (cdr keywords))
       (if (not (and (consp matcher)
-		    (stringp (car matcher))
-		    (string-match "@" (car matcher))))
-	  (setq kw (cons matcher kw))))
+                    (stringp (car matcher))
+                    (string-match "@" (car matcher))))
+          (setq kw (cons matcher kw))))
     (nreverse kw)))
 
 (defconst jdee-font-lock-html-ahref-keyword
@@ -551,8 +551,8 @@ A new keyword is pushed into `jdee-font-lock-html-keywords'."
     `(progn
        (add-to-list 'jdee-font-lock-html-keywords '(,matcher 2 ,face t))
        (defun ,matcher (end)
-	 (jdee-font-lock-search-in-javadoc
-	  ,(jdee-font-lock-html-tag-regexp tag) end)))))
+         (jdee-font-lock-search-in-javadoc
+          ,(jdee-font-lock-html-tag-regexp tag) end)))))
 
 (jdee-font-lock-def-html-keyword "b" jdee-font-lock-bold-face)
 (jdee-font-lock-def-html-keyword "strong" jdee-font-lock-bold-face)
@@ -568,7 +568,7 @@ Limit search to END position."
   (jdee-font-lock-search-in-javadoc
    (eval-when-compile
      (concat "^[ \t]*\\(/\\*\\*\\|\\*?\\)[ \t]*"
-	     "\\(@[" jdee-font-lock-letter-or-digit "]+\\)"))
+             "\\(@[" jdee-font-lock-letter-or-digit "]+\\)"))
    end))
 
 (defconst jdee-font-lock-javadoc-tag-keyword
@@ -607,8 +607,8 @@ Limit search to END position."
   (jdee-font-lock-search-in-javadoc
    (eval-when-compile
      (concat "^[ \t]*\\(/\\*\\*\\|\\*?\\)[ \t]*"
-	     "@see\\>[ \t]*"
-	     "\\([.#" jdee-font-lock-letter-or-digit "]+\\)"))
+             "@see\\>[ \t]*"
+             "\\([.#" jdee-font-lock-letter-or-digit "]+\\)"))
    end))
 
 (defconst jdee-font-lock-javadoc-see-ref-keyword
@@ -659,8 +659,8 @@ keywords by entering the command:
 \\[universal-argument] \\[jdee-font-lock-setup-keywords]."
   :group 'jdee-project
   :type '(choice :tag "Names"
-		 (const :tag "No" nil)
-		 (file  :tag "In file" :format "%t\n%v")))
+                 (const :tag "No" nil)
+                 (file  :tag "In file" :format "%t\n%v")))
 
 (defcustom jdee-font-lock-api-name-filter nil
   "*Function used to filter a name."
@@ -670,7 +670,7 @@ keywords by entering the command:
 (defconst jdee-font-lock-api-entry-regexp
   (eval-when-compile
     (concat "^[" jdee-font-lock-letter "]"
-	    "[" jdee-font-lock-letter-or-digit "]+$"))
+            "[" jdee-font-lock-letter-or-digit "]+$"))
   "Regexp to match a valid entry in `jdee-font-lock-api-file'.")
 
 (defconst jdee-font-lock-api-entry-match 0
@@ -682,16 +682,16 @@ If optional FILTER function is non-nil it is called for each name
 found and must return non-nil to include it in the result list."
   (let (k kl)
     (if (and jdee-font-lock-api-file
-	     (file-readable-p jdee-font-lock-api-file))
-	(with-temp-buffer
-	  (erase-buffer)
-	  (insert-file-contents jdee-font-lock-api-file)
-	  (goto-char (point-min))
-	  (while (re-search-forward jdee-font-lock-api-entry-regexp nil t)
-	    (setq k (match-string jdee-font-lock-api-entry-match))
-	    ;; Allow filtering of names
-	    (if (or (null filter) (funcall filter k))
-		(setq kl (cons k kl))))))
+             (file-readable-p jdee-font-lock-api-file))
+        (with-temp-buffer
+          (erase-buffer)
+          (insert-file-contents jdee-font-lock-api-file)
+          (goto-char (point-min))
+          (while (re-search-forward jdee-font-lock-api-entry-regexp nil t)
+            (setq k (match-string jdee-font-lock-api-entry-match))
+            ;; Allow filtering of names
+            (if (or (null filter) (funcall filter k))
+                (setq kl (cons k kl))))))
     kl))
 
 (defun jdee-font-lock-api-split-list (l n)
@@ -700,17 +700,17 @@ If L is nil return nil.  If N is less than 1 all elements will be in
 one sub list."
   (if l
       (if (<= n 0)
-	  (list l)
-	(let (split-list sub-list i)
-	  (while l
-	    (setq i 0 sub-list nil)
-	    (while (and l (< i n))
-	      (setq sub-list (cons (car l) sub-list)
-		    i        (1+ i)
-		    l        (cdr l)))
-	    (if sub-list
-		(setq split-list (cons sub-list split-list))))
-	  split-list))))
+          (list l)
+        (let (split-list sub-list i)
+          (while l
+            (setq i 0 sub-list nil)
+            (while (and l (< i n))
+              (setq sub-list (cons (car l) sub-list)
+                    i        (1+ i)
+                    l        (cdr l)))
+            (if sub-list
+                (setq split-list (cons sub-list split-list))))
+          split-list))))
 
 (defun jdee-font-lock-api-build-regexps (max-matches)
   "Build regular expressions matching names to fontify.
@@ -718,14 +718,14 @@ MAX-MATCHES is the maximum number of names that one regular expression
 will match.  If MAX-MATCHES is less than 1 one regular expression will
 match all the names."
   (let ((max-specpdl-size 2000)) ;; Prevent errors in `regexp-opt'
-				 ;; when processing long string listes
+                                 ;; when processing long string listes
     (mapcar (function
-	     (lambda (k)
-	       (concat "\\<" (regexp-opt k t) "\\>")))
-	    (jdee-font-lock-api-split-list
-	     (jdee-font-lock-api-names
-	      jdee-font-lock-api-name-filter)
-	     max-matches))))
+             (lambda (k)
+               (concat "\\<" (regexp-opt k t) "\\>")))
+            (jdee-font-lock-api-split-list
+             (jdee-font-lock-api-names
+              jdee-font-lock-api-name-filter)
+             max-matches))))
 
 (defvar jdee-font-lock-api-cache nil
   "Cache of regular expressions matching names to fontify..")
@@ -736,8 +736,8 @@ There is a different cache file for each major version of (X)Emacs
 because of incompatible regular expressions returned by `regexp-opt'."
   (and jdee-font-lock-api-file
        (format "%s.emacs-%d.apicache"
-	       jdee-font-lock-api-file
-	       emacs-major-version)))
+               jdee-font-lock-api-file
+               emacs-major-version)))
 
 (defconst jdee-font-lock-api-cache-file-header
   ";;; Regular expressions matching names to fontify.
@@ -769,51 +769,51 @@ is created."
      ;; A cache file exists
      ((file-readable-p cache)
       (if (file-newer-than-file-p jdee-font-lock-api-file cache)
-	  (progn
-	    (message
-	     "jdee-font-lock: names file %s newer than cache file %s"
-	     jdee-font-lock-api-file cache)
-	    ;; The api file has been modified since the cache was
-	    ;; created, so clear the cache to rebuild
-	    (setq jdee-font-lock-api-cache nil))
-	;; Try to load the existing cache if needed
-	(or jdee-font-lock-api-cache
-	    (condition-case nil
-		(load-file cache)
-	      ;; If load fails clear the cache to rebuild
-	      (error
-	       (setq jdee-font-lock-api-cache nil)))))))
+          (progn
+            (message
+             "jdee-font-lock: names file %s newer than cache file %s"
+             jdee-font-lock-api-file cache)
+            ;; The api file has been modified since the cache was
+            ;; created, so clear the cache to rebuild
+            (setq jdee-font-lock-api-cache nil))
+        ;; Try to load the existing cache if needed
+        (or jdee-font-lock-api-cache
+            (condition-case nil
+                (load-file cache)
+              ;; If load fails clear the cache to rebuild
+              (error
+               (setq jdee-font-lock-api-cache nil)))))))
 
     (or jdee-font-lock-api-cache
-	(not cache)
-	;; Build a new cache if it is empty and available
-	(progn
-	  (message "jdee-font-lock: building names cache...")
-	  (when (setq jdee-font-lock-api-cache
-		      (jdee-font-lock-api-build-regexps
-		       jdee-font-lock-max-names-by-regexp))
-	    ;; Save regexps in cache
-	    (with-current-buffer (find-file-noselect cache)
-	      (erase-buffer)
-	      (insert
-	       (format jdee-font-lock-api-cache-file-header
-		       (current-time-string))
-	       (format "(setq jdee-font-lock-api-cache '%S)"
-		       jdee-font-lock-api-cache))
-	      (save-buffer)
-	      (kill-buffer (current-buffer))))
-	  (message "jdee-font-lock: building names cache...%s"
-		   (if jdee-font-lock-api-cache "done" "empty"))))
-	  jdee-font-lock-api-cache))
+        (not cache)
+        ;; Build a new cache if it is empty and available
+        (progn
+          (message "jdee-font-lock: building names cache...")
+          (when (setq jdee-font-lock-api-cache
+                      (jdee-font-lock-api-build-regexps
+                       jdee-font-lock-max-names-by-regexp))
+            ;; Save regexps in cache
+            (with-current-buffer (find-file-noselect cache)
+              (erase-buffer)
+              (insert
+               (format jdee-font-lock-api-cache-file-header
+                       (current-time-string))
+               (format "(setq jdee-font-lock-api-cache '%S)"
+                       jdee-font-lock-api-cache))
+              (save-buffer)
+              (kill-buffer (current-buffer))))
+          (message "jdee-font-lock: building names cache...%s"
+                   (if jdee-font-lock-api-cache "done" "empty"))))
+          jdee-font-lock-api-cache))
 
 (defun jdee-font-lock-api-keywords (&optional rebuild)
   "Return a list of font lock keywords for user's defined names.
 If optional REBUILD flag is non-nil create a new cache of regular
 expressions."
   (mapcar (function
-	   (lambda (k)
-	     (cons k 'jdee-font-lock-api-face)))
-	  (jdee-font-lock-api-regexps rebuild)))
+           (lambda (k)
+             (cons k 'jdee-font-lock-api-face)))
+          (jdee-font-lock-api-regexps rebuild)))
 
 ;;;;
 ;;;; Font lock setup.
@@ -827,12 +827,12 @@ expressions."
   (dolist (b (buffer-list))
     (when (buffer-live-p b)
       (with-current-buffer b
-	(when (and font-lock-mode
-		   (memq major-mode '(java-mode jdee-mode)))
-	  (message "JDEE refontify buffer %s..." b)
-	  (font-lock-mode -1)
-	  (font-lock-mode 1)
-	  (message "JDEE refontify  buffer %s...done" b))))))
+        (when (and font-lock-mode
+                   (memq major-mode '(java-mode jdee-mode)))
+          (message "JDEE refontify buffer %s..." b)
+          (font-lock-mode -1)
+          (font-lock-mode 1)
+          (message "JDEE refontify  buffer %s...done" b))))))
 
 (defun jdee-font-lock-keywords (&optional rebuild)
   "JDEE's extra level font lock keywords.
@@ -845,74 +845,74 @@ expressions."
        java-font-lock-keywords-3
        ;; Fontify user's defined names
        (mapcar #'(lambda (e)
-		   (list
-		    (c-make-font-lock-search-function
-		     (car e)
-		     (list 0 (cdr e) t))))
-	       (jdee-font-lock-api-keywords rebuild))
+                   (list
+                    (c-make-font-lock-search-function
+                     (car e)
+                     (list 0 (cdr e) t))))
+               (jdee-font-lock-api-keywords rebuild))
        (list
-	;; Fontify modifiers.
-	`(,(c-make-font-lock-search-function
-	    jdee-font-lock-modifier-regexp
-	    '(0 jdee-font-lock-modifier-face t)))
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(false\\|null\\|true\\)\\>"
-	    '(1 jdee-font-lock-constant-face t)))
-	;; Fontify default and assert as keywords
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(default\\|assert\\)\\>"
-	    '(1 font-lock-keyword-face t)))
-	;; Fontify const and goto with warning face. These keywords are
-	;; reserved, even though they are not currently used.
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(const\\|goto\\)\\>"
-	    '(1 font-lock-warning-face t)))
-	;; package and imports
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(package\\|import\\(?:\\s-+static\\)?\\)\\s-+\\(\\(?:[a-z_$*][a-zA-Z0-9_$]*\\.?\\)*\\)"
-	    '(1 font-lock-keyword-face t)
-	    '(2 jdee-font-lock-package-face t)))
-	;; constructor
-	`(,(c-make-font-lock-search-function
-	    (concat
-	     "^\\s-*\\<\\(?:public\\|private\\|protected\\)\\>?\\s-*"
-	     "\\([" jdee-font-lock-capital-letter "]\\sw*\\)"
-	     "(.*?)")
-	    '(1 jdee-font-lock-constructor-face t)))
-	;; class names
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(new\\|instanceof\\)\\>[ \t]+\\(\\sw+\\)"
-	    '(2 font-lock-type-face t)))
-
-	;; modifier protections
+        ;; Fontify modifiers.
         `(,(c-make-font-lock-search-function
-	    "\\<\\(private\\)\\>"
-	    '(1 jdee-font-lock-private-face t)))
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(protected\\)\\>"
-	    '(1 jdee-font-lock-protected-face t)))
-	`(,(c-make-font-lock-search-function
-	    "\\<\\(public\\)\\>"
-	    '(1 jdee-font-lock-public-face t)))
-	;; Fontify numbers
-	`(,(c-make-font-lock-search-function
-	    jdee-font-lock-number-regexp
-	    '(0 jdee-font-lock-number-face t)))
-	;; Fontify operators
+            jdee-font-lock-modifier-regexp
+            '(0 jdee-font-lock-modifier-face t)))
+        `(,(c-make-font-lock-search-function
+            "\\<\\(false\\|null\\|true\\)\\>"
+            '(1 jdee-font-lock-constant-face t)))
+        ;; Fontify default and assert as keywords
+        `(,(c-make-font-lock-search-function
+            "\\<\\(default\\|assert\\)\\>"
+            '(1 font-lock-keyword-face t)))
+        ;; Fontify const and goto with warning face. These keywords are
+        ;; reserved, even though they are not currently used.
+        `(,(c-make-font-lock-search-function
+            "\\<\\(const\\|goto\\)\\>"
+            '(1 font-lock-warning-face t)))
+        ;; package and imports
+        `(,(c-make-font-lock-search-function
+            "\\<\\(package\\|import\\(?:\\s-+static\\)?\\)\\s-+\\(\\(?:[a-z_$*][a-zA-Z0-9_$]*\\.?\\)*\\)"
+            '(1 font-lock-keyword-face t)
+            '(2 jdee-font-lock-package-face t)))
+        ;; constructor
+        `(,(c-make-font-lock-search-function
+            (concat
+             "^\\s-*\\<\\(?:public\\|private\\|protected\\)\\>?\\s-*"
+             "\\([" jdee-font-lock-capital-letter "]\\sw*\\)"
+             "(.*?)")
+            '(1 jdee-font-lock-constructor-face t)))
+        ;; class names
+        `(,(c-make-font-lock-search-function
+            "\\<\\(new\\|instanceof\\)\\>[ \t]+\\(\\sw+\\)"
+            '(2 font-lock-type-face t)))
+
+        ;; modifier protections
+        `(,(c-make-font-lock-search-function
+            "\\<\\(private\\)\\>"
+            '(1 jdee-font-lock-private-face t)))
+        `(,(c-make-font-lock-search-function
+            "\\<\\(protected\\)\\>"
+            '(1 jdee-font-lock-protected-face t)))
+        `(,(c-make-font-lock-search-function
+            "\\<\\(public\\)\\>"
+            '(1 jdee-font-lock-public-face t)))
+        ;; Fontify numbers
+        `(,(c-make-font-lock-search-function
+            jdee-font-lock-number-regexp
+            '(0 jdee-font-lock-number-face t)))
+        ;; Fontify operators
 ;;;     `(,(c-make-font-lock-search-function
 ;;;         jdee-font-lock-operator-regexp
 ;;;         '(0 jdee-font-lock-operator-face t)))
-	;; Fontify capitalised identifiers as constant
-	`(,jdee-font-lock-capital-id-regexp
-	  1 jdee-font-lock-constant-face)
-	;; Fontify text between `' in comments
-	jdee-font-lock-quote-keyword
-	;; Fontify javadoc comments
-	'((lambda (limit)
-	    (c-font-lock-doc-comments
-		"/\\*\\*" limit
-	      jdee-font-lock-doc-comments)))
-	)
+        ;; Fontify capitalised identifiers as constant
+        `(,jdee-font-lock-capital-id-regexp
+          1 jdee-font-lock-constant-face)
+        ;; Fontify text between `' in comments
+        jdee-font-lock-quote-keyword
+        ;; Fontify javadoc comments
+        '((lambda (limit)
+            (c-font-lock-doc-comments
+                "/\\*\\*" limit
+              jdee-font-lock-doc-comments)))
+        )
        )
 
     ;; Through JDEE's own support
@@ -930,25 +930,25 @@ expressions."
       '("\\<\\(const\\|goto\\)\\>" (1 font-lock-warning-face))
       ;; Fontify modifiers.
       (cons jdee-font-lock-modifier-regexp
-	    'jdee-font-lock-modifier-face)
+            'jdee-font-lock-modifier-face)
       ;; Fontify package directives
       '("\\<\\(package\\)\\>\\s-+\\(\\sw+\\)"
-	(1 font-lock-keyword-face)
-	(2 jdee-font-lock-package-face nil t)
-	("\\=\\.\\(\\sw+\\)" nil nil
-	 (1 jdee-font-lock-package-face nil t)))
+        (1 font-lock-keyword-face)
+        (2 jdee-font-lock-package-face nil t)
+        ("\\=\\.\\(\\sw+\\)" nil nil
+         (1 jdee-font-lock-package-face nil t)))
       ;; Fontify import directives
       '("\\<\\(import\\)\\>\\s-+\\(\\sw+\\)"
-	(1 font-lock-keyword-face)
-	(2 (if (equal (char-after (match-end 0)) ?\.)
-	       jdee-font-lock-package-face
-	     font-lock-type-face))
-	("\\=\\.\\(\\*\\|\\sw+\\)" nil nil
-	 (1 (if (equal (char-after (match-end 0)) ?\.)
-		jdee-font-lock-package-face
-	      (if (equal (char-before (match-end 0)) ?\*)
-		  jdee-font-lock-number-face
-		font-lock-type-face)))))
+        (1 font-lock-keyword-face)
+        (2 (if (equal (char-after (match-end 0)) ?\.)
+               jdee-font-lock-package-face
+             font-lock-type-face))
+        ("\\=\\.\\(\\*\\|\\sw+\\)" nil nil
+         (1 (if (equal (char-after (match-end 0)) ?\.)
+                jdee-font-lock-package-face
+              (if (equal (char-before (match-end 0)) ?\*)
+                  jdee-font-lock-number-face
+                font-lock-type-face)))))
       ;; modifier protections
       '("\\<\\(private\\)\\>" (1 jdee-font-lock-private-face))
       '("\\<\\(protected\\)\\>" (1 jdee-font-lock-protected-face))
@@ -986,13 +986,13 @@ expressions."
      (list
       ;; Fontify numbers
       (cons jdee-font-lock-number-regexp
-	    'jdee-font-lock-number-face)
+            'jdee-font-lock-number-face)
       ;; Fontify operators
 ;;;      (cons jdee-font-lock-operator-regexp
 ;;;            'jdee-font-lock-operator-face)
       ;; Fontify capitalised identifiers as constant
       (cons jdee-font-lock-capital-id-regexp
-	    '(1 jdee-font-lock-constant-face))
+            '(1 jdee-font-lock-constant-face))
       ;; Fontify text between `' in comments
       jdee-font-lock-quote-keyword
       ;; Fontify javadoc tags (including non official ones)
@@ -1049,7 +1049,7 @@ expressions."
            nil nil ((?_ . "w") (?$ . "w") (?@ . "w")) nil
            (font-lock-mark-block-function . mark-defun))))
     (cons (append (car java-defaults) '(java-font-lock-keywords-4))
-	  (cdr java-defaults)))
+          (cdr java-defaults)))
   "Defaults for coloring Java keywords in jdee-mode. The defaults
 consist of the java-mode defaults plus `java-font-lock-keywords-4'.")
 
@@ -1068,7 +1068,7 @@ standard `java-mode'."
   (when jdee-use-font-lock
     ;; Setup `font-lock-defaults'
     (set (make-local-variable 'font-lock-defaults)
-	 jdee-font-lock-defaults)
+         jdee-font-lock-defaults)
     ;; Use the maximum decoration available
     (set (make-local-variable 'font-lock-maximum-decoration) t)
     ;; Handle multiline

--- a/jdee-gen.el
+++ b/jdee-gen.el
@@ -696,7 +696,7 @@ It then moves the point to the location of the first method."
    ";; We jump back and add those things retrospectively."
    "(progn (tempo-backward-mark)"
    " (jdee-gen-save-excursion"
-   "  (jdee-gen-main-method))"
+   "  (jdee-gen-main))"
    " (tempo-backward-mark)"
    " (jdee-gen-save-excursion"
    "  (jdee-wiz-gen-method \"private\" \"\""
@@ -2057,32 +2057,6 @@ command, `jdee-gen-change-listener', as a side-effect."
 	     "Insert skeleton change listener."))
 	  (set-default sym val)))
 
-(defcustom jdee-gen-main-method-template
-  '(
-    "(jdee-gen-save-excursion"
-    " (jdee-wiz-gen-method"
-    "   \"public static\""
-    "   \"void\""
-    "   \"main\""
-    "   \"String[] args\""
-    "   \"\" \"\"))"
-    ";; don't move point"
-    "(setq tempo-marks nil)"
-    )
-  "Template for generating the main method.
-Setting this variable defines a template instantiation
-command, `jdee-gen-main-method', as a side-effect."
-  :group 'jdee-gen
-  :type '(repeat string)
-  :set '(lambda (sym val)
-	  (defalias 'jdee-gen-main-method
-	    (tempo-define-template
-	     "main-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton main method."))
-	  (set-default sym val)))
-
 
 (defcustom  jdee-gen-println
   '(
@@ -3315,7 +3289,7 @@ It then moves the point to the location of the first method."
 
 (defcustom jdee-gen-code-templates
   (list (cons "Get Set Pair" 'jdee-gen-get-set)
-	(cons "main method" 'jdee-gen-main-method)
+	(cons "main method" 'jdee-gen-main)
 	(cons "toString Method (Apache)" 'jdee-gen-tostring-method)
 	(cons "Equals Method" 'jdee-gen-equals-method)
 	(cons "Hash Code Method" 'jdee-gen-hashcode-method)
@@ -3387,6 +3361,29 @@ list bound to `jdee-gen-abbrev-templates'. "
        abbrev
        (format "JDE template for %s control flow abbreviation." abbrev)
        'jdee-gen-abbrev-templates))))
+
+(defcustom jdee-gen-main-method-template
+  '(
+    "(jdee-gen-save-excursion"
+    " (jdee-wiz-gen-method"
+    "   \"public static\""
+    "   \"void\""
+    "   \"main\""
+    "   \"String[] args\""
+    "   \"\" \"\"))"
+    ";; don't move point"
+    "(setq tempo-marks nil)"
+    )
+  "Template for generating the main method.
+Setting this variable defines a template instantiation
+command, `jdee-gen-main', as a side-effect."
+  :group 'jdee-gen
+  :type '(repeat string)
+  :set '(lambda (sym val)
+	  (jdee-gen-define-abbrev-template
+	   "main"
+	   (jdee-gen-read-template val))
+	  (set-default sym val)))
 
 (defcustom jdee-gen-cflow-enable t
   "Enables abbreviations for Java control flow constructs."

--- a/jdee-gen.el
+++ b/jdee-gen.el
@@ -112,8 +112,8 @@ and Gradle \"src/test/java\" is standard path."
   "Delete any syntactical whitespace (including newlines)
 before point."
   (while (and (not (bobp))
-	      (or (bolp)
-		  (re-search-backward "\\s-\\=" nil t)))
+              (or (bolp)
+                  (re-search-backward "\\s-\\=" nil t)))
     (delete-char -1)))
 
 (defun jdee-gen-extract-ids-from-params (params)
@@ -122,9 +122,9 @@ ids and return as \"id1, id2, ...\"."
   (mapconcat
    (lambda (arg)
      (nth 1 (split-string
-	     (jdee-replace-in-string
-	      (jdee-replace-in-string arg "^[ \t\n\f\l]+" "")
-	      "[ \t\n\f\l]+$" ""))))
+             (jdee-replace-in-string
+              (jdee-replace-in-string arg "^[ \t\n\f\l]+" "")
+              "[ \t\n\f\l]+$" ""))))
    (split-string params "[,]") ", "))
 
 (defun jdee-gen-lookup-named (name)
@@ -137,14 +137,14 @@ Returns the data if NAME was found, and nil otherwise."
 of strings to a list of Lisp objects as required by
 tempo."
   (let ((template-string "")
-	(n (length strings))
-	(i 0))
+        (n (length strings))
+        (i 0))
     (while (< i n)
       (setq template-string
-	    (concat template-string (nth i strings) "\n"))
+            (concat template-string (nth i strings) "\n"))
       (setq i (1+ i)))
     (setq template-string
-	  (concat "'(" template-string ")"))
+          (concat "'(" template-string ")"))
     (eval (car (read-from-string template-string)))))
 
 (defcustom jdee-gen-buffer-boilerplate nil
@@ -168,20 +168,20 @@ specified by `jdee-gen-buffer-boilerplate'."
 variable `jdee-gen-buffer-boilerplate'."
   (if jdee-gen-buffer-boilerplate
       (let ((bp "")
-	    (n (length jdee-gen-buffer-boilerplate))
-	    (i 0))
-	(while (< i n)
-	  (setq bp
-		(concat bp (elt jdee-gen-buffer-boilerplate i) "\n"))
-	  (setq i (1+ i)))
-	bp)))
+            (n (length jdee-gen-buffer-boilerplate))
+            (i 0))
+        (while (< i n)
+          (setq bp
+                (concat bp (elt jdee-gen-buffer-boilerplate i) "\n"))
+          (setq i (1+ i)))
+        bp)))
 
 (defun jdee-gen-get-extend-class ()
   (let ((super-class (read-from-minibuffer "extends: ")))
     (if (not (string= super-class ""))
-	(progn
-	  (jdee-import-find-and-import super-class)
-	  (concat "extends " super-class " ")))))
+        (progn
+          (jdee-import-find-and-import super-class)
+          (concat "extends " super-class " ")))))
 
 (defcustom jdee-gen-final-arguments t
   "Specifies whether to add final modifiers to method arguments.
@@ -202,21 +202,21 @@ Note that anonymous classes are implicitly final."
   "Inserts the final modifier depending on `jdee-gen-final-arguments'."
   (if jdee-gen-final-arguments
       (let ((comma nil)
-	    (arg-list (split-string method-args ",")))
-	(setq method-args "")
-	(mapc
-	 (lambda (arg)
-	   (if (string-match "\\<final\\>" arg)
-	       (setq method-args (concat method-args comma arg))
-	     (setq method-args
-		   (concat method-args
-			   comma
-			   (if (string-match "^[ \t]" arg) " ")
-			   "final"
-			   (if (string-match "^[^ \t]" arg) " ")
-			   arg)))
-	   (setq comma ","))
-	 arg-list)))
+            (arg-list (split-string method-args ",")))
+        (setq method-args "")
+        (mapc
+         (lambda (arg)
+           (if (string-match "\\<final\\>" arg)
+               (setq method-args (concat method-args comma arg))
+             (setq method-args
+                   (concat method-args
+                           comma
+                           (if (string-match "^[ \t]" arg) " ")
+                           "final"
+                           (if (string-match "^[^ \t]" arg) " ")
+                           arg)))
+           (setq comma ","))
+         arg-list)))
   method-args)
 
 (defun jdee-gen-final-method-modifier (method-modifiers)
@@ -226,28 +226,28 @@ Note that anonymous classes are implicitly final."
     ;; Java Language specification, section 15.9.5.
     ;; http://java.sun.com/docs/books/jls/second_edition/html/classes.doc.html
     (unless (or (member "final" class-info) ; explicit final modifier?
-		(save-excursion
-		  (and class-info
-		       (goto-char (cdar class-info))
-		       (looking-at "new")))) ; anonymous class?
+                (save-excursion
+                  (and class-info
+                       (goto-char (cdar class-info))
+                       (looking-at "new")))) ; anonymous class?
       (if (and jdee-gen-final-methods
-	       (not (string-match "final" method-modifiers))
-	       (not (string-match "private" method-modifiers))
-	       (not (string-match "abstract" method-modifiers)))
-	  ;; Find correct position according to
-	  ;; Java Language specification, section 8.4.3.
-	  ;; http://java.sun.com/docs/books/jls/second_edition/html/classes.doc.html
-	  (let* ((pos (max (if (string-match "public" method-modifiers) (match-end 0) 0)
-			   (if (string-match "protected" method-modifiers) (match-end 0) 0)
-			   (if (string-match "static" method-modifiers) (match-end 0) 0)))
-		 (left (substring method-modifiers 0 pos))
-		 (right (substring method-modifiers pos)))
-	    (setq method-modifiers (concat
-			     left
-			     (if (> (length left) 0) " ")
-			     "final"
-			     (if (and (= (length left) 0) (> (length right) 0)) " ")
-			     right))))))
+               (not (string-match "final" method-modifiers))
+               (not (string-match "private" method-modifiers))
+               (not (string-match "abstract" method-modifiers)))
+          ;; Find correct position according to
+          ;; Java Language specification, section 8.4.3.
+          ;; http://java.sun.com/docs/books/jls/second_edition/html/classes.doc.html
+          (let* ((pos (max (if (string-match "public" method-modifiers) (match-end 0) 0)
+                           (if (string-match "protected" method-modifiers) (match-end 0) 0)
+                           (if (string-match "static" method-modifiers) (match-end 0) 0)))
+                 (left (substring method-modifiers 0 pos))
+                 (right (substring method-modifiers pos)))
+            (setq method-modifiers (concat
+                             left
+                             (if (> (length left) 0) " ")
+                             "final"
+                             (if (and (= (length left) 0) (> (length right) 0)) " ")
+                             right))))))
   method-modifiers)
 
 (defmacro jdee-gen-save-excursion (&rest body)
@@ -260,9 +260,9 @@ without having mutual interference of those templates.
 Returns nil."
   `(progn
      (let ((tempo-marks)
-	   (tempo-named-insertions)
-	   (tempo-region-start (make-marker))
-	   (tempo-region-stop (make-marker)))
+           (tempo-named-insertions)
+           (tempo-region-start (make-marker))
+           (tempo-region-stop (make-marker)))
        (progn ,@body))
      nil))
 
@@ -286,8 +286,8 @@ Removes indentation if the current line contains only whitespaces.
 The purpose of this function is to avoid trailing whitespaces
 in generated java code. Returns nil."
   (if (save-excursion
-	(beginning-of-line)
-	(looking-at "\\s-+$"))
+        (beginning-of-line)
+        (looking-at "\\s-+$"))
       (replace-match ""))
   (if (not (and (bolp) (eolp)))
       (c-indent-line))
@@ -304,9 +304,9 @@ Indentation and trailing whitespace of surrounding non-blank lines will stay unc
 Returns nil."
   (interactive "*")
   (if (or (bolp) (eolp)
-	  (save-excursion
-	    (beginning-of-line)
-	    (looking-at "\\s-*$")))
+          (save-excursion
+            (beginning-of-line)
+            (looking-at "\\s-*$")))
       (delete-region
        (+ (point) (skip-chars-backward " \t\n") (skip-chars-forward  " \t"))
        (+ (point) (skip-chars-forward  " \t\n") (skip-chars-backward " \t"))))
@@ -343,13 +343,13 @@ it sets this variable to nil. If INSERT-IMMEDIATELY is non-nil,
 and jdee-gen-interface-to-gen will be set to nil."
   (let ((interface (read-from-minibuffer "implements: ")))
     (if (not (string= interface ""))
-	(progn
-	  (setq jdee-gen-interface-to-gen
-		(cons (point-marker) interface))
-	  (if insert-immediately
-	      (progn
-		(jdee-gen-insert-interface-implementation)
-		(setq jdee-gen-interface-to-gen nil))))
+        (progn
+          (setq jdee-gen-interface-to-gen
+                (cons (point-marker) interface))
+          (if insert-immediately
+              (progn
+                (jdee-gen-insert-interface-implementation)
+                (setq jdee-gen-interface-to-gen nil))))
       (setq jdee-gen-interface-to-gen nil)))
   nil) ;; must return nil to prevent template insertion.
 
@@ -359,10 +359,10 @@ and inserts it in the current buffer at the location specified
 by the car of `jdee-gen-interface-to-gen'."
   (if jdee-gen-interface-to-gen
       (let ((ins-pos (marker-position (car jdee-gen-interface-to-gen)))
-	    (interface (cdr jdee-gen-interface-to-gen)))
-	(save-excursion
-	  (goto-char ins-pos)
-	  (jdee-wiz-implement-interface-internal interface)))))
+            (interface (cdr jdee-gen-interface-to-gen)))
+        (save-excursion
+          (goto-char ins-pos)
+          (jdee-wiz-implement-interface-internal interface)))))
 
 (defvar jdee-gen-package-name nil)
 
@@ -375,19 +375,19 @@ Ask the user for confirmation.  Also sets buffer local
 `jdee-gen-package-name'."
   (require 'jdee-package)
   (let* ((package-dir (jdee-package-get-package-directory))
-	 (suggested-package-name
+         (suggested-package-name
           (or package
               (if (or
                    (string= package-dir jdee-package-unknown-package-name)
                    (string= package-dir ""))
                   nil
                 (jdee-package-convert-directory-to-package package-dir))))
-	 (package-name
+         (package-name
           (or jdee-gen-package-name
               (read-from-minibuffer "Package: " suggested-package-name))))
     (if (and
-	 package-name
-	 (not (string= package-name "")))
+         package-name
+         (not (string= package-name "")))
         (progn
           (set (make-local-variable 'jdee-gen-package-name) package-name)
           (format "package %s;\n\n" package-name)))))
@@ -399,11 +399,11 @@ For example, if set to a single space [\" \"], then a generated method might
 look like:
 
     void setXxxx () {
-		^
+                ^
 If not set, the same generated method would look like:
 
     void setXxxx() {
-		^
+                ^
 Note: According to the Java Code Convention [section 6.4], this value should
       be the empty string."
   :group 'jdee-gen
@@ -417,11 +417,11 @@ For example, if set to a single space [\" \"], then a generated method might
 look like:
 
     void setXxxx( boolean newValue ) {
-		 ^                ^
+                 ^                ^
 If not set, the same generated method would look like:
 
     void setXxxx(boolean newValue) {
-		 ^              ^
+                 ^              ^
 Note: According to the Java Code Convention [section 6.4], this value should
       be the empty string."
   :group 'jdee-gen
@@ -434,11 +434,11 @@ argument list for a method call or definition.  For example, if set to
 a single space [\" \"], then a generated method might look like:
 
     void setXxxx(boolean newValue) {
-				  ^
+                                  ^
 If not set, the same generated method would look like:
 
     void setXxxx(boolean newValue){
-				  ^
+                                  ^
 Note: According to the Java Code Convention [section 6.4], this value should
       be a single space."
   :group 'jdee-gen
@@ -514,27 +514,27 @@ as well as the corresponding padding, whitespace and/or Java keywords."
   (if (> (length type) 0) ; ordinary method?
       (setq access (jdee-gen-final-method-modifier access)))
   (let ((sig
-	 (concat
-	  (if (> (length access) 0)
-	      (concat access " ")
-	    ());; if no access (e.g. "public static"), then nothing
-	  (if (> (length type) 0)
-	      (concat type " ")
-	    ());; if no type (e.g. "boolean" or "void"), then nothing
-	  name
-	  jdee-gen-method-signature-padding-1
-	  "("
-	  (if (> (length arglist) 0)
-	      (concat jdee-gen-method-signature-padding-2 (jdee-gen-final-argument-modifier arglist)
-		      jdee-gen-method-signature-padding-2 )
-	    ())
-	  ")"
-	  (if (> (length throwslist) 0)
-	      (concat " throws " throwslist)
-	    ())
-	  (if jdee-gen-k&r
-	      jdee-gen-method-signature-padding-3
-	    ()))))
+         (concat
+          (if (> (length access) 0)
+              (concat access " ")
+            ());; if no access (e.g. "public static"), then nothing
+          (if (> (length type) 0)
+              (concat type " ")
+            ());; if no type (e.g. "boolean" or "void"), then nothing
+          name
+          jdee-gen-method-signature-padding-1
+          "("
+          (if (> (length arglist) 0)
+              (concat jdee-gen-method-signature-padding-2 (jdee-gen-final-argument-modifier arglist)
+                      jdee-gen-method-signature-padding-2 )
+            ())
+          ")"
+          (if (> (length throwslist) 0)
+              (concat " throws " throwslist)
+            ())
+          (if jdee-gen-k&r
+              jdee-gen-method-signature-padding-3
+            ()))))
     sig))
 
 (defcustom jdee-gen-class-create-constructor t
@@ -546,8 +546,8 @@ as well as the corresponding padding, whitespace and/or Java keywords."
   "*If non-nil, generate constructor for `jdee-gen-class-buffer'."
   :group 'jdee-gen
   :type  '(choice
-	   (const :tag "Prompt for package" jdee-gen-get-package-statement)
-	   (const :tag "Package updates automatically" jdee-package-update)))
+           (const :tag "Prompt for package" jdee-gen-get-package-statement)
+           (const :tag "Package updates automatically" jdee-package-update)))
 
 ;;(makunbound 'jdee-gen-class-buffer-template)
 (defcustom jdee-gen-class-buffer-template
@@ -598,16 +598,16 @@ command `jdee-gen-class', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (tempo-define-template "java-class-buffer-template"
-				 (jdee-gen-read-template val)
-				 nil
-				 "Insert a generic Java class buffer skeleton.")
-	  (defalias 'jdee-gen-class
-	    (list 'lambda (list)
-		  (list 'interactive)
-		  (list 'tempo-template-java-class-buffer-template)
-		  (list 'jdee-gen-insert-interface-implementation)))
-	  (set-default sym val)))
+          (tempo-define-template "java-class-buffer-template"
+                                 (jdee-gen-read-template val)
+                                 nil
+                                 "Insert a generic Java class buffer skeleton.")
+          (defalias 'jdee-gen-class
+            (list 'lambda (list)
+                  (list 'interactive)
+                  (list 'tempo-template-java-class-buffer-template)
+                  (list 'jdee-gen-insert-interface-implementation)))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-class-buffer (file)
@@ -649,15 +649,15 @@ command `jdee-gen-interface', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (tempo-define-template "java-interface-buffer-template"
-				 (jdee-gen-read-template val)
-				 nil
-				 "Insert a generic Java interface buffer skeleton.")
-	  (defalias 'jdee-gen-interface
-	    (list 'lambda (list)
-		  (list 'interactive)
-		  (list 'tempo-template-java-interface-buffer-template)))
-	  (set-default sym val)))
+          (tempo-define-template "java-interface-buffer-template"
+                                 (jdee-gen-read-template val)
+                                 nil
+                                 "Insert a generic Java interface buffer skeleton.")
+          (defalias 'jdee-gen-interface
+            (list 'lambda (list)
+                  (list 'interactive)
+                  (list 'tempo-template-java-interface-buffer-template)))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-interface-buffer (file)
@@ -709,12 +709,12 @@ command `jdee-gen-console', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-console
-	    (tempo-define-template "java-console-buffer-template"
-				   (jdee-gen-read-template val)
-				   nil
-				   "Insert skeleton for a new Java console buffer"))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-console
+            (tempo-define-template "java-console-buffer-template"
+                                   (jdee-gen-read-template val)
+                                   nil
+                                   "Insert skeleton for a new Java console buffer"))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-console-buffer (file)
@@ -727,14 +727,14 @@ It then moves the point to the location to the constructor."
 
 (defun jdee-gen-deep-clone-copies ()
   (let* ((class-tag (semantic-current-tag))
-	 (class-name (semantic-tag-name class-tag))
-	 (members (sort (jdee-parse-get-serializable-members class-tag)
-			'jdee-parse-compare-member-types)))
+         (class-name (semantic-tag-name class-tag))
+         (members (sort (jdee-parse-get-serializable-members class-tag)
+                        'jdee-parse-compare-member-types)))
     (apply #' append '(l)
-	      (mapcar #'(lambda (elt)
-			  (let ((e (car elt)))
-			    (list (format "if (%s != null) ret.%s = %s.clone();" e e e) '> 'n)))
-		      members))))
+              (mapcar #'(lambda (elt)
+                          (let ((e (car elt)))
+                            (list (format "if (%s != null) ret.%s = %s.clone();" e e e) '> 'n)))
+                      members))))
 
 (defcustom jdee-gen-deep-clone-catch-exception t
   "*Whether or not to catch CloneNotSupportedException."
@@ -824,13 +824,13 @@ command `jdee-gen-deep-clone', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-deep-clone
-	    (tempo-define-template
-	     "java-deep-clone-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create a deep clone method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-deep-clone
+            (tempo-define-template
+             "java-deep-clone-method"
+             (jdee-gen-read-template val)
+             nil
+             "Create a deep clone method at the current point."))
+          (set-default sym val)))
 
 ;; TO DO: Add support for style that puts member declarations at the bottom
 ;; of a class.
@@ -854,12 +854,12 @@ NO-MOVE-POINT if nil move the point, either way, we return the position.
 "
   (if (stringp modifiers) (setq modifiers (split-string modifiers ",")))
   (let* ((pair (jdee-parse-get-innermost-class-at-point))
-	 (class-name (if pair (car pair)))
-	 pos)
+         (class-name (if pair (car pair)))
+         pos)
     (if (null pair) (error "point is not in a class definition"))
     (semantic-fetch-tags)
     (setq pos (jdee-parse-get-nth-member class-name modifiers
-					nil -1 nil 'subset))
+                                        nil -1 nil 'subset))
 
     (if (null pos) (setq pos (jdee-parse-get-top-of-class class-name)))
     (if (and pos (not no-move-to-point)) (goto-char pos))
@@ -950,13 +950,13 @@ command `jdee-gen-get-set', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-get-set
-	    (tempo-define-template
-	     "java-get-set-pair"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert variable at the top of the class and get-set method pair at point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-get-set
+            (tempo-define-template
+             "java-get-set-pair"
+             (jdee-gen-read-template val)
+             nil
+             "Insert variable at the top of the class and get-set method pair at point."))
+          (set-default sym val)))
 
 (defalias 'jdee-gen-property 'jdee-gen-get-set)
 
@@ -1009,13 +1009,13 @@ command `jdee-gen-bean', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-bean
-	    (tempo-define-template
-	     "java-bean-template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create a Java bean."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-bean
+            (tempo-define-template
+             "java-bean-template"
+             (jdee-gen-read-template val)
+             nil
+             "Create a Java bean."))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-bean-buffer (file)
@@ -1046,13 +1046,13 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-hibernate-pojo-equals-method
-	    (tempo-define-template
-	     "java-hibernate-pojo-equals-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create an equals method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-hibernate-pojo-equals-method
+            (tempo-define-template
+             "java-hibernate-pojo-equals-method"
+             (jdee-gen-read-template val)
+             nil
+             "Create an equals method at the current point."))
+          (set-default sym val)))
 
 ;(makunbound 'jdee-gen-hibernate-pojo-template)
 (defcustom jdee-gen-hibernate-pojo-buffer-template
@@ -1094,13 +1094,13 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-hibernate-pojo
-	    (tempo-define-template
-	     "java-hibernate-pojo-buffer-template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create an equals method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-hibernate-pojo
+            (tempo-define-template
+             "java-hibernate-pojo-buffer-template"
+             (jdee-gen-read-template val)
+             nil
+             "Create an equals method at the current point."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-jfc-app-buffer-template
   (list
@@ -1309,12 +1309,12 @@ command `jdee-gen-jfc-app', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-jfc-app
-	    (tempo-define-template "java-jfc-app-buffer-template"
-				   (jdee-gen-read-template val)
-				   nil
-				   "Insert skeleton for a JFC app buffer"))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-jfc-app
+            (tempo-define-template "java-jfc-app-buffer-template"
+                                   (jdee-gen-read-template val)
+                                   nil
+                                   "Insert skeleton for a JFC app buffer"))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-jfc-app-buffer (file)
@@ -1352,15 +1352,15 @@ It then moves the point to the location to the constructor."
     "\"\" 'n"
     "\"# Java Compiler Args\" 'n"
     "\"JAVACFLAGS := -bootclasspath $\\\(JAVA_HOME\\\)/jre/lib/rt.jar \\\\\" 'n"
-    "\"	-classpath $\\\(CLASSPATH\\\) \\\\\" 'n"
-    "\"	-sourcepath $\\\(SRCDIR\\\) \\\\\" 'n"
-    "\"	-d $\\\(OBJDIR\\\) \\\\\" 'n"
-    "\"	$\\\(JVM_OPTION\\\)\" 'n"
+    "\"        -classpath $\\\(CLASSPATH\\\) \\\\\" 'n"
+    "\"        -sourcepath $\\\(SRCDIR\\\) \\\\\" 'n"
+    "\"        -d $\\\(OBJDIR\\\) \\\\\" 'n"
+    "\"        $\\\(JVM_OPTION\\\)\" 'n"
     "\"\" 'n"
     "\"# Sources\" 'n"
     "\"SOURCES = $\\\(shell find $\\\(SRCDIR\\\) \\\\\" 'n"
-    "\"	-name *.java \\\\\" 'n"
-    "\"	$\\\(foreach x, $\\\(RES_EXT\\\), -o -name \\\"*.$\\\(x\\\)\\\"\\\) \\\\\" 'n"
+    "\"        -name *.java \\\\\" 'n"
+    "\"        $\\\(foreach x, $\\\(RES_EXT\\\), -o -name \\\"*.$\\\(x\\\)\\\"\\\) \\\\\" 'n"
     "\"\\\)\" 'n"
     "\"# Obj files\" 'n"
     "\"OBJS = $\\\(patsubst $\\\(SRCDIR\\\)/%, $\\\(OBJDIR\\\)/%, $\\\(patsubst %.java, %.class, $\\\(SOURCES\\\)\\\)\\\)\" 'n"
@@ -1373,33 +1373,33 @@ It then moves the point to the location to the constructor."
     "\"# Jar\" 'n"
     "\"jar : compile $\\\(PKG\\\)\" 'n"
     "\"$\\\(PKG\\\) : $\\\(OBJS\\\)\" 'n"
-    "\"	$\\\(JAR\\\) cf $\\\(PKG\\\) -C $\\\(OBJDIR\\\) .\" 'n"
+    "\"        $\\\(JAR\\\) cf $\\\(PKG\\\) -C $\\\(OBJDIR\\\) .\" 'n"
     "\"\" 'n"
     "\"# Compile\" 'n"
     "\"compile : $\\\(OBJDIR\\\) $\\\(OBJS\\\)\" 'n"
     "\"# Javac\" 'n"
     "\"$\\\(OBJDIR\\\)/%.class : $\\\(SRCDIR\\\)/%.java\" 'n"
-    "\"	@echo compile $<\" 'n"
-    "\"	@$\\\(JAVAC\\\) $\\\(JAVACFLAGS\\\) $<\" 'n"
+    "\"        @echo compile $<\" 'n"
+    "\"        @$\\\(JAVAC\\\) $\\\(JAVACFLAGS\\\) $<\" 'n"
     "\"ifneq \\\($\\\(OBJDIR\\\),$\\\(SRCDIR\\\)\\\)\" 'n"
     "\"# Resource file\" 'n"
     "\"$\\\(OBJDIR\\\)/% : $\\\(SRCDIR\\\)/%\" 'n"
-    "\"	@mkdir -p $\\\(dir $@\\\)\" 'n"
-    "\"	cp $< $@\" 'n"
+    "\"        @mkdir -p $\\\(dir $@\\\)\" 'n"
+    "\"        cp $< $@\" 'n"
     "\"endif\" 'n"
     "\"\" 'n"
     "\"\" 'n"
     "\"# Create obj directory\" 'n"
     "\"$\\\(OBJDIR\\\) :\" 'n"
-    "\"	mkdir -p $\\\(OBJDIR\\\)\" 'n"
+    "\"        mkdir -p $\\\(OBJDIR\\\)\" 'n"
     "\"\" 'n"
     "\"# Clean up\" 'n"
     "\"clean :\" 'n"
-    "\"	rm -fr $\\\(PKG\\\) \" 'n"
+    "\"        rm -fr $\\\(PKG\\\) \" 'n"
     "\"ifeq \\\($\\\(OBJDIR\\\),$\\\(SRCDIR\\\)\\\)\" 'n"
-    "\"	find $\\\(OBJDIR\\\) -name *.class -exec rm {} \\\\\;\" 'n"
+    "\"        find $\\\(OBJDIR\\\) -name *.class -exec rm {} \\\\\;\" 'n"
     "\"else\" 'n"
-    "\"	rm -fr $\\\(OBJDIR\\\) \" 'n"
+    "\"        rm -fr $\\\(OBJDIR\\\) \" 'n"
     "\"endif\" 'n"
     "\"\" 'n"
     "\"# Rebuild\" 'n"
@@ -1411,28 +1411,28 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-makefile
-	    (tempo-define-template
-	     "jdee-makefile"
-	     (jdee-gen-read-template val)
-	     nil
-	     "insert makefile buffer."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-makefile
+            (tempo-define-template
+             "jdee-makefile"
+             (jdee-gen-read-template val)
+             nil
+             "insert makefile buffer."))
+          (set-default sym val)))
 
 (defun jdee-gen-makefile-buffer ()
   "Create a new Makefile buffer.
 This command a makefile for jde project using template generated by `jdee-gen-makefile'."
   (interactive)
   (let* ((default-directory
-	   (file-name-directory
-	    (if (string= jdee-current-project "")
-		(or (jdee-find-project-file ".") (expand-file-name "./prj.el"))
-	      jdee-current-project)))
-	 (file (read-file-name "Makefile " default-directory "Makefile")))
+           (file-name-directory
+            (if (string= jdee-current-project "")
+                (or (jdee-find-project-file ".") (expand-file-name "./prj.el"))
+              jdee-current-project)))
+         (file (read-file-name "Makefile " default-directory "Makefile")))
     (if (file-directory-p file)
-	(setq file (concat file "/Makefile")))
+        (setq file (concat file "/Makefile")))
     (when (or (not (file-exists-p file))
-	      (yes-or-no-p "Makefile exist, do you want to overwrite it? "))
+              (yes-or-no-p "Makefile exist, do you want to overwrite it? "))
       (find-file file)
       (makefile-mode)
       (delete-region (point-min) (point-max))
@@ -1515,33 +1515,33 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-ant-buildfile
-	    (tempo-define-template
-	     "jdee-ant-buildfile"
-	     (jdee-gen-read-template val)
-	     nil
-	     "insert ant buildfile buffer."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-ant-buildfile
+            (tempo-define-template
+             "jdee-ant-buildfile"
+             (jdee-gen-read-template val)
+             nil
+             "insert ant buildfile buffer."))
+          (set-default sym val)))
 
 (defun jdee-gen-ant-buildfile-buffer ()
   "Create a new Makefile buffer.
 This command a makefile for jde project using template generated by `jdee-gen-ant-buildfile'."
   (interactive)
   (let* ((default-directory
-	   (file-name-directory
-	    (if (string= jdee-current-project "")
-		(or (jdee-find-project-file ".") (expand-file-name "./prj.el"))
-	      jdee-current-project)))
-	 (jdee-ant-buildfile (or (and (boundp 'jdee-ant-buildfile) jdee-ant-buildfile)
-			     "build.xml"))
-	 (file (read-file-name
-		(concat jdee-ant-buildfile " ")
-		default-directory
-		jdee-ant-buildfile)))
+           (file-name-directory
+            (if (string= jdee-current-project "")
+                (or (jdee-find-project-file ".") (expand-file-name "./prj.el"))
+              jdee-current-project)))
+         (jdee-ant-buildfile (or (and (boundp 'jdee-ant-buildfile) jdee-ant-buildfile)
+                             "build.xml"))
+         (file (read-file-name
+                (concat jdee-ant-buildfile " ")
+                default-directory
+                jdee-ant-buildfile)))
     (if (file-directory-p file)
-	(setq file (concat file "/" jdee-ant-buildfile)))
+        (setq file (concat file "/" jdee-ant-buildfile)))
     (when (or (not (file-exists-p file))
-	      (yes-or-no-p "Buildfile exist, do you want to overwrite it? "))
+              (yes-or-no-p "Buildfile exist, do you want to overwrite it? "))
       (find-file file)
       (delete-region (point-min) (point-max))
       (jdee-gen-ant-buildfile))))
@@ -1549,11 +1549,11 @@ This command a makefile for jde project using template generated by `jdee-gen-an
 
 (defcustom jdee-gen-buffer-templates
   (list (cons "Class" 'jdee-gen-class)
-	(cons "Interface" 'jdee-gen-interface)
-	(cons "Exception Class" 'jdee-gen-exception)
-	(cons "Console" 'jdee-gen-console)
-	(cons "Swing App" 'jdee-gen-jfc-app)
-	(cons "Unit Test" 'jdee-junit-test-class))
+        (cons "Interface" 'jdee-gen-interface)
+        (cons "Exception Class" 'jdee-gen-exception)
+        (cons "Console" 'jdee-gen-console)
+        (cons "Swing App" 'jdee-gen-jfc-app)
+        (cons "Unit Test" 'jdee-junit-test-class))
   "*Specifies available autocode templates for creating buffers.
 The value of this variable is an association list. The car of
 each element specifies the template's title. The cdr specifies
@@ -1562,20 +1562,20 @@ a command that inserts the template into a buffer. See the function
 insertion command."
   :group 'jdee-gen
   :type '(repeat
-	  (cons :tag "Template"
-		(string :tag "Title")
-		(function :tag "Command")))
+          (cons :tag "Template"
+                (string :tag "Title")
+                (function :tag "Command")))
   :set '(lambda (sym val)
-	  (let ((n (length val))
-		(i 0))
-	    (setq jdee-gen-buffer-template-names (list))
-	    (while (< i n)
-	      (setq jdee-gen-buffer-template-names
-		    (append
-		     jdee-gen-buffer-template-names
-		     (list (cons (car (nth i val)) (1+ i)))))
-	      (setq i (1+ i))))
-	  (set-default sym val)))
+          (let ((n (length val))
+                (i 0))
+            (setq jdee-gen-buffer-template-names (list))
+            (while (< i n)
+              (setq jdee-gen-buffer-template-names
+                    (append
+                     jdee-gen-buffer-template-names
+                     (list (cons (car (nth i val)) (1+ i)))))
+              (setq i (1+ i))))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-buffer (template file)
@@ -1584,7 +1584,7 @@ This command inserts the specified template at the beginning
 of the buffer."
   (interactive
    (list (completing-read "Template: " jdee-gen-buffer-template-names)
-	 (read-file-name "File: ")))
+         (read-file-name "File: ")))
   (find-file file)
   (funcall (cdr (assoc template jdee-gen-buffer-templates)))
   (goto-char (point-min))
@@ -1613,13 +1613,13 @@ comment to a source code section by code generating functions."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-section-comment
-	    (tempo-define-template
-	     "section comment"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert section comment."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-section-comment
+            (tempo-define-template
+             "section comment"
+             (jdee-gen-read-template val)
+             nil
+             "Insert section comment."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-inner-class-template
   '(
@@ -1656,15 +1656,15 @@ comment to a source code section by code generating functions."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (tempo-define-template "java-inner-class"
-				 (jdee-gen-read-template val)
-				 nil
-				 "Insert inner class.")
-	  (defalias 'jdee-gen-inner-class-internal
-	    (list 'lambda (list)
-		  (list 'tempo-template-java-inner-class)
-		  (list 'jdee-gen-insert-interface-implementation)))
-	  (set-default sym val)))
+          (tempo-define-template "java-inner-class"
+                                 (jdee-gen-read-template val)
+                                 nil
+                                 "Insert inner class.")
+          (defalias 'jdee-gen-inner-class-internal
+            (list 'lambda (list)
+                  (list 'tempo-template-java-inner-class)
+                  (list 'jdee-gen-insert-interface-implementation)))
+          (set-default sym val)))
 
 (defun jdee-gen-inner-class ()
   (interactive)
@@ -1708,13 +1708,13 @@ command, `jdee-gen-action-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-action-listener
-	    (tempo-define-template
-	     "java-action-listener"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton action listener."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-action-listener
+            (tempo-define-template
+             "java-action-listener"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton action listener."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-window-listener-template
   '(
@@ -1842,13 +1842,13 @@ command, `jdee-gen-window-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-window-listener
-	    (tempo-define-template
-	     "java-window-listener"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton window listener."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-window-listener
+            (tempo-define-template
+             "java-window-listener"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton window listener."))
+          (set-default sym val)))
 
 
 
@@ -1947,13 +1947,13 @@ command, `jdee-gen-mouse-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-mouse-listener
-	    (tempo-define-template
-	     "java-mouse-listener"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton mouse listener."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-mouse-listener
+            (tempo-define-template
+             "java-mouse-listener"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton mouse listener."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-mouse-motion-listener-template
   '(
@@ -2005,13 +2005,13 @@ command, `jdee-gen-mouse-motion-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-mouse-motion-listener
-	    (tempo-define-template
-	     "java-mouse-motion-listener"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton mouse motion listener."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-mouse-motion-listener
+            (tempo-define-template
+             "java-mouse-motion-listener"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton mouse motion listener."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-change-listener-template
   '(
@@ -2049,13 +2049,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-change-listener
-	    (tempo-define-template
-	     "java-change-listener"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton change listener."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-change-listener
+            (tempo-define-template
+             "java-change-listener"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton change listener."))
+          (set-default sym val)))
 
 
 (defcustom  jdee-gen-println
@@ -2067,13 +2067,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-println
-	    (tempo-define-template
-	     "println"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert println statement."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-println
+            (tempo-define-template
+             "println"
+             (jdee-gen-read-template val)
+             nil
+             "Insert println statement."))
+          (set-default sym val)))
 
 (defcustom  jdee-gen-beep
   '(
@@ -2084,13 +2084,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-beep
-	    (tempo-define-template
-	     "beep statement"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert beep statement."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-beep
+            (tempo-define-template
+             "beep statement"
+             (jdee-gen-read-template val)
+             nil
+             "Insert beep statement."))
+          (set-default sym val)))
 
 (defcustom  jdee-gen-property-change-support
   '(
@@ -2331,13 +2331,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-property-change-support
-	    (tempo-define-template
-	     "property change support template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert property change support template."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-property-change-support
+            (tempo-define-template
+             "property change support template"
+             (jdee-gen-read-template val)
+             nil
+             "Insert property change support template."))
+          (set-default sym val)))
 
 (defcustom  jdee-gen-listener-registry
   '(
@@ -2410,13 +2410,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-listener-registry
-	    (tempo-define-template
-	     "listener registry template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert listener registry template."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-listener-registry
+            (tempo-define-template
+             "listener registry template"
+             (jdee-gen-read-template val)
+             nil
+             "Insert listener registry template."))
+          (set-default sym val)))
 
 (defcustom  jdee-gen-event-source-fire-method-template
   '(
@@ -2475,13 +2475,13 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-event-source-fire-method
-	    (tempo-define-template
-	     "event source fire method template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert event source fire method template."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-event-source-fire-method
+            (tempo-define-template
+             "event source fire method template"
+             (jdee-gen-read-template val)
+             nil
+             "Insert event source fire method template."))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-gen-enity-bean-template)
 (defcustom jdee-gen-entity-bean-template
@@ -2601,17 +2601,17 @@ command, `jdee-gen-change-listener', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-entity-bean
-	    (tempo-define-template
-	     "ejb-entity-bean"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Adds an implementation of the EJB Entity Bean interface to the
+          (defalias 'jdee-gen-entity-bean
+            (tempo-define-template
+             "ejb-entity-bean"
+             (jdee-gen-read-template val)
+             nil
+             "Adds an implementation of the EJB Entity Bean interface to the
 class in the current buffer at the current point in the buffer. Before invoking
 this command,  position point at the point in the buffer where you want the first
 Entity Bean method to appear. Use `jdee-ejb-entity-bean-buffer' to create a complete
 skeleton entity bean implementation from scratch."))
-	  (set-default sym val)))
+          (set-default sym val)))
 
 
 ;; (makunbound 'jdee-gen-session-bean-template)
@@ -2710,17 +2710,17 @@ skeleton entity bean implementation from scratch."))
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-session-bean
-	    (tempo-define-template
-	     "ejb-session-bean"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Adds an implementation of the EJB Session Bean interface to the
+          (defalias 'jdee-gen-session-bean
+            (tempo-define-template
+             "ejb-session-bean"
+             (jdee-gen-read-template val)
+             nil
+             "Adds an implementation of the EJB Session Bean interface to the
 class in the current buffer at the current point in the buffer. Before invoking
 this command,  position point at the point in the buffer where you want the first
 Session Bean method to appear. Use `jdee-ejb-session-bean-buffer' to create a complete
 skeleton session bean implementation from scratch."))
-	  (set-default sym val)))
+          (set-default sym val)))
 
 
 
@@ -2751,9 +2751,9 @@ the `jdee-gen-method-template'. The choices are
      is also being generated in the same run."
   :group 'jdee-gen
   :type '(choice
-	  (const :tag "Template" "template")
-	  (const :tag "Inherit Tag" "inherit")
-	  (const :tag "None" "none")))
+          (const :tag "Template" "template")
+          (const :tag "Inherit Tag" "inherit")
+          (const :tag "None" "none")))
 
 
 ;; (makunbound 'jdee-gen-method-template)
@@ -2802,13 +2802,13 @@ instantiation command, `jdee-gen-method', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-method
-	    (tempo-define-template
-	     "method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert skeleton method."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-method
+            (tempo-define-template
+             "method"
+             (jdee-gen-read-template val)
+             nil
+             "Insert skeleton method."))
+          (set-default sym val)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2824,14 +2824,14 @@ line, else on the next line before the comparison.  With
 `jdee-gen-equals-trailing-and-operators' set to nil:
 
     return (a == o.a)
-	&& (b == o.b)
-	&& (s == null ? o.s == null : s.equals(o.s));
+        && (b == o.b)
+        && (s == null ? o.s == null : s.equals(o.s));
 
 Or, with `jdee-gen-equals-trailing-and-operators' set to t:
 
     return (a == o.a) &&
-	(b == o.b) &&
-	(s == null ? o.s == null : s.equals(o.s));
+        (b == o.b) &&
+        (s == null ? o.s == null : s.equals(o.s));
 "
   :group 'jdee-gen
   :type 'boolean)
@@ -2843,14 +2843,14 @@ surrounded by parentheses.
 With `jdee-gen-equals-trailing-and-operators' set to nil:
 
     return ((a == o.a)
-	    && (b == o.b)
-	    && (s == null ? o.s == null : s.equals(o.s)));
+            && (b == o.b)
+            && (s == null ? o.s == null : s.equals(o.s)));
 
 Or, with `jdee-gen-equals-trailing-and-operators' set to t:
 
     return ((a == o.a) &&
-	    (b == o.b) &&
-	    (s == null ? o.s == null : s.equals(o.s)));
+            (b == o.b) &&
+            (s == null ? o.s == null : s.equals(o.s)));
 "
   :group 'jdee-gen
   :type 'boolean)
@@ -2877,13 +2877,13 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-equals-method
-	    (tempo-define-template
-	     "java-equals-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create an equals method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-equals-method
+            (tempo-define-template
+             "java-equals-method"
+             (jdee-gen-read-template val)
+             nil
+             "Create an equals method at the current point."))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-equals-return (&optional parm-name var-name class super-method)
@@ -2902,77 +2902,77 @@ is then used instead of the result of `semantic-current-tag'.
 
 Example:
     class Bean {
-	int a;
-	long b;
-	String s;
+        int a;
+        long b;
+        String s;
     }
 
 Result:
     Bean o = (Bean) obj;
 
     return (a == o.a)
-	&& (b == o.b)
-	&& (s == null ? o.s == null : s.equals(o.s));
+        && (b == o.b)
+        && (s == null ? o.s == null : s.equals(o.s));
 
 Or, with `jdee-gen-equals-trailing-and-operators' set to t:
     Bean o = (Bean) obj;
 
     return (a == o.a) &&
-	(b == o.b) &&
-	(s == null ? o.s == null : s.equals(o.s));
+        (b == o.b) &&
+        (s == null ? o.s == null : s.equals(o.s));
 "
   (interactive)
   (let* ((parm (or parm-name "obj"))
-	 (var (or var-name "o"))
-	 (class-tag (or class (semantic-current-tag)))
-	 (class-name (semantic-tag-name class-tag))
-	 (members (sort (jdee-parse-get-serializable-members class-tag)
-			'jdee-parse-compare-member-types))
-	 (super (car (semantic-tag-type-superclasses class-tag)))
-	 (extends (and super (not (string= "Object" super)))))
+         (var (or var-name "o"))
+         (class-tag (or class (semantic-current-tag)))
+         (class-name (semantic-tag-name class-tag))
+         (members (sort (jdee-parse-get-serializable-members class-tag)
+                        'jdee-parse-compare-member-types))
+         (super (car (semantic-tag-type-superclasses class-tag)))
+         (extends (and super (not (string= "Object" super)))))
     (setq super-method (or super-method "equals"))
     (list 'l '>
-	  class-name " " var " = (" class-name ") " parm ";" '>'n '>'n
-	  "return "
-	  (if jdee-gen-equals-parens-around-expression "(")
-	  (if extends (list 'l (format "super.%s(" super-method) var ")")) '>
-	  (cons 'l (mapcar
-	      (lambda (tag)
-		(let ((name (semantic-tag-name tag))
-		      (type (semantic-tag-type tag)))
-		  (list 'l (if extends (jdee-gen-equals-add-and-operator)
-			     (setq extends t) nil)
-			(cond
-			 ;; primitive arrays
-			 ((and (string-match "\\`\\(byte\\|char\\|short\\|int\\|long\\|float\\|double\\|boolean\\)" type)
-			     (or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type)))
-			  (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
-			    (concat "java.util.Arrays.equals(" array ", " var "." array ")")))
+          class-name " " var " = (" class-name ") " parm ";" '>'n '>'n
+          "return "
+          (if jdee-gen-equals-parens-around-expression "(")
+          (if extends (list 'l (format "super.%s(" super-method) var ")")) '>
+          (cons 'l (mapcar
+              (lambda (tag)
+                (let ((name (semantic-tag-name tag))
+                      (type (semantic-tag-type tag)))
+                  (list 'l (if extends (jdee-gen-equals-add-and-operator)
+                             (setq extends t) nil)
+                        (cond
+                         ;; primitive arrays
+                         ((and (string-match "\\`\\(byte\\|char\\|short\\|int\\|long\\|float\\|double\\|boolean\\)" type)
+                             (or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type)))
+                          (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
+                            (concat "java.util.Arrays.equals(" array ", " var "." array ")")))
 
-			 ;; object arrays
-			 ((or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type))
-			  (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
-			    (concat "java.util.Arrays.deepEquals(" array ", " var "." array ")")))
+                         ;; object arrays
+                         ((or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type))
+                          (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
+                            (concat "java.util.Arrays.deepEquals(" array ", " var "." array ")")))
 
-			 ;; primitives
-			 ((or (semantic-tag-of-type-p tag "byte")
-			      (semantic-tag-of-type-p tag "char")
-			      (semantic-tag-of-type-p tag "short")
-			      (semantic-tag-of-type-p tag "int")
-			      (semantic-tag-of-type-p tag "long")
-			      (semantic-tag-of-type-p tag "boolean"))
-			  (concat "(" name " == " var "." name ")"))
+                         ;; primitives
+                         ((or (semantic-tag-of-type-p tag "byte")
+                              (semantic-tag-of-type-p tag "char")
+                              (semantic-tag-of-type-p tag "short")
+                              (semantic-tag-of-type-p tag "int")
+                              (semantic-tag-of-type-p tag "long")
+                              (semantic-tag-of-type-p tag "boolean"))
+                          (concat "(" name " == " var "." name ")"))
 
-			 ;; floating point; use epsilon?
-			 ((or (semantic-tag-of-type-p tag "float")
-			      (semantic-tag-of-type-p tag "double"))
-			  (concat "(" name " == " var "." name ")"))
+                         ;; floating point; use epsilon?
+                         ((or (semantic-tag-of-type-p tag "float")
+                              (semantic-tag-of-type-p tag "double"))
+                          (concat "(" name " == " var "." name ")"))
 
-			 ;; object references
-			 (t (concat "(" name " == null ? " var "." name " == null : "
-				    name ".equals(" var "." name "))" )))
-			'>))) members))
-	  (if jdee-gen-equals-parens-around-expression ")") ";")))
+                         ;; object references
+                         (t (concat "(" name " == null ? " var "." name " == null : "
+                                    name ".equals(" var "." name "))" )))
+                        '>))) members))
+          (if jdee-gen-equals-parens-around-expression ")") ";")))
 
 (defun jdee-gen-equals-add-and-operator ()
   (if jdee-gen-equals-trailing-and-operators
@@ -3008,13 +3008,13 @@ Setting this variable defines a template instantiation command
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-hashcode-method
-	    (tempo-define-template
-	     "java-hashcode-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create a hashCode method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-hashcode-method
+            (tempo-define-template
+             "java-hashcode-method"
+             (jdee-gen-read-template val)
+             nil
+             "Create a hashCode method at the current point."))
+          (set-default sym val)))
 
 (defvar jdee-gen-hashcode-primes
   '(11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97)
@@ -3027,7 +3027,7 @@ Setting this variable defines a template instantiation command
   "Get the next prime number"
   (let ((last jdee-gen-hashcode-current-prime))
     (setq jdee-gen-hashcode-current-prime (% (+ 1 last)
-					    (length jdee-gen-hashcode-primes)))
+                                            (length jdee-gen-hashcode-primes)))
     (int-to-string (nth last jdee-gen-hashcode-primes))))
 
 ;;;###autoload
@@ -3044,61 +3044,61 @@ then used instead of the result of `semantic-current-tag'.
 "
   (interactive)
   (let* ((var (or var-name "code"))
-	 (class-tag (or class (semantic-current-tag)))
-	 (members (sort (jdee-parse-get-serializable-members class-tag)
-			'jdee-parse-compare-member-types))
-	 (super (car (semantic-tag-type-superclasses class-tag)))
-	 (extends (and super (not (string= "Object" super)))))
+         (class-tag (or class (semantic-current-tag)))
+         (members (sort (jdee-parse-get-serializable-members class-tag)
+                        'jdee-parse-compare-member-types))
+         (super (car (semantic-tag-type-superclasses class-tag)))
+         (extends (and super (not (string= "Object" super)))))
     (list 'l "int " var " = "
-	  (if extends "super.hashCode()" (jdee-gen-hashcode-next-prime)) ";"
-	  '> 'n '> 'n
-	  (cons
-	   'l
-	   (mapcar
-	    (lambda (tag)
-	      (let ((name (semantic-tag-name tag))
-		    (type (semantic-tag-type tag)))
-		(list 'l var " = " var " * 37 + "
-		      (cond
-		       ;; arrays must be first
+          (if extends "super.hashCode()" (jdee-gen-hashcode-next-prime)) ";"
+          '> 'n '> 'n
+          (cons
+           'l
+           (mapcar
+            (lambda (tag)
+              (let ((name (semantic-tag-name tag))
+                    (type (semantic-tag-type tag)))
+                (list 'l var " = " var " * 37 + "
+                      (cond
+                       ;; arrays must be first
 
-		       ;; primitive arrays
-		       ((and (string-match "\\`\\(byte\\|char\\|short\\|int\\|long\\|float\\|double\\|boolean\\)" type)
-			     (or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type)))
-			(let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
-			  (concat "java.util.Arrays.hashCode(" array ")")))
-		       ;; object arrays
-		       ((or (string-match "\\[.*\\]" name) (string-match "\\[\\]" type))
-			(let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
-			  (concat "java.util.Arrays.deepHashCode(" array ")")))
+                       ;; primitive arrays
+                       ((and (string-match "\\`\\(byte\\|char\\|short\\|int\\|long\\|float\\|double\\|boolean\\)" type)
+                             (or (string-match "\\[.*\\]" name) (string-match "\\[.*\\]" type)))
+                        (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
+                          (concat "java.util.Arrays.hashCode(" array ")")))
+                       ;; object arrays
+                       ((or (string-match "\\[.*\\]" name) (string-match "\\[\\]" type))
+                        (let ((array (replace-regexp-in-string "\\[.*\\]" "" name)))
+                          (concat "java.util.Arrays.deepHashCode(" array ")")))
 
-		       ;; smaller types
-		       ((or (semantic-tag-of-type-p tag "byte")
-			    (semantic-tag-of-type-p tag "char")
-			    (semantic-tag-of-type-p tag "short"))
-			(concat "(int) " name))
-		       ;; integers
-		       ((semantic-tag-of-type-p tag "int") name)
-		       ((semantic-tag-of-type-p tag "long")
-			(concat "(int) (" name " ^ (" name " >> 32))" ))
-		       ;; booleans
-		       ((semantic-tag-of-type-p tag "boolean")
-			(concat "(" name " ? 1 : 0)"))
+                       ;; smaller types
+                       ((or (semantic-tag-of-type-p tag "byte")
+                            (semantic-tag-of-type-p tag "char")
+                            (semantic-tag-of-type-p tag "short"))
+                        (concat "(int) " name))
+                       ;; integers
+                       ((semantic-tag-of-type-p tag "int") name)
+                       ((semantic-tag-of-type-p tag "long")
+                        (concat "(int) (" name " ^ (" name " >> 32))" ))
+                       ;; booleans
+                       ((semantic-tag-of-type-p tag "boolean")
+                        (concat "(" name " ? 1 : 0)"))
 
-		       ;; floating point
-		       ((semantic-tag-of-type-p tag "float")
-			(concat "Float.floatToIntBits(" name ")" ))
-		       ((semantic-tag-of-type-p tag "double")
-			(concat "(int) (Double.doubleToLongBits(" name ") ^ (Double.doubleToLongBits(" name ") >> 32))" ))
+                       ;; floating point
+                       ((semantic-tag-of-type-p tag "float")
+                        (concat "Float.floatToIntBits(" name ")" ))
+                       ((semantic-tag-of-type-p tag "double")
+                        (concat "(int) (Double.doubleToLongBits(" name ") ^ (Double.doubleToLongBits(" name ") >> 32))" ))
 
 
-		       ;; object references
-		       (t
-			(concat "(" name " == null ? " (jdee-gen-hashcode-next-prime)
-				" : " name ".hashCode())"))) ";"
-		      '> 'n))) members))
-	  '> 'n
-	  "return " var ";")))
+                       ;; object references
+                       (t
+                        (concat "(" name " == null ? " (jdee-gen-hashcode-next-prime)
+                                " : " name ".hashCode())"))) ";"
+                      '> 'n))) members))
+          '> 'n
+          "return " var ";")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;_* toString method generator
@@ -3127,13 +3127,13 @@ command `jdee-gen-tostring-method', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-tostring-method
-	    (tempo-define-template
-	     "java-tostring-method"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create an toString method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-tostring-method
+            (tempo-define-template
+             "java-tostring-method"
+             (jdee-gen-read-template val)
+             nil
+             "Create an toString method at the current point."))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-tostring-return (&optional class)
@@ -3142,26 +3142,26 @@ java.lang.Object#toString function. This gets the member variables
 of the current class from semantic via `semantic-current-tag'."
   (interactive)
   (let* ((class-tag (or class (semantic-current-tag)))
-	 (class-name (semantic-tag-name class-tag))
-	 (members (jdee-parse-get-member-variables class-tag))
-	 (super (car (semantic-tag-type-superclasses class-tag)))
-	 (extends (and super (not (string= "Object" super))))
-	 (first t)
-	 (str-bld-type "StringBuilder"))
+         (class-name (semantic-tag-name class-tag))
+         (members (jdee-parse-get-member-variables class-tag))
+         (super (car (semantic-tag-type-superclasses class-tag)))
+         (extends (and super (not (string= "Object" super))))
+         (first t)
+         (str-bld-type "StringBuilder"))
     (list 'l '>
-	  (format "return new %s(" str-bld-type)
-	  (cons 'l (mapcar
-		    (lambda (tag)
-		      (let ((name (semantic-tag-name tag)))
-			(prog1
-			    (list 'l (concat (if (not first) ".append(")
-					     "\""
-					     (if (not first) ", "))
-				  name "=\" + " name ")"
-				  '> 'n)
-			  (setq first nil))))
-		    members))
-	  ".toString();")))
+          (format "return new %s(" str-bld-type)
+          (cons 'l (mapcar
+                    (lambda (tag)
+                      (let ((name (semantic-tag-name tag)))
+                        (prog1
+                            (list 'l (concat (if (not first) ".append(")
+                                             "\""
+                                             (if (not first) ", "))
+                                  name "=\" + " name ")"
+                                  '> 'n)
+                          (setq first nil))))
+                    members))
+          ".toString();")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;_* Generate all object methods
@@ -3267,15 +3267,15 @@ command `jdee-gen-exception', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (tempo-define-template "java-exception-buffer-template"
-				 (jdee-gen-read-template val)
-				 nil
-				 "Insert a generic Java exception buffer skeleton.")
-	  (defalias 'jdee-gen-exception
-	    (list 'lambda (list)
-		  (list 'interactive)
-		  (list 'tempo-template-java-exception-buffer-template)))
-	  (set-default sym val)))
+          (tempo-define-template "java-exception-buffer-template"
+                                 (jdee-gen-read-template val)
+                                 nil
+                                 "Insert a generic Java exception buffer skeleton.")
+          (defalias 'jdee-gen-exception
+            (list 'lambda (list)
+                  (list 'interactive)
+                  (list 'tempo-template-java-exception-buffer-template)))
+          (set-default sym val)))
 
 ;;;###autoload
 (defun jdee-gen-exception-buffer (file)
@@ -3289,23 +3289,23 @@ It then moves the point to the location of the first method."
 
 (defcustom jdee-gen-code-templates
   (list (cons "Get Set Pair" 'jdee-gen-get-set)
-	(cons "main method" 'jdee-gen-main)
-	(cons "toString Method (Apache)" 'jdee-gen-tostring-method)
-	(cons "Equals Method" 'jdee-gen-equals-method)
-	(cons "Hash Code Method" 'jdee-gen-hashcode-method)
-	(cons "Deep clone" 'jdee-gen-deep-clone)
-	(cons "Action Listener" 'jdee-gen-action-listener)
-	(cons "Change Listener" 'jdee-gen-change-listener)
-	(cons "Window Listener" 'jdee-gen-window-listener)
-	(cons "Mouse Listener" 'jdee-gen-mouse-listener)
-	(cons "Mouse Motion Listener" 'jdee-gen-mouse-motion-listener)
-	(cons "Inner Class" 'jdee-gen-inner-class)
-	(cons "println" 'jdee-gen-println)
-	(cons "beep" 'jdee-gen-beep)
-	(cons "property change support" 'jdee-gen-property-change-support)
-	(cons "EJB Entity Bean" 'jdee-gen-entity-bean)
-	(cons "EJB Session Bean" 'jdee-gen-session-bean)
-	)
+        (cons "main method" 'jdee-gen-main)
+        (cons "toString Method (Apache)" 'jdee-gen-tostring-method)
+        (cons "Equals Method" 'jdee-gen-equals-method)
+        (cons "Hash Code Method" 'jdee-gen-hashcode-method)
+        (cons "Deep clone" 'jdee-gen-deep-clone)
+        (cons "Action Listener" 'jdee-gen-action-listener)
+        (cons "Change Listener" 'jdee-gen-change-listener)
+        (cons "Window Listener" 'jdee-gen-window-listener)
+        (cons "Mouse Listener" 'jdee-gen-mouse-listener)
+        (cons "Mouse Motion Listener" 'jdee-gen-mouse-motion-listener)
+        (cons "Inner Class" 'jdee-gen-inner-class)
+        (cons "println" 'jdee-gen-println)
+        (cons "beep" 'jdee-gen-beep)
+        (cons "property change support" 'jdee-gen-property-change-support)
+        (cons "EJB Entity Bean" 'jdee-gen-entity-bean)
+        (cons "EJB Session Bean" 'jdee-gen-session-bean)
+        )
   "*Specifies available autocode templates.
 The value of this variable is an association list. The car of
 each element specifies a template name. The cdr specifies
@@ -3314,20 +3314,20 @@ a command that inserts the template into a buffer. See the function
 insertion command."
   :group 'jdee-gen
   :type '(repeat
-	  (cons :tag "Template"
-		(string :tag "Name")
-		(function :tag "Command")))
+          (cons :tag "Template"
+                (string :tag "Name")
+                (function :tag "Command")))
   :set '(lambda (sym val)
-	  (let ((n (length val))
-		(i 0))
-	    (setq jdee-gen-template-names (list))
-	    (while (< i n)
-	      (setq jdee-gen-template-names
-		    (append
-		     jdee-gen-template-names
-		     (list (cons (car (nth i val)) (1+ i)))))
-	      (setq i (1+ i))))
-	  (set-default sym val)))
+          (let ((n (length val))
+                (i 0))
+            (setq jdee-gen-template-names (list))
+            (while (< i n)
+              (setq jdee-gen-template-names
+                    (append
+                     jdee-gen-template-names
+                     (list (cons (car (nth i val)) (1+ i)))))
+              (setq i (1+ i))))
+          (set-default sym val)))
 
 (defun jdee-gen-code (name)
   "Insert the code template specified by NAME at point.
@@ -3380,10 +3380,10 @@ command, `jdee-gen-main', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "main"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "main"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-enable t
   "Enables abbreviations for Java control flow constructs."
@@ -3433,10 +3433,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "if"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "if"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-else
   '(
@@ -3454,10 +3454,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "else"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "else"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-if-else
   '(
@@ -3486,10 +3486,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "ife"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "ife"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-else-if
   '(
@@ -3509,10 +3509,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "eif"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "eif"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-gen-cflow-while)
 (defcustom jdee-gen-cflow-while
@@ -3533,10 +3533,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "while"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "while"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-for
   '(
@@ -3556,10 +3556,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "for"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "for"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-for-i
   '(
@@ -3584,10 +3584,10 @@ Note: `tempo-interactive' must be set to a non-nil value to be prompted
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "fori"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "fori"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-for-iter
   '(
@@ -3614,10 +3614,10 @@ Note: `tempo-interactive' must be set to a non-nil value to be prompted
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "foriter"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "foriter"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-switch
   '(
@@ -3642,10 +3642,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "switch"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "switch"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-case
   '(
@@ -3659,10 +3659,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "case"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "case"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 ;; (makunbound 'jdee-gen-cflow-try-catch)
 (defcustom jdee-gen-cflow-try-catch
@@ -3689,7 +3689,7 @@ and then space. Note that abbrev mode must be enabled. See
     "'p'n"
     "\"}\""
     " (if jdee-gen-comments "
-    "	'(l \" // end of try-catch\"))"
+    "        '(l \" // end of try-catch\"))"
     "'>'n"
     )
   "Skeleton try-catch statement. To insert the statement at point, type try
@@ -3698,10 +3698,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "try"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "try"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-catch
   '(
@@ -3721,10 +3721,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "catch"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "catch"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-try-finally
   '(
@@ -3758,10 +3758,10 @@ tryf and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "tryf"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "tryf"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-cflow-finally
   '(
@@ -3779,10 +3779,10 @@ and then space. Note that abbrev mode must be enabled. See
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (jdee-gen-define-abbrev-template
-	   "finally"
-	   (jdee-gen-read-template val))
-	  (set-default sym val)))
+          (jdee-gen-define-abbrev-template
+           "finally"
+           (jdee-gen-read-template val))
+          (set-default sym val)))
 
 (defcustom jdee-gen-log-member-template
   '(
@@ -3801,13 +3801,13 @@ command `jdee-gen-log-member', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-log-member
-	    (tempo-define-template
-	     "java-log-member"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create a log member at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-log-member
+            (tempo-define-template
+             "java-log-member"
+             (jdee-gen-read-template val)
+             nil
+             "Create a log member at the current point."))
+          (set-default sym val)))
 
 (defcustom jdee-gen-log-statement-template
   '(
@@ -3834,13 +3834,13 @@ command `jdee-gen-log-statement', as a side-effect."
   :group 'jdee-gen
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-gen-log-statement
-	    (tempo-define-template
-	     "java-log-statement"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Create an log statement method at the current point."))
-	  (set-default sym val)))
+          (defalias 'jdee-gen-log-statement
+            (tempo-define-template
+             "java-log-statement"
+             (jdee-gen-read-template val)
+             nil
+             "Create an log statement method at the current point."))
+          (set-default sym val)))
 
 (defun jdee-gen-abbrev-hook ()
   "Abbreviation hook. Inserts an abbreviation template.
@@ -3849,22 +3849,22 @@ This function does nothing, if point is in a comment or string.
 Returns t, if the template has been inserted, otherwise nil."
   (unless (jdee-parse-comment-or-quoted-p)
     (let* ((abbrev-start
-	    (or abbrev-start-location
-		(save-excursion (re-search-backward "\\<.*\\="))))
-	   (abbrev
-	    (buffer-substring-no-properties abbrev-start (point)))
-	   (template (assoc-string abbrev jdee-gen-abbrev-templates t)))
+            (or abbrev-start-location
+                (save-excursion (re-search-backward "\\<.*\\="))))
+           (abbrev
+            (buffer-substring-no-properties abbrev-start (point)))
+           (template (assoc-string abbrev jdee-gen-abbrev-templates t)))
       (if template
-	  (progn
-	    (delete-char (- (length abbrev)))
-	    ;; Following let avoids infinite expansion.
-	    ;; Infinite expansions could be caused by
-	    ;; (newline) in templates.
-	    ;; e.g. "else" (newline)
-	    (let (local-abbrev-table)
-	      (funcall (cdr template)))
-	    t) ; don't insert self-inserting input character that triggered the expansion.
-	(error "Template for abbreviation %s not found!" abbrev)))))
+          (progn
+            (delete-char (- (length abbrev)))
+            ;; Following let avoids infinite expansion.
+            ;; Infinite expansions could be caused by
+            ;; (newline) in templates.
+            ;; e.g. "else" (newline)
+            (let (local-abbrev-table)
+              (funcall (cdr template)))
+            t) ; don't insert self-inserting input character that triggered the expansion.
+        (error "Template for abbreviation %s not found!" abbrev)))))
 
 ;; The following enables the hook to control the treatment of the
 ;; self-inserting input character that triggered the expansion.
@@ -3873,13 +3873,13 @@ Returns t, if the template has been inserted, otherwise nil."
 (defun jdee-gen-load-abbrev-templates ()
   "Defines jdee-mode abbrevs for the control flow templates."
   (loop for template in jdee-gen-abbrev-templates do
-	(let ((abbrev (car template)))
-	  (define-abbrev
-	    local-abbrev-table
-	    abbrev
-	    t ;; Hack (see note below)
-	    'jdee-gen-abbrev-hook
-	    0))))
+        (let ((abbrev (car template)))
+          (define-abbrev
+            local-abbrev-table
+            abbrev
+            t ;; Hack (see note below)
+            'jdee-gen-abbrev-hook
+            0))))
 
 ;; Note: the previous function uses the following hack to address the
 ;; problem of preventing expansion of control flow abbreviations in
@@ -3899,35 +3899,35 @@ Returns t, if the template has been inserted, otherwise nil."
    (insert "public class Test {\n\n}")
    (backward-char 2)
    (loop for flags in '((t . t) (t . nil) (nil . t) (nil . nil)) do
-	 (let ((jdee-gen-k&r (car flags))
-	       (jdee-gen-comments (cdr flags)))
-	   (insert (format "/**** jdee-gen-comments: %S jdee-gen-k&r: %S ****/\n\n"
-			   jdee-gen-comments jdee-gen-k&r))
-	   (loop for abbrev in
-		 '(("if"      (clause . "true"))
-		   ("else")
-		   ("ife"     (clause . "true"))
-		   ("eif"     (clause . "true"))
-		   ("while"   (clause . "true"))
-		   ("for"     (clause . "int i = 0; i < 10; i++"))
-		   ("fori"    (var . "i") (upper-bound . "10"))
-		   ("foriter" (var . "iter") (coll . "list"))
-		   ("switch"  (clause . "digit") (first-value . "1"))
-		   ("case"    (value . "2"))
-		   ("try"     (clause . "Exception"))
-		   ("catch"   (clause . "Exception"))
-		   ("tryf"    (clause . "Exception"))
-		   ("finally"))
-		 do
-		 (let (insertations
-		       (abbrev-start-location (point)))
-		   (insert (car abbrev))
-		   (while (setq abbrev (cdr abbrev))
-		     (setq insertations (car abbrev))
-		     (tempo-save-named (car insertations) (cdr insertations)))
-		   (jdee-gen-abbrev-hook)
-		   (goto-char (- (point-max) 2))
-		   (insert "\n"))))))
+         (let ((jdee-gen-k&r (car flags))
+               (jdee-gen-comments (cdr flags)))
+           (insert (format "/**** jdee-gen-comments: %S jdee-gen-k&r: %S ****/\n\n"
+                           jdee-gen-comments jdee-gen-k&r))
+           (loop for abbrev in
+                 '(("if"      (clause . "true"))
+                   ("else")
+                   ("ife"     (clause . "true"))
+                   ("eif"     (clause . "true"))
+                   ("while"   (clause . "true"))
+                   ("for"     (clause . "int i = 0; i < 10; i++"))
+                   ("fori"    (var . "i") (upper-bound . "10"))
+                   ("foriter" (var . "iter") (coll . "list"))
+                   ("switch"  (clause . "digit") (first-value . "1"))
+                   ("case"    (value . "2"))
+                   ("try"     (clause . "Exception"))
+                   ("catch"   (clause . "Exception"))
+                   ("tryf"    (clause . "Exception"))
+                   ("finally"))
+                 do
+                 (let (insertations
+                       (abbrev-start-location (point)))
+                   (insert (car abbrev))
+                   (while (setq abbrev (cdr abbrev))
+                     (setq insertations (car abbrev))
+                     (tempo-save-named (car insertations) (cdr insertations)))
+                   (jdee-gen-abbrev-hook)
+                   (goto-char (- (point-max) 2))
+                   (insert "\n"))))))
 
 
 
@@ -3959,57 +3959,57 @@ BEG and END are modified so the region only contains complete lines."
 nil it is omitted. BEG and END are modified so the region only contains
 complete lines."
   (let ((to (make-marker))
-	indent-region-function)
+        indent-region-function)
     (set-marker to
-		(save-excursion
-		  (goto-char end)
-		  (if (and (bolp)
-			   (not (= beg end)))
-		      (point)
-		    (end-of-line)
-		    (1+ (point)))))
+                (save-excursion
+                  (goto-char end)
+                  (if (and (bolp)
+                           (not (= beg end)))
+                      (point)
+                    (end-of-line)
+                    (1+ (point)))))
     (goto-char beg)
     (beginning-of-line)
     (insert expr1)
     (if (string= expr1 "if")
-	(insert (concat jdee-gen-conditional-padding-1
-			"(" jdee-gen-conditional-padding-2 ")")))
+        (insert (concat jdee-gen-conditional-padding-1
+                        "(" jdee-gen-conditional-padding-2 ")")))
     (if jdee-gen-k&r
-	(insert " ")
+        (insert " ")
       (insert "\n"))
     (insert "{\n")
     (if jdee-gen-k&r
-	(forward-char -1)
+        (forward-char -1)
       (forward-char -4))
     (indent-for-tab-command)
     (indent-region (point) to nil)
     (goto-char to)
     (insert "}")
     (if expr2
-	(progn
-	  (if jdee-gen-k&r
-	      (insert jdee-gen-conditional-padding-3)
-	    (insert "\n"))
-	  (if (string= expr2 "catch")
-	      (insert (concat expr2 jdee-gen-conditional-padding-1
-			      "(" jdee-gen-conditional-padding-2 " e"
-			      jdee-gen-conditional-padding-2 ")"))
-	    (insert expr2))
-	  (if jdee-gen-k&r
-	      (insert jdee-gen-conditional-padding-3)
-	    (insert "\n"))
-	  (insert "{\n}")
-	  (if jdee-gen-comments
-	      (insert " // end of " expr1
-		      (if expr2
-			  (concat "-" expr2))))))
+        (progn
+          (if jdee-gen-k&r
+              (insert jdee-gen-conditional-padding-3)
+            (insert "\n"))
+          (if (string= expr2 "catch")
+              (insert (concat expr2 jdee-gen-conditional-padding-1
+                              "(" jdee-gen-conditional-padding-2 " e"
+                              jdee-gen-conditional-padding-2 ")"))
+            (insert expr2))
+          (if jdee-gen-k&r
+              (insert jdee-gen-conditional-padding-3)
+            (insert "\n"))
+          (insert "{\n}")
+          (if jdee-gen-comments
+              (insert " // end of " expr1
+                      (if expr2
+                          (concat "-" expr2))))))
     (insert "\n")
     (indent-region (marker-position to) (point) nil)
     (goto-char to)
     (if (string= expr1 "if")
-	(search-backward (concat "(" jdee-gen-conditional-padding-2 ")")))
+        (search-backward (concat "(" jdee-gen-conditional-padding-2 ")")))
     (if (string= expr2 "catch")
-	(search-forward "("))))
+        (search-forward "("))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -4027,7 +4027,7 @@ time to enable or disable eelctric return mode."
   :group 'jdee-gen
   :type 'boolean
   :set '(lambda (sym val)
-	  (if (featurep 'jdee)
+          (if (featurep 'jdee)
               (mapc
                (lambda (buf)
                  (with-current-buffer buf
@@ -4036,8 +4036,8 @@ time to enable or disable eelctric return mode."
                          (define-key (current-local-map) key 'jdee-electric-return)
                        (local-unset-key key)))))
                (jdee-get-project-source-buffers)))
-	  (setq jdee-electric-return-mode val)
-	  (set-default sym val)))
+          (setq jdee-electric-return-mode val)
+          (set-default sym val)))
 
 (defcustom jdee-newline-function  'newline-and-indent
   "Indent command that `jdee-electric-return' calls.  Functions
@@ -4055,7 +4055,7 @@ So if before
 you had:
 
    pubic void function () {
-			   ^
+                           ^
 You now have:
 
    pubic void function () {
@@ -4075,17 +4075,17 @@ After:
    } ^"
   (interactive)
   (if (or (eq (point) (point-min))
-	  (save-excursion
-	    (backward-char)
-	    (not (looking-at "{}?$"))))
+          (save-excursion
+            (backward-char)
+            (not (looking-at "{}?$"))))
       (newline-and-indent)
     ;; else
     (progn
       (newline-and-indent)
       (newline-and-indent)
       (when (not (looking-at "}"))
-	(insert "}")
-	(c-indent-command))
+        (insert "}")
+        (c-indent-command))
       (forward-line -1)
       (c-indent-command))))
 
@@ -4094,9 +4094,9 @@ After:
   (interactive)
   (if  ;; the current line ends at an open brace.
        (and
-	(save-excursion
-	  (re-search-backward "{\\s-*" (line-beginning-position) t))
-	(looking-at "}?\\s-*$"))
+        (save-excursion
+          (re-search-backward "{\\s-*" (line-beginning-position) t))
+        (looking-at "}?\\s-*$"))
       (jdee-gen-embrace)
     (call-interactively jdee-newline-function)))
 
@@ -4113,9 +4113,9 @@ by rebinding the Return key to its original binding."
   (interactive)
   (when (boundp 'jdee-mode-map)
     (let ((key (car (read-from-string "[return]"))))
-	   (if jdee-electric-return-mode
-	       (local-unset-key key)
-	     (define-key (current-local-map) key 'jdee-electric-return))))
+           (if jdee-electric-return-mode
+               (local-unset-key key)
+             (define-key (current-local-map) key 'jdee-electric-return))))
   (setq jdee-electric-return-mode (not jdee-electric-return-mode))
   (if jdee-electric-return-mode
       (message "electric return mode on")

--- a/jdee-imenu.el
+++ b/jdee-imenu.el
@@ -81,9 +81,9 @@ See also `jdee-imenu-modifier-abbrev-alist'."
 
 (defconst jdee-imenu-valid-modifiers-regexp
   (concat "\\b"
-	  (regexp-opt
-	   (mapcar #'car jdee-imenu-default-modifier-abbrev-alist) t)
-	  "\\b")
+          (regexp-opt
+           (mapcar #'car jdee-imenu-default-modifier-abbrev-alist) t)
+          "\\b")
   "Regexp of valid Java modifiers used by
 `jdee-imenu-modifier-field-validate'.")
 
@@ -93,10 +93,10 @@ Used by `jdee-imenu-modifier-abbrev-alist' customization."
   (save-excursion
     (let ((value (widget-value widget)))
       (if (and (stringp value)
-	       (string-match jdee-imenu-valid-modifiers-regexp value))
-	  nil
-	(widget-put widget :error (format "Invalid modifier: %S" value))
-	widget))))
+               (string-match jdee-imenu-valid-modifiers-regexp value))
+          nil
+        (widget-put widget :error (format "Invalid modifier: %S" value))
+        widget))))
 
 (defun jdee-imenu-abbrev-field-validate (widget)
   "Validate a character abbreviation.
@@ -104,10 +104,10 @@ Used by `jdee-imenu-modifier-abbrev-alist' customization."
   (save-excursion
     (let ((value (widget-value widget)))
       (if (characterp value)
-	  nil
-	(widget-put widget :error
-		    (format "Invalid character value: %S" value))
-	widget))))
+          nil
+        (widget-put widget :error
+                    (format "Invalid character value: %S" value))
+        widget))))
 
 (defcustom jdee-imenu-modifier-abbrev-alist
   jdee-imenu-default-modifier-abbrev-alist
@@ -118,21 +118,21 @@ and CHARACTER any valid character. Modifiers without any valid
 association are not displayed (see also `jdee-imenu-include-modifiers')."
   :group 'jdee-project
   :type '(repeat
-	  (cons :tag "Abbrev"
-		(string :tag "Modifier"
-			:validate
-			(lambda (widget)
-			  (jdee-imenu-modifier-field-validate widget))
-			"")
-		(choice :tag "Abbreviation"
-			(const     :tag "None" nil)
-			(character :tag "Character")
-			(integer   :tag "Character value"
-				   :validate
-				   (lambda (widget)
-				     (jdee-imenu-abbrev-field-validate widget))
-				   ))
-		)))
+          (cons :tag "Abbrev"
+                (string :tag "Modifier"
+                        :validate
+                        (lambda (widget)
+                          (jdee-imenu-modifier-field-validate widget))
+                        "")
+                (choice :tag "Abbreviation"
+                        (const     :tag "None" nil)
+                        (character :tag "Character")
+                        (integer   :tag "Character value"
+                                   :validate
+                                   (lambda (widget)
+                                     (jdee-imenu-abbrev-field-validate widget))
+                                   ))
+                )))
 
 (defun jdee--imenu-setup-sorting (sym val)
   ;; setup sorting for `semantic-create-imenu-index'
@@ -159,8 +159,8 @@ You can choose:
 Use *Rescan* to rebuild the imenu when you have changed this option."
   :group 'jdee-project
   :type '(choice (const :tag "No sort"    nil )
-		 (const :tag "Ascending"  asc )
-		 (const :tag "Descending" desc))
+                 (const :tag "Ascending"  asc )
+                 (const :tag "Descending" desc))
   :set #'jdee--imenu-setup-sorting)
 
 ;;;;
@@ -175,19 +175,19 @@ also `jdee-imenu-include-modifiers')."
   (if (not jdee-imenu-include-modifiers)
       ""
     (let ((alist jdee-imenu-modifier-abbrev-alist)
-	  (abbrevs "")
-	  entry modifier)
+          (abbrevs "")
+          entry modifier)
       (while alist
-	(setq entry (car alist)
-	      alist (cdr alist))
-	(if (member (car entry) modifiers)
-	    (setq abbrevs
-		  (concat abbrevs (if (characterp (cdr entry))
-				      (char-to-string (cdr entry))
-				    "")))))
+        (setq entry (car alist)
+              alist (cdr alist))
+        (if (member (car entry) modifiers)
+            (setq abbrevs
+                  (concat abbrevs (if (characterp (cdr entry))
+                                      (char-to-string (cdr entry))
+                                    "")))))
       (if (> (length abbrevs) 0)
-	  (concat abbrevs " ")         ; trailing whitespace separator
-	abbrevs))))
+          (concat abbrevs " ")         ; trailing whitespace separator
+        abbrevs))))
 
 ;;;;
 ;;;; Universal `semantic-imenu' stuff adapted to JDE's needs
@@ -197,49 +197,49 @@ also `jdee-imenu-include-modifiers')."
   "Return a prototype for TAG.
 See also `semantic-prototype-nonterminal'."
   (let* ((tag-cat  (semantic-tag-class tag))
-	 (prototyper (intern-soft (format "jdee-imenu-prototype-%s"
-					  tag-cat))))
+         (prototyper (intern-soft (format "jdee-imenu-prototype-%s"
+                                          tag-cat))))
     (if (fboundp prototyper)
-	(funcall prototyper tag parent color)
+        (funcall prototyper tag parent color)
       (if (fboundp 'semantic-format-prototype-tag-java-mode)
-	  (semantic-format-prototype-tag-java-mode tag parent color) ;; cedet-1.0pre6 and earlier
-	(semantic-format-tag-prototype-java-mode tag parent color)) ;; cedet-1.0pre7
+          (semantic-format-prototype-tag-java-mode tag parent color) ;; cedet-1.0pre6 and earlier
+        (semantic-format-tag-prototype-java-mode tag parent color)) ;; cedet-1.0pre7
       )))
 
 (defun jdee-imenu-prototype-function (tag &optional parent color)
   "Return a function (method) prototype for TAG.
 See also `semantic-java-prototype-function'."
   (let ((sign (if jdee-imenu-include-signature
-		  (semantic-java-prototype-function tag parent color)
-		(concat (if color
-			    (semantic--format-colorize-text
-			     (semantic-tag-name tag) 'function)
-			  (semantic-tag-name tag))
-			"()"))))
+                  (semantic-java-prototype-function tag parent color)
+                (concat (if color
+                            (semantic--format-colorize-text
+                             (semantic-tag-name tag) 'function)
+                          (semantic-tag-name tag))
+                        "()"))))
     (concat (jdee-imenu-abbreviate-modifiers
-	     (semantic-tag-modifiers tag))
-	    sign)))
+             (semantic-tag-modifiers tag))
+            sign)))
 
 (defun jdee-imenu-prototype-variable (tag &optional parent color)
   "Return a variable (field) prototype for TAG.
 See also `semantic-java-prototype-variable'."
   (let ((sign (if jdee-imenu-include-signature
-		  (semantic-java-prototype-variable tag parent color)
-		(if color
-		    (semantic--format-colorize-text
-		     (semantic-tag-name tag) 'variable)
-		  (semantic-tag-name tag)))))
+                  (semantic-java-prototype-variable tag parent color)
+                (if color
+                    (semantic--format-colorize-text
+                     (semantic-tag-name tag) 'variable)
+                  (semantic-tag-name tag)))))
     (concat (jdee-imenu-abbreviate-modifiers
-	     (semantic-tag-modifiers tag))
-	    sign)))
+             (semantic-tag-modifiers tag))
+            sign)))
 
 (defun jdee-imenu-prototype-type (tag &optional parent color)
   "Return a type (class/interface) prototype for TAG.
 See also `semantic-prototype-nonterminal'."
   (let ((sign (semantic-java-prototype-type tag parent color)))
     (concat (jdee-imenu-abbreviate-modifiers
-	     (semantic-tag-modifiers tag))
-	    sign)))
+             (semantic-tag-modifiers tag))
+            sign)))
 
 ;;;;
 ;;;; Specific JDE's imenu (to be replaced by semantic-imenu stuff)
@@ -254,102 +254,102 @@ index to go to class definition."
 (defun jdee-imenu-sort-tags (tags)
   "Sorts the tag list TAGS depending on `jdee-imenu-sort' value."
   (cond ((eq jdee-imenu-sort 'asc)
-	 (sort tags
-	       (function
-		(lambda (tag1 tag2)
-		  (string-lessp (upcase (semantic-tag-name tag1))
-				(upcase (semantic-tag-name tag2)))))))
-	((eq jdee-imenu-sort 'desc)
-	 (sort tags
-	       (function
-		(lambda (tag1 tag2)
-		  (string-lessp (upcase (semantic-tag-name tag2))
-				(upcase (semantic-tag-name tag1)))))))
-	(t
-	 tags)))
+         (sort tags
+               (function
+                (lambda (tag1 tag2)
+                  (string-lessp (upcase (semantic-tag-name tag1))
+                                (upcase (semantic-tag-name tag2)))))))
+        ((eq jdee-imenu-sort 'desc)
+         (sort tags
+               (function
+                (lambda (tag1 tag2)
+                  (string-lessp (upcase (semantic-tag-name tag2))
+                                (upcase (semantic-tag-name tag1)))))))
+        (t
+         tags)))
 
 (defun jdee-imenu-index-class  (class-tag)
   "Creates an imenu index for a class in CLASS-TAG."
   (let* ((class-name  (semantic-tag-name       class-tag))
-	 (class-type  (semantic-tag-type       class-tag))
-	 (class-start (semantic-tag-start      class-tag))
-	 (class-parts (semantic-tag-type-members class-tag))
-	 (class-index (jdee-imenu-index-class-parts class-parts)))
+         (class-type  (semantic-tag-type       class-tag))
+         (class-start (semantic-tag-start      class-tag))
+         (class-parts (semantic-tag-type-members class-tag))
+         (class-index (jdee-imenu-index-class-parts class-parts)))
 
     (if jdee-imenu-include-classdef
-	;; If requested adds a *class def* item to go to the class def.
-	(setq class-index (cons (cons "*class def*" class-start)
-				class-index))
+        ;; If requested adds a *class def* item to go to the class def.
+        (setq class-index (cons (cons "*class def*" class-start)
+                                class-index))
       ;; Else adds an *empty* item to go to the class def. only
       ;; when there is not parts
       (or class-index
-	  (setq class-index
-		(list (cons "*empty*"
-			    class-start)))))
+          (setq class-index
+                (list (cons "*empty*"
+                            class-start)))))
 
     (list (cons (format "%s %s" class-type class-name)
-		class-index))))
+                class-index))))
 
 (defun jdee-imenu-index-class-parts (tags)
   "Creates an imenu index for class parts in TAGS.
 When`jdee-imenu-include-signature' is non-nil the
 index menu displays full method signatures and field types."
   (let ((methods (semantic-brute-find-tag-by-class 'function tags))
-	(fields  (semantic-brute-find-tag-by-class 'variable tags))
-	(classes (semantic-brute-find-tag-by-class 'type     tags))
-	index)
+        (fields  (semantic-brute-find-tag-by-class 'variable tags))
+        (classes (semantic-brute-find-tag-by-class 'type     tags))
+        index)
 
     (setq methods (jdee-imenu-sort-tags methods))
     (while methods
       (let* ((method-tag (car methods))
-	     (method-name  (semantic-tag-name method-tag))
-	     (method-pos   (semantic-tag-start method-tag))
-	     method-sig)
-	(if jdee-imenu-include-signature
-	    (let ((method-type  (semantic-tag-type method-tag))
-		  (method-args  (semantic-tag-function-arguments method-tag)))
-	      (setq method-sig (if method-type
-				   (format "%s %s(" method-type method-name)
-				 (format "%s(" method-name)))
-	      (while method-args
-		(let ((method-arg-tag (car method-args))
-		      method-arg-type)
-		  (when (semantic-tag-p method-arg-tag)
-		    (setq method-arg-type (semantic-tag-type method-arg-tag))
-		    (setq method-sig (concat method-sig method-arg-type ",")))
-		  (setq method-args (cdr method-args))))
-	      ;; remove the extra comma at end
-	      (if (char-equal ?, (aref method-sig (1- (length method-sig))))
-		  (setq method-sig (substring method-sig 0 -1)))
-	      (setq method-sig (concat method-sig ")")))
-	  (setq method-sig (format "%s()" method-name)))
-	(setq index
-	      (append
-	       index (list (cons method-sig method-pos)))))
+             (method-name  (semantic-tag-name method-tag))
+             (method-pos   (semantic-tag-start method-tag))
+             method-sig)
+        (if jdee-imenu-include-signature
+            (let ((method-type  (semantic-tag-type method-tag))
+                  (method-args  (semantic-tag-function-arguments method-tag)))
+              (setq method-sig (if method-type
+                                   (format "%s %s(" method-type method-name)
+                                 (format "%s(" method-name)))
+              (while method-args
+                (let ((method-arg-tag (car method-args))
+                      method-arg-type)
+                  (when (semantic-tag-p method-arg-tag)
+                    (setq method-arg-type (semantic-tag-type method-arg-tag))
+                    (setq method-sig (concat method-sig method-arg-type ",")))
+                  (setq method-args (cdr method-args))))
+              ;; remove the extra comma at end
+              (if (char-equal ?, (aref method-sig (1- (length method-sig))))
+                  (setq method-sig (substring method-sig 0 -1)))
+              (setq method-sig (concat method-sig ")")))
+          (setq method-sig (format "%s()" method-name)))
+        (setq index
+              (append
+               index (list (cons method-sig method-pos)))))
       (setq methods (cdr methods)))
 
     ;; Add a separator between method and field index
     (if fields
-	(setq index (append index '(("-")))))
+        (setq index (append index '(("-")))))
 
     (setq fields (jdee-imenu-sort-tags fields))
     (while fields
       (let* ((field-tag (car fields))
-	     (field-name  (semantic-tag-name  field-tag))
-	     (field-pos   (semantic-tag-start field-tag)))
-	(if jdee-imenu-include-signature
-	    (setq field-name (concat (semantic-tag-type field-tag)
-				     " " field-name)))
-	(setq index
-	      (append
-	       index (list (cons field-name field-pos)))))
+             (field-name  (semantic-tag-name  field-tag))
+             (field-pos   (semantic-tag-start field-tag)))
+        (if jdee-imenu-include-signature
+            (setq field-name (concat (semantic-tag-type field-tag)
+                                     " " field-name)))
+        (setq index
+              (append
+               index (list (cons field-name field-pos)))))
       (setq fields (cdr fields)))
 
     (setq classes (jdee-imenu-sort-tags classes))
     (while classes
       (let* ((class-tag  (car classes))
-	     (class-index  (jdee-imenu-index-class class-tag)))
-	(setq index (append index class-index)))
+             (class-index  (jdee-imenu-index-class class-tag)))
+        (setq index (append index class-index)))
       (setq classes (cdr classes)))
     index))
 
@@ -407,15 +407,15 @@ This function uses the semantic bovinator to index the buffer."
     ;; semantic overloaded functions
     (semantic-install-function-overrides
      (if (fboundp 'semantic-format-tag-prototype)
-	 '((format-tag-prototype . jdee-imenu-prototype-nonterminal))
+         '((format-tag-prototype . jdee-imenu-prototype-nonterminal))
        '((prototype-nonterminal . jdee-imenu-prototype-nonterminal))
        ))
 
     ;; function to use for creating the imenu
     (setq imenu-create-index-function
-	  (if (fboundp jdee-imenu-create-index-function)
-	      jdee-imenu-create-index-function
-	    'semantic-create-imenu-index))
+          (if (fboundp jdee-imenu-create-index-function)
+              jdee-imenu-create-index-function
+            'semantic-create-imenu-index))
 
     ;; add the imenu to the menu bar for the current buffer
     (imenu-add-to-menubar "Classes")

--- a/jdee-import.el
+++ b/jdee-import.el
@@ -69,11 +69,11 @@ If more than one fully qualified class names match the unqualified name that you
 the command prompts you to select only the classes that are not excluded."
   :group 'jdee-project
   :type '(repeat
-	  (cons :tag "Exclude rule"
-		(choice :tag "Exclude test"
-			(regexp :tag "Regexp")
-			(function :tag "Test function"))
-		(boolean :tag "Exclude synonyms"))))
+          (cons :tag "Exclude rule"
+                (choice :tag "Exclude test"
+                        (regexp :tag "Regexp")
+                        (function :tag "Test function"))
+                (boolean :tag "Exclude synonyms"))))
 
 ;; auto sorting of import statements
 (defcustom jdee-import-auto-sort nil
@@ -106,10 +106,10 @@ See command `jdee-import-organize'. Note: For sorting the packages
 within each group, see variable `jdee-import-reverse-sort-group'."
   :group 'jdee-project
   :type '(choice :tag "Order"
-		 (const :tag "No sort"                  nil)
-		 (const :tag "group-of-rules order"     gor)
-		 (const :tag "alphabetic order"         asc)
-		 (const :tag "reverse alphabetic order" desc)))
+                 (const :tag "No sort"                  nil)
+                 (const :tag "group-of-rules order"     gor)
+                 (const :tag "alphabetic order"         asc)
+                 (const :tag "reverse alphabetic order" desc)))
 
 (defcustom jdee-import-group-function 'jdee-import-group-of
   "*Function used to associate an import token to a group.
@@ -130,15 +130,15 @@ Each group definition is a pair (REGEXP . GROUP) where:
     group name or nil if REGEXP is the group name."
   :group 'jdee-project
   :type '(repeat
-	  (cons :tag "Group Rule"
-		regexp
-		(choice :tag "Group Name"
-			(string  :tag "A String")
-			(integer :tag "Match data at")
-			(const   :tag "The Regexp" nil))))
+          (cons :tag "Group Rule"
+                regexp
+                (choice :tag "Group Name"
+                        (string  :tag "A String")
+                        (integer :tag "Match data at")
+                        (const   :tag "The Regexp" nil))))
   :set '(lambda (sym val)
-	  ;; delete empty entries!
-	  (set-default sym (delete '("") val))))
+          ;; delete empty entries!
+          (set-default sym (delete '("") val))))
 
 (defcustom jdee-import-default-group-name nil
   "*Default group name if no group name is found.
@@ -146,7 +146,7 @@ If a group name is not found in `jdee-import-group-of-rules' then this
 group name is used.  If nil no default group name is used."
   :group 'jdee-project
   :type '(choice (string  :tag "A String")
-		 (const :tag "none" nil)))
+                 (const :tag "none" nil)))
 
 (defcustom jdee-import-insert-group-names nil
   "*If non-nil `jdee-import-organize' inserts group name before imports.
@@ -183,7 +183,7 @@ in the latter case, supplying the no-exclude argument to `jdee-import-all' will 
 the same package as the class in the current buffer."
   (let ((pkg (jdee-parse-get-package-name)))
     (if pkg
-	(string= pkg (jdee-parse-get-package-from-name class)))))
+        (string= pkg (jdee-parse-get-package-from-name class)))))
 
 (defun jdee-import-get-qualified-names (unqualified-class)
   "Return a list containing all qualified name for UNQUALIFIED-CLASS."
@@ -192,13 +192,13 @@ the same package as the class in the current buffer."
 (defun jdee-import-get-imports ()
   "Return a list containing all imported classes."
   (let* (imports
-	 (tags  (semantic-fetch-tags))
-	 (import-tags (semantic-brute-find-tag-by-class 'include tags)))
+         (tags  (semantic-fetch-tags))
+         (import-tags (semantic-brute-find-tag-by-class 'include tags)))
     (dolist (import-tag import-tags)
       (setq imports
-	    (cons
-	     (semantic-tag-name import-tag)
-	     imports)))
+            (cons
+             (semantic-tag-name import-tag)
+             imports)))
     (nreverse imports)))
 
 (defun jdee-import-get-import (unqualified-class)
@@ -206,12 +206,12 @@ the same package as the class in the current buffer."
 This name may have the form \"package.*\". Returns nil,
 if there is no import statement for UNQUALIFIED-CLASS."
   (let (import
-	(imports (jdee-import-get-imports))
-	(qualified-names (jdee-import-get-qualified-names unqualified-class)))
+        (imports (jdee-import-get-imports))
+        (qualified-names (jdee-import-get-qualified-names unqualified-class)))
     (catch 'found
       (dolist (class qualified-names)
-	(if (setq import (jdee-import-already-imports-class class imports))
-	    (throw 'found import))))))
+        (if (setq import (jdee-import-already-imports-class class imports))
+            (throw 'found import))))))
 
 (defun jdee-import-get-import-insertion-point ()
   "Determine where to insert an import statement.
@@ -224,36 +224,36 @@ contains a class definition, return the beginning
 of the line before the class definition; otherwise,
 return the beginning of the buffer."
   (cl-flet ((insertion-point-after
-	     (tag-end)
-	     (goto-char tag-end)
-	     (if (eolp) (forward-char 1)(forward-line 1)) ;skip comment
-	     (point)
-	     ))
+             (tag-end)
+             (goto-char tag-end)
+             (if (eolp) (forward-char 1)(forward-line 1)) ;skip comment
+             (point)
+             ))
     (let* ((tags (semantic-fetch-tags)) ;(xx (message "tags = %s" tags))
-	   (import-tag (car
-			(last (semantic-brute-find-tag-by-class
-			       'include tags))))
-	   (package-tag (car (semantic-brute-find-tag-by-class
-			      'package tags)))
-	   (class-tag (car (semantic-brute-find-tag-by-class
-			    'type tags)))
-	   )
+           (import-tag (car
+                        (last (semantic-brute-find-tag-by-class
+                               'include tags))))
+           (package-tag (car (semantic-brute-find-tag-by-class
+                              'package tags)))
+           (class-tag (car (semantic-brute-find-tag-by-class
+                            'type tags)))
+           )
       (save-excursion
-	(cond (import-tag
-	       (insertion-point-after (semantic-tag-end import-tag)))
-	      (package-tag
-	       (insertion-point-after (semantic-tag-end package-tag))
-	       (insert "\n")		;empty line before new imports
-	       (unless (eolp)		;empty line after new imports
-		 (save-excursion (insert "\n")))
-	       (point))
-	      (class-tag
-	       (let ((comment-token (semantic-documentation-for-tag
-				     class-tag 'lex)))
-		 (if comment-token
-		     (semantic-lex-token-start comment-token)
-		   (semantic-tag-start class-tag))))
-	      (t 1)))
+        (cond (import-tag
+               (insertion-point-after (semantic-tag-end import-tag)))
+              (package-tag
+               (insertion-point-after (semantic-tag-end package-tag))
+               (insert "\n")                ;empty line before new imports
+               (unless (eolp)                ;empty line after new imports
+                 (save-excursion (insert "\n")))
+               (point))
+              (class-tag
+               (let ((comment-token (semantic-documentation-for-tag
+                                     class-tag 'lex)))
+                 (if comment-token
+                     (semantic-lex-token-start comment-token)
+                   (semantic-tag-start class-tag))))
+              (t 1)))
       )))
 
 (defun jdee-import-import (class)
@@ -288,23 +288,23 @@ semantic Java parser and requires JDE 2.1.6-beta24 and above."
   (or (eq major-mode 'jdee-mode)
       (error "Invalid major mode found. Must be 'jdee-mode'."))
   (or (and (local-variable-p 'semantic--parse-table (current-buffer))
-	   (symbol-value 'semantic--parse-table))
+           (symbol-value 'semantic--parse-table))
       (error "Semantic Java parser not found."))
   (and (called-interactively-p 'interactive)
        (consp current-prefix-arg)
        (setq reverse t))
   (let* ((tags  (semantic-fetch-tags))
-	 (depends (semantic-brute-find-tag-by-class 'include tags)))
+         (depends (semantic-brute-find-tag-by-class 'include tags)))
     (if depends
-	(let* ((first-import-tag (car depends))
-	       (last-import-tag  (nth (1- (length depends)) depends))
-	       (start (semantic-tag-start first-import-tag))
-	       (end   (semantic-tag-end   last-import-tag)))
-	  (when (and start end)
-	    (require 'sort)
-	    (let (sort-fold-case)
-	      (sort-lines reverse start end)
-	      (goto-char start)))))))
+        (let* ((first-import-tag (car depends))
+               (last-import-tag  (nth (1- (length depends)) depends))
+               (start (semantic-tag-start first-import-tag))
+               (end   (semantic-tag-end   last-import-tag)))
+          (when (and start end)
+            (require 'sort)
+            (let (sort-fold-case)
+              (sort-lines reverse start end)
+              (goto-char start)))))))
 
 (defun jdee-import-find-and-import (class &optional no-errors no-exclude qualifiedp)
   "*Insert an import statement for a class in the current buffer.
@@ -324,83 +324,83 @@ classpath, except jars implicitly included by the jvm, e.g.,
 rt.jar. The NO-ERRORS is used to avoid showing erros to the user."
   (interactive
    (cl-flet ((vfn
-	      (class)
-	      (let ((existing-import (jdee-import-get-import (third class))))
-		(if (null existing-import)
-		    class
-		  (message "Skipping: already imported %s" existing-import)
-		  'pass))))
+              (class)
+              (let ((existing-import (jdee-import-get-import (third class))))
+                (if (null existing-import)
+                    class
+                  (message "Skipping: already imported %s" existing-import)
+                  'pass))))
      (list (jdee-read-class nil nil nil nil nil #'vfn) nil current-prefix-arg t)))
   (if qualifiedp
       (unless (eq class 'pass)
-	(jdee-parse-class-exists "java.util.List")
-	(jdee-import-insert-import (list class) (not no-exclude)))
+        (jdee-parse-class-exists "java.util.List")
+        (jdee-import-insert-import (list class) (not no-exclude)))
     (let (existing-import)
       (setq existing-import (jdee-import-get-import class))
       (if (not (null existing-import))
-	  (message "Skipping: already imported %s" existing-import)
-	(let ((imports (jdee-import-get-qualified-names class)))
-	  (setq imports (cl-remove-duplicates imports :test 'equal))
-	  (if imports
-	      (jdee-import-insert-import imports (not no-exclude))
-	    (if (not no-errors)
-		(message "Error: could not find %s." class))))))))
+          (message "Skipping: already imported %s" existing-import)
+        (let ((imports (jdee-import-get-qualified-names class)))
+          (setq imports (cl-remove-duplicates imports :test 'equal))
+          (if imports
+              (jdee-import-insert-import imports (not no-exclude))
+            (if (not no-errors)
+                (message "Error: could not find %s." class))))))))
 
 (defun jdee-import-exclude-imports (imports)
   "Remove imports from IMPORTS according to `jdee-import-excluded-classes'."
   (if jdee-import-excluded-classes
       (let (synonym-list ; synonyms to be excluded
-	    remaining-imports)
-	;; Exclude all imports matching an element of jdee-import-excluded-classes
-	;; and collect all synonyms to be excluded.
-	(setq remaining-imports
-	      (mapcar
-	       (lambda (import)
-		 (catch 'found
-		   (dolist (rule jdee-import-excluded-classes)
-		     (when (and
-			    (string-match "[.]" import)
-			    (if (functionp (car rule))
-				(funcall (car rule) import)
-			      (string-match (car rule) import)))
-		       (message "Excluding %s." import)
-		       (when (cdr rule)    ; exclude all classes having same name?
-			 (setq synonym-list
-			       (cons (jdee-parse-get-unqualified-name import) synonym-list)))
-		       (throw 'found nil)))
-		   import))
-	       imports))
-	;; Exclude all synonyms contained in synonym-list.
-	(setq remaining-imports
-	      (mapcar
-	       (lambda (import)
-		 (if import
-		     (catch 'found
-		       (dolist (synonym synonym-list)
-			 (when (string-match (concat (regexp-quote synonym) "$") import)
-			   (message "Excluding synonym %s." import)
-			   (throw 'found nil)))
-		       import)))
-	       remaining-imports))
-	;; Remove all nil inserted instead of excluded classes.
-	(delq nil remaining-imports))
+            remaining-imports)
+        ;; Exclude all imports matching an element of jdee-import-excluded-classes
+        ;; and collect all synonyms to be excluded.
+        (setq remaining-imports
+              (mapcar
+               (lambda (import)
+                 (catch 'found
+                   (dolist (rule jdee-import-excluded-classes)
+                     (when (and
+                            (string-match "[.]" import)
+                            (if (functionp (car rule))
+                                (funcall (car rule) import)
+                              (string-match (car rule) import)))
+                       (message "Excluding %s." import)
+                       (when (cdr rule)    ; exclude all classes having same name?
+                         (setq synonym-list
+                               (cons (jdee-parse-get-unqualified-name import) synonym-list)))
+                       (throw 'found nil)))
+                   import))
+               imports))
+        ;; Exclude all synonyms contained in synonym-list.
+        (setq remaining-imports
+              (mapcar
+               (lambda (import)
+                 (if import
+                     (catch 'found
+                       (dolist (synonym synonym-list)
+                         (when (string-match (concat (regexp-quote synonym) "$") import)
+                           (message "Excluding synonym %s." import)
+                           (throw 'found nil)))
+                       import)))
+               remaining-imports))
+        ;; Remove all nil inserted instead of excluded classes.
+        (delq nil remaining-imports))
     imports))
 
 (defun jdee-import-insert-import (new-imports &optional exclude)
   "Asks user, if necessary, to choose one of NEW-IMPORTS and
 inserts the selected import in the buffer."
   (let* ((existing-imports (jdee-import-get-imports))
-	 (candidate-imports (if exclude
-				(jdee-import-exclude-imports new-imports)
-			      new-imports))
-	 (new-import
-	  (if (> (length candidate-imports) 1)
-	      (jdee-import-choose-import candidate-imports)
-	    (car candidate-imports))))
+         (candidate-imports (if exclude
+                                (jdee-import-exclude-imports new-imports)
+                              new-imports))
+         (new-import
+          (if (> (length candidate-imports) 1)
+              (jdee-import-choose-import candidate-imports)
+            (car candidate-imports))))
     (if new-import
-	(if (jdee-import-already-imports-class new-import existing-imports)
-	    (message "This buffer already imports %s" new-import)
-	  (jdee-import-insert-imports-into-buffer (list new-import))))))
+        (if (jdee-import-already-imports-class new-import existing-imports)
+            (message "This buffer already imports %s" new-import)
+          (jdee-import-insert-imports-into-buffer (list new-import))))))
 
 (defun jdee-import-insert-imports-into-buffer (new-imports &optional exclude)
   "Inserts imports into the correct place in the buffer."
@@ -410,14 +410,14 @@ inserts the selected import in the buffer."
     (if exclude
         (setq new-imports (jdee-import-exclude-imports new-imports)))
     (loop for new-import in new-imports do
-	  (when (> (length new-import) 0) ;; added to avoid insert empty import statements.
-	    (insert (concat "import " new-import ";\n"))
-	    (message "Imported %s" new-import)))
+          (when (> (length new-import) 0) ;; added to avoid insert empty import statements.
+            (insert (concat "import " new-import ";\n"))
+            (message "Imported %s" new-import)))
     (if jdee-import-auto-collapse-imports
-	(let (jdee-import-auto-collapse-imports) ;; setting this to avoid infinite recursion
-	  (jdee-import-collapse-imports)))
+        (let (jdee-import-auto-collapse-imports) ;; setting this to avoid infinite recursion
+          (jdee-import-collapse-imports)))
     (if jdee-import-auto-sort
-	(funcall jdee-import-auto-sort-function))
+        (funcall jdee-import-auto-sort-function))
     (semantic-fetch-tags)
     (semantic-parse-changes)
     ))
@@ -429,15 +429,15 @@ inserts the selected import in the buffer."
    class-name
    existing-imports
    :test (lambda (new existing)
-		   (let ((new-package (jdee-parse-get-package-from-name new))
-			 (new-class (jdee-parse-get-unqualified-name new))
-			 (existing-package (jdee-parse-get-package-from-name existing))
-			 (existing-class (jdee-parse-get-unqualified-name existing)))
-		     (and
-		      (string= new-package existing-package)
-		      (or
-		       (string= new-class existing-class)
-		       (string= existing-class "*")))))))
+                   (let ((new-package (jdee-parse-get-package-from-name new))
+                         (new-class (jdee-parse-get-unqualified-name new))
+                         (existing-package (jdee-parse-get-package-from-name existing))
+                         (existing-class (jdee-parse-get-unqualified-name existing)))
+                     (and
+                      (string= new-package existing-package)
+                      (or
+                       (string= new-class existing-class)
+                       (string= existing-class "*")))))))
 
 (defun jdee-import-strip-existing-imports (new-imports existing-imports)
   "Exclude classes that have already been imported."
@@ -446,7 +446,7 @@ inserts the selected import in the buffer."
    (mapcar
     (lambda (new-import)
       (unless  (jdee-import-already-imports-class new-import existing-imports)
-	new-import))
+        new-import))
     new-imports)))
 
 (defun jdee-import-choose-import (new-imports)
@@ -478,94 +478,94 @@ The current buffer must be in `jdee-mode'."
        (consp current-prefix-arg)
        (setq comment t))
   (let* ((tags    (semantic-fetch-tags))
-	 (imports (semantic-brute-find-tag-by-class 'include tags)))
+         (imports (semantic-brute-find-tag-by-class 'include tags)))
     (if (not imports)
-	(message "No import found")
+        (message "No import found")
       (let* ((packages (semantic-brute-find-tag-by-class 'package tags))
-	     (package-imports
-	      (append
-	       (mapcar
-		(lambda (package)
-		  ;; Return a global import name from PACKAGE tag.
-		  ;; That is add ".*" at end of tag name.
-		  (concat (semantic-tag-name package) ".*"))
-		packages)
-	       (delq nil
-		     (mapcar
-		      (lambda (import)
-			;; Return tag name if IMPORT is global or nil if not.
-			;; IMPORT is global if its name ends with ".*".
-			(let ((name (semantic-tag-name import)))
-			  (and (string-match "[.][*]\\'" name)
-			       name)))
-		      imports))))
-	     (first-import (car imports))
-	     extra-imports
-	     required-imports)
-	(save-excursion
-	  ;; Get the list of extra imports
-	  ;; Going to character zero so the the count-matches method work.
-	  (goto-char 0)
-	  (while imports
-	    (let* ((import (car imports))
-		   (name (semantic-tag-name import))
-		   (classname (jdee-import-get-classname name))
-		   (case-fold-search nil)
-		   (number-of-matches
-		    (count-matches
-		     (concat "\\b" classname "\\b"))))
-	      (if (or
-		   ;; If name is already listed in the set
-		   ;; of required imports...
-		   (member name required-imports)
-		   ;;or the class is not reference in the file
-		   ;;and is not an import of the whole package i.e. .*
-		   (and (< number-of-matches 2)
-			(not (string= classname "*")))
-		   ;; or imports a class in the current package...
-		   (and
-		    ;; make sure name is not a package import, e.g., foo.bar.*
-		    (not (string-match "[.][*]\\'" name))
-		    (member
-		     ;; convert class import to equivalent package import
-		     ;; e.g., foo.barClass to foo.*
-		     (concat
-		      (substring
-		       name
-		       0
-		       (or (string-match "[.][^.]+\\'" name)
-			   (length name)))
-		      ".*")
-		     package-imports)))
-		  ;; add name to the list of extra imports...
-		  (setq extra-imports (cons import extra-imports))
-		;; otherwise add to the list or required  imports
-		(setq required-imports (cons name required-imports))))
-	    (setq imports (cdr imports)))
-	  (if (not extra-imports)
-	      (message "No extra imports found")
-	    (let ((count 0))
-	      ;; Move the point at the beginning of the first import
-	      (goto-char (semantic-tag-start first-import))
-	      ;; Kill or comment out extra imports
-	      (while extra-imports
-		(let* ((extra-import (car extra-imports))
-		       (start (semantic-tag-start extra-import))
-		       (end (semantic-tag-end extra-import)))
-		  (setq count  (1+ count))
-		  (if comment
-		      (comment-region start end)
-		    ;; The following assumes that there is only one import
-		    ;; statement on the same line. Line end comments are deleted
-		    ;; too.
-		    (kill-region start
-				 (progn
-				   (goto-char end)
-				   (forward-line)
-				   (point))))
-		  (setq extra-imports (cdr extra-imports))))
-	      (message "%d extra import%s removed"
-		       count (if (= count 1) "" "s")))))))))
+             (package-imports
+              (append
+               (mapcar
+                (lambda (package)
+                  ;; Return a global import name from PACKAGE tag.
+                  ;; That is add ".*" at end of tag name.
+                  (concat (semantic-tag-name package) ".*"))
+                packages)
+               (delq nil
+                     (mapcar
+                      (lambda (import)
+                        ;; Return tag name if IMPORT is global or nil if not.
+                        ;; IMPORT is global if its name ends with ".*".
+                        (let ((name (semantic-tag-name import)))
+                          (and (string-match "[.][*]\\'" name)
+                               name)))
+                      imports))))
+             (first-import (car imports))
+             extra-imports
+             required-imports)
+        (save-excursion
+          ;; Get the list of extra imports
+          ;; Going to character zero so the the count-matches method work.
+          (goto-char 0)
+          (while imports
+            (let* ((import (car imports))
+                   (name (semantic-tag-name import))
+                   (classname (jdee-import-get-classname name))
+                   (case-fold-search nil)
+                   (number-of-matches
+                    (count-matches
+                     (concat "\\b" classname "\\b"))))
+              (if (or
+                   ;; If name is already listed in the set
+                   ;; of required imports...
+                   (member name required-imports)
+                   ;;or the class is not reference in the file
+                   ;;and is not an import of the whole package i.e. .*
+                   (and (< number-of-matches 2)
+                        (not (string= classname "*")))
+                   ;; or imports a class in the current package...
+                   (and
+                    ;; make sure name is not a package import, e.g., foo.bar.*
+                    (not (string-match "[.][*]\\'" name))
+                    (member
+                     ;; convert class import to equivalent package import
+                     ;; e.g., foo.barClass to foo.*
+                     (concat
+                      (substring
+                       name
+                       0
+                       (or (string-match "[.][^.]+\\'" name)
+                           (length name)))
+                      ".*")
+                     package-imports)))
+                  ;; add name to the list of extra imports...
+                  (setq extra-imports (cons import extra-imports))
+                ;; otherwise add to the list or required  imports
+                (setq required-imports (cons name required-imports))))
+            (setq imports (cdr imports)))
+          (if (not extra-imports)
+              (message "No extra imports found")
+            (let ((count 0))
+              ;; Move the point at the beginning of the first import
+              (goto-char (semantic-tag-start first-import))
+              ;; Kill or comment out extra imports
+              (while extra-imports
+                (let* ((extra-import (car extra-imports))
+                       (start (semantic-tag-start extra-import))
+                       (end (semantic-tag-end extra-import)))
+                  (setq count  (1+ count))
+                  (if comment
+                      (comment-region start end)
+                    ;; The following assumes that there is only one import
+                    ;; statement on the same line. Line end comments are deleted
+                    ;; too.
+                    (kill-region start
+                                 (progn
+                                   (goto-char end)
+                                   (forward-line)
+                                   (point))))
+                  (setq extra-imports (cdr extra-imports))))
+              (message "%d extra import%s removed"
+                       count (if (= count 1) "" "s")))))))))
 
 ;;;;
 ;;;; Helper functions
@@ -587,20 +587,20 @@ A group is found as soon as the import name matches a regexp in
 `jdee-import-group-of-rules'.  The returned group name depends on the
 corresponding group definition in `jdee-import-group-of-rules'."
   (let ((import-name (semantic-tag-name import-tag))
-	(groups      jdee-import-group-of-rules)
-	match rule regexp group)
+        (groups      jdee-import-group-of-rules)
+        match rule regexp group)
     (while (and groups (not match))
       (setq rule    (car groups)
-	    groups  (cdr groups)
-	    regexp  (car rule)
-	    group   (cdr rule)
-	    match   (and (string-match regexp import-name)
-			 (cond ((stringp  group)
-				group)
-			       ((integerp group)
-				(match-string group import-name))
-			       (t
-				regexp)))))
+            groups  (cdr groups)
+            regexp  (car rule)
+            group   (cdr rule)
+            match   (and (string-match regexp import-name)
+                         (cond ((stringp  group)
+                                group)
+                               ((integerp group)
+                                (match-string group import-name))
+                               (t
+                                regexp)))))
     match))
 
 (defun jdee-import-bucketize (imports)
@@ -615,60 +615,60 @@ bucket contains imports that do not belong to any group."
     ;; for imports not in any group.
     (while imports
       (setq import  (car imports)
-	    imports (cdr imports)
-	    group   (funcall (or jdee-import-group-function
-				 #'jdee-import-group-of)
-			     import))
+            imports (cdr imports)
+            group   (funcall (or jdee-import-group-function
+                                 #'jdee-import-group-of)
+                             import))
       (if (not group)
-	  (setq others (cons import others))
-	(setq bin (assoc group bins))
-	(if bin
-	    (setcdr bin (cons import (cdr bin)))
-	  (setq bins (cons (cons group (list import)) bins)))))
+          (setq others (cons import others))
+        (setq bin (assoc group bins))
+        (if bin
+            (setcdr bin (cons import (cdr bin)))
+          (setq bins (cons (cons group (list import)) bins)))))
     ;; If required sort the bins by group name
     ;; Remember that bins are in reverse order at this point.
     (cond ((eq jdee-import-sorted-groups 'asc)
-	   (setq bins (sort bins
-			    (function
-			     (lambda (bin1 bin2)
-			       (string-lessp (car bin2)
-					     (car bin1)))))))
-	  ((eq jdee-import-sorted-groups 'desc)
-	   (setq bins (sort bins
-			    (function
-			     (lambda (bin1 bin2)
-			       (string-lessp (car bin1)
-					     (car bin2)))))))
-	  ((eq jdee-import-sorted-groups 'gor)
-	   (let* ((group-list (mapcar (function
+           (setq bins (sort bins
+                            (function
+                             (lambda (bin1 bin2)
+                               (string-lessp (car bin2)
+                                             (car bin1)))))))
+          ((eq jdee-import-sorted-groups 'desc)
+           (setq bins (sort bins
+                            (function
+                             (lambda (bin1 bin2)
+                               (string-lessp (car bin1)
+                                             (car bin2)))))))
+          ((eq jdee-import-sorted-groups 'gor)
+           (let* ((group-list (mapcar (function
                                    ;; If item does not have a second element,
                                    ;; that means to use the regex itself
-				       (lambda (item) (or (cdr item) (car item))))
-				      jdee-import-group-of-rules)))
-	     (setq bins
-		   (sort bins
-			 (function
-			  (lambda (bin1 bin2)
-			    (let* ((name1 (car bin1))
-				   (name2 (car bin2))
-				   (idx1 (length (member name1 group-list)))
-				   (idx2 (length (member name2 group-list))))
-			      (< idx1 idx2)))))))))
+                                       (lambda (item) (or (cdr item) (car item))))
+                                      jdee-import-group-of-rules)))
+             (setq bins
+                   (sort bins
+                         (function
+                          (lambda (bin1 bin2)
+                            (let* ((name1 (car bin1))
+                                   (name2 (car bin2))
+                                   (idx1 (length (member name1 group-list)))
+                                   (idx2 (length (member name2 group-list))))
+                              (< idx1 idx2)))))))))
     ;; Build the vector of buckets.
     (setq bins (vconcat
-		(delq nil
-		      (nreverse
-		       (cons (cons jdee-import-default-group-name
-				   others)
-			     bins))))
-	  n    (length bins)
-	  i    0)
+                (delq nil
+                      (nreverse
+                       (cons (cons jdee-import-default-group-name
+                                   others)
+                             bins))))
+          n    (length bins)
+          i    0)
     ;; Sort each bucket.
     (while (< i n)
       (setq bin (aref bins i))
       (setcdr bin (if jdee-import-reverse-sort-group
-		      (semantic-sort-tags-by-name-decreasing (cdr bin))
-		    (semantic-sort-tags-by-name-increasing (cdr bin))))
+                      (semantic-sort-tags-by-name-decreasing (cdr bin))
+                    (semantic-sort-tags-by-name-increasing (cdr bin))))
       (setq i (1+ i)))
     bins))
 
@@ -680,7 +680,7 @@ If optional NAME is non-nil add it as comment just before the group."
     (when skip-line
       (newline)
       (if jdee-import-blank-line-between-groups
-	  (newline)))
+          (newline)))
     (when (and jdee-import-insert-group-names name)
       (insert comment-start name)
       (newline))
@@ -722,73 +722,73 @@ version of the JDE with the semantic parser."
        (setq force t))
   (save-excursion
     (let* ((tags  (semantic-fetch-tags))
-	   (imports (semantic-brute-find-tag-by-class 'include tags)))
+           (imports (semantic-brute-find-tag-by-class 'include tags)))
       (if imports
-	  (let* ((bins (jdee-import-bucketize imports))
-		 (n    (length bins))
-		 i l sl changed group bin)
-	    (if force
-		(setq changed t)
-	      ;; Check if imports already ordered
-	      (setq sl (apply #'append (mapcar #'cdr bins))
-		    l  imports)
-	      (while (and (not changed) l)
-		(setq changed (not (string-equal
-				    (semantic-tag-name (car l))
-				    (semantic-tag-name (car sl))))
-		      l  (cdr l)
-		      sl (cdr sl))))
-	    (if (not changed)
-		(message "Import statements already ordered")
-	      ;; Imports need to be reordered.
-	      ;; 1- Get ordered import texts
-	      (setq i 0)
-	      (while (< i n)
-		(setq bin (aref bins i))
-		(setcdr bin (mapcar (function
-				     (lambda (import)
-				       (buffer-substring-no-properties
-					(semantic-tag-start import)
-					(progn
-					  (goto-char (semantic-tag-end import))
-					  (end-of-line)	; keep any line comment
-					  (point)))))
-				    (cdr bin)))
-		(setq i (1+ i)))
-	      ;; 2- Keep the point at the beginning of the first import
-	      (goto-char (semantic-tag-start (car imports)))
-	      ;; 2b- But check if the previous line already contains the
-	      ;; group name for the first group
-	      (when jdee-import-insert-group-names
-		(setq i 0)
-		(while (and (< i n) (not group))
-		  (setq group (aref bins i)
-			i     (1+ i)))
-		(when (car group)
-		  (forward-line -1)
-		  (if (not (string< (concat comment-start (car group))
-				    (thing-at-point 'line)))
-		      (forward-line 1)))
-		(setq group nil))
-	      ;; 3- Kill current imports
-	      (kill-region (point)
-			   (progn
-			     (goto-char (semantic-tag-end
-					 (car (reverse imports))))
-			     (end-of-line)
-			     (point)))
-	      ;; 4- Insert ordered imports
-	      ;; Insert the first group found
-	      (setq i 0)
-	      (while (and (< i n) (not group))
-		(setq group (aref bins i)
-		      i     (1+ i)))
-	      (jdee-import-insert-group (cdr group) nil (car group))
-	      ;; Insert the others with a blank line before each group
-	      (while (< i n)
-		(setq group (aref bins i)
-		      i (1+ i))
-		(jdee-import-insert-group (cdr group) 'skip-line (car group)))))))))
+          (let* ((bins (jdee-import-bucketize imports))
+                 (n    (length bins))
+                 i l sl changed group bin)
+            (if force
+                (setq changed t)
+              ;; Check if imports already ordered
+              (setq sl (apply #'append (mapcar #'cdr bins))
+                    l  imports)
+              (while (and (not changed) l)
+                (setq changed (not (string-equal
+                                    (semantic-tag-name (car l))
+                                    (semantic-tag-name (car sl))))
+                      l  (cdr l)
+                      sl (cdr sl))))
+            (if (not changed)
+                (message "Import statements already ordered")
+              ;; Imports need to be reordered.
+              ;; 1- Get ordered import texts
+              (setq i 0)
+              (while (< i n)
+                (setq bin (aref bins i))
+                (setcdr bin (mapcar (function
+                                     (lambda (import)
+                                       (buffer-substring-no-properties
+                                        (semantic-tag-start import)
+                                        (progn
+                                          (goto-char (semantic-tag-end import))
+                                          (end-of-line)        ; keep any line comment
+                                          (point)))))
+                                    (cdr bin)))
+                (setq i (1+ i)))
+              ;; 2- Keep the point at the beginning of the first import
+              (goto-char (semantic-tag-start (car imports)))
+              ;; 2b- But check if the previous line already contains the
+              ;; group name for the first group
+              (when jdee-import-insert-group-names
+                (setq i 0)
+                (while (and (< i n) (not group))
+                  (setq group (aref bins i)
+                        i     (1+ i)))
+                (when (car group)
+                  (forward-line -1)
+                  (if (not (string< (concat comment-start (car group))
+                                    (thing-at-point 'line)))
+                      (forward-line 1)))
+                (setq group nil))
+              ;; 3- Kill current imports
+              (kill-region (point)
+                           (progn
+                             (goto-char (semantic-tag-end
+                                         (car (reverse imports))))
+                             (end-of-line)
+                             (point)))
+              ;; 4- Insert ordered imports
+              ;; Insert the first group found
+              (setq i 0)
+              (while (and (< i n) (not group))
+                (setq group (aref bins i)
+                      i     (1+ i)))
+              (jdee-import-insert-group (cdr group) nil (car group))
+              ;; Insert the others with a blank line before each group
+              (while (< i n)
+                (setq group (aref bins i)
+                      i (1+ i))
+                (jdee-import-insert-group (cdr group) 'skip-line (car group)))))))))
 
 (defcustom jdee-import-collapse-imports-threshold 2
   "Threshold level used by `jdee-import-collapse-imports' to decide when a
@@ -810,27 +810,27 @@ invoking `jdee-import-kill-extra-imports' to clean up."
   (or (eq major-mode 'jdee-mode)
       (error "Major mode must be 'jdee-mode'"))
   (let* ((tags    (semantic-fetch-tags))
-	 (imports (semantic-brute-find-tag-by-class 'include tags)))
+         (imports (semantic-brute-find-tag-by-class 'include tags)))
     (if (<= jdee-import-collapse-imports-threshold 0)
-	(message "Collapse threshold set to zero. No collapsing will occur.")
+        (message "Collapse threshold set to zero. No collapsing will occur.")
     (if (not imports)
-	(message "No import found")
+        (message "No import found")
       (let* ((package-buckets (jdee-import-collapse-imports-bucketize imports))
-	     (extra-imports   nil)
-	     (required-imports nil)
-	     (new-imports nil))
-	(while package-buckets
-	  (let*
-	      ((bucket (car package-buckets)))
-	    (if (>= (length bucket) jdee-import-collapse-imports-threshold)
-		(progn
-		  (add-to-list 'extra-imports (cdr bucket))
-		  ;; Add the collapsing package statement
-		  (add-to-list 'new-imports (concat (car bucket) ".*")))
-	      (add-to-list 'required-imports (cdr bucket))))
-	  (setq package-buckets (cdr package-buckets)))
-	(jdee-import-insert-imports-into-buffer new-imports)
-	(jdee-import-kill-extra-imports comments))))))
+             (extra-imports   nil)
+             (required-imports nil)
+             (new-imports nil))
+        (while package-buckets
+          (let*
+              ((bucket (car package-buckets)))
+            (if (>= (length bucket) jdee-import-collapse-imports-threshold)
+                (progn
+                  (add-to-list 'extra-imports (cdr bucket))
+                  ;; Add the collapsing package statement
+                  (add-to-list 'new-imports (concat (car bucket) ".*")))
+              (add-to-list 'required-imports (cdr bucket))))
+          (setq package-buckets (cdr package-buckets)))
+        (jdee-import-insert-imports-into-buffer new-imports)
+        (jdee-import-kill-extra-imports comments))))))
 
 
 ;; Contributed by Martin Schwamberger.
@@ -843,32 +843,32 @@ is used by `jdee-import-all'. This function is roughly the opposite of
 `jdee-import-collapse-imports'."
    (interactive "P")
    (let* ((tags  (semantic-fetch-tags))
-	  (imports (semantic-brute-find-tag-by-class 'include tags))
-	  import-all
-	  package-import-start
-	  package-import-end
-	  jdee-import-auto-collapse-imports) ; disable auto collapse
+          (imports (semantic-brute-find-tag-by-class 'include tags))
+          import-all
+          package-import-start
+          package-import-end
+          jdee-import-auto-collapse-imports) ; disable auto collapse
      (dolist (import imports)
        (when package-import-start
-	 ;; kill from start of package-import to beginning of following import
-	 (kill-region package-import-start (semantic-tag-start import))
-	 (setq import-all t)
-	 (setq package-import-start nil))
+         ;; kill from start of package-import to beginning of following import
+         (kill-region package-import-start (semantic-tag-start import))
+         (setq import-all t)
+         (setq package-import-start nil))
        (when (string-match "\\.\\*" (semantic-tag-name import)) ; package-import?
-	 (setq package-import-start (semantic-tag-start import))
-	 (setq package-import-end (semantic-tag-end import))))
+         (setq package-import-start (semantic-tag-start import))
+         (setq package-import-end (semantic-tag-end import))))
      ;; kill last import?
      (when package-import-start
        ;; kill from start of package-import to end of line
        (kill-region package-import-start
-		    (save-excursion
-		      (goto-char package-import-end)
-		      (end-of-line)
-		      (or (eobp) (forward-char))
-		      (point)))
+                    (save-excursion
+                      (goto-char package-import-end)
+                      (end-of-line)
+                      (or (eobp) (forward-char))
+                      (point)))
        (setq import-all t))
      (if import-all
-	 (jdee-import-all no-exclude))))
+         (jdee-import-all no-exclude))))
 
 
 (defun jdee-import-collapse-imports-bucketize (imports)
@@ -876,14 +876,14 @@ is used by `jdee-import-all'. This function is roughly the opposite of
   (let ((package-buckets))
     (while imports
       (let* ((import (car imports))
-	     (name (semantic-tag-name import))
-	     (packagename (jdee-parse-get-package-from-name name))
-	     (packagebin))
-	(setq packagebin (assoc packagename package-buckets))
-	(if packagebin
-	    (setcdr packagebin (cons import (cdr packagebin)))
-	  (setq package-buckets (cons (cons packagename (list import)) package-buckets)))
-	(setq imports (cdr imports))))
+             (name (semantic-tag-name import))
+             (packagename (jdee-parse-get-package-from-name name))
+             (packagebin))
+        (setq packagebin (assoc packagename package-buckets))
+        (if packagebin
+            (setcdr packagebin (cons import (cdr packagebin)))
+          (setq package-buckets (cons (cons packagename (list import)) package-buckets)))
+        (setq imports (cdr imports))))
   package-buckets))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -911,86 +911,86 @@ buffer that start with an uppercase character, have at least one lower
 case character, and that are not included in an import statement and
 are not the names of inner or outer classes declared in this buffer."
   (let (declared-classes
-	imported-classes
-	classes-to-import)
+        imported-classes
+        classes-to-import)
 
     ;; Get the names of classes that are already imported into this buffer.
     (let ((import-tags (semantic-brute-find-tag-by-class 'include (current-buffer))))
       (setq
-	imported-classes
-	(mapcar
-	 (lambda (import-tag)
-	   (jdee-parse-get-unqualified-name (semantic-tag-name import-tag)))
-	 import-tags)))
+        imported-classes
+        (mapcar
+         (lambda (import-tag)
+           (jdee-parse-get-unqualified-name (semantic-tag-name import-tag)))
+         import-tags)))
 
     ;; Get the names of classes declared in this buffer.
     (let ((buffer-class-tags (semantic-brute-find-tag-by-class 'type (current-buffer))))
       (dolist (class-tag buffer-class-tags)
-	(setq declared-classes (append declared-classes  (list (semantic-tag-name class-tag))))
-	(jdee-import-find-declared-classes class-tag declared-classes)))
+        (setq declared-classes (append declared-classes  (list (semantic-tag-name class-tag))))
+        (jdee-import-find-declared-classes class-tag declared-classes)))
 
     ;; Sort through the Java tokens in this buffer, looking
     ;; for identifiers that start with an uppercase character and
     ;; do not appear in an import statement or a toplevel
     ;; class declaration.
     (let ((tokens (semantic-lex-buffer 1000)))
-	     (dolist (token tokens classes-to-import)
+             (dolist (token tokens classes-to-import)
       (let ((type (car token))
-	    (start (cadr token))
-	    (end (cddr token)))
-	(if (eq type 'IDENTIFIER)
-	    (let (case-fold-search
-		  (name (buffer-substring-no-properties start end)))
-	      (unless (or
-		       (string-match "^[a-z]" name)
-		       (not (string-match "[a-z]" name))
-		       (member name declared-classes)
-		       (member name imported-classes))
-		(add-to-list 'classes-to-import  name t)))))))))
+            (start (cadr token))
+            (end (cddr token)))
+        (if (eq type 'IDENTIFIER)
+            (let (case-fold-search
+                  (name (buffer-substring-no-properties start end)))
+              (unless (or
+                       (string-match "^[a-z]" name)
+                       (not (string-match "[a-z]" name))
+                       (member name declared-classes)
+                       (member name imported-classes))
+                (add-to-list 'classes-to-import  name t)))))))))
 
 (defun jdee-import-is-included0 (name import0)
   "check single qualified name against a single qualified class name."
   (and import0
        (let* ((len0 (length import0))
-	      (dotstar (eq t (compare-strings import0 (- len0 2) len0 ".*" nil nil nil)))
-	      (import (if dotstar (substring import0 0 (- len0 2)) import0))
-	      (len (length import)))
-	 (or
-	  (string-equal import name)	; name.equals(import)
-	  (and
-	   (eq t (compare-strings name 0 len import nil nil nil))  ; name.startsWith(import)
-	   (eq t (compare-strings name len (1+ len) "." nil nil )) ; name[len] == "."
-	   ))
-	 )))
+              (dotstar (eq t (compare-strings import0 (- len0 2) len0 ".*" nil nil nil)))
+              (import (if dotstar (substring import0 0 (- len0 2)) import0))
+              (len (length import)))
+         (or
+          (string-equal import name)        ; name.equals(import)
+          (and
+           (eq t (compare-strings name 0 len import nil nil nil))  ; name.startsWith(import)
+           (eq t (compare-strings name len (1+ len) "." nil nil )) ; name[len] == "."
+           ))
+         )))
 
 (defun jdee-import-is-included1 (name classes)
   "check single qualified name against list of qualified classes"
   (and name
        (do* ((imports classes (cdr imports))
-	     (import (car imports) (car imports))
-	     (incl (jdee-import-is-included0 name import) (jdee-import-is-included0 name import)))
-	   ((or (null import) incl) incl)
-	 )))
+             (import (car imports) (car imports))
+             (incl (jdee-import-is-included0 name import) (jdee-import-is-included0 name import)))
+           ((or (null import) incl) incl)
+         )))
 
 (defun jdee-import-is-included (names classes)
   "check single or list of qualified names against qualified classes"
   (if (listp names)
       (do* ((nlist names (cdr nlist))
-	    (name (car nlist) (car nlist))
-	    (incl (jdee-import-is-included1 name classes) (jdee-import-is-included1 name classes))
-	    )
-	  ((or (null name) incl) incl))
+            (name (car nlist) (car nlist))
+            (incl (jdee-import-is-included1 name classes) (jdee-import-is-included1 name classes))
+            )
+          ((or (null name) incl) incl))
     (jdee-import-is-included1 names classes)
     ))
 
 (defun jdee-import-filter-inner-imports (qualified-names)
   "remove names that are imported by outer classes or some.package.*"
   (let* ((import-tags (semantic-brute-find-tag-by-class 'include (current-buffer)))
-	 (imported-classes (mapcar (lambda (import-tag) (semantic-tag-name import-tag)) import-tags))
-	 (imports nil))
+         (imported-classes (mapcar (lambda (import-tag) (semantic-tag-name import-tag)) import-tags))
+         (imports nil))
     (dolist (qnames qualified-names imports)
       (if (not (jdee-import-is-included qnames imported-classes))
-	  (setq imports (cons qnames imports))))
+          (setq imports (cons qnames imports))))
     ))
 
 (defun jdee-import-all-show ()
@@ -999,12 +999,12 @@ buffer that are not declared or explicitly imported into this
 buffer and hence may need to be imported."
   (interactive)
   (let ((candidate-imports
-	 (jdee-import-all-find-classes-to-import)))
+         (jdee-import-all-find-classes-to-import)))
     (with-output-to-temp-buffer "*jde import*"
       (mapcar
        (lambda(match)
-	 (princ match)
-	 (princ "\n"))
+         (princ match)
+         (princ "\n"))
        candidate-imports))))
 
 (defun jdee-import-all-filter (unqualified-imports &optional no-exclude)
@@ -1018,12 +1018,12 @@ any classes that appear to be included by outer-class imports."
    (lambda (unqualified-class)
      (let ((qualified-imports (jdee-import-get-qualified-names unqualified-class)))
        (if no-exclude
-	   qualified-imports
-	 (jdee-import-exclude-imports qualified-imports))))
+           qualified-imports
+         (jdee-import-exclude-imports qualified-imports))))
    unqualified-imports))
-	)
+        )
     (if (or no-exclude (not jdee-import-exclude-inner-imports))
-	imports
+        imports
       (jdee-import-filter-inner-imports imports))))
 
 (defun jdee-import-all-unique ()
@@ -1033,18 +1033,18 @@ which there is only one fully qualified name on the current
 classpath."
   (interactive)
   (let ((list
-	 (jdee-import-all-filter (jdee-import-all-find-classes-to-import)))
-	(retn))
+         (jdee-import-all-filter (jdee-import-all-find-classes-to-import)))
+        (retn))
     (delq nil
-	  ;; take single length sublists, and return item..
-	  (mapcar
-	   (lambda(item)
-	     (if (= 1 (length item))
-		 (add-to-list 'retn
-			      (car item))))
-	   list))
+          ;; take single length sublists, and return item..
+          (mapcar
+           (lambda(item)
+             (if (= 1 (length item))
+                 (add-to-list 'retn
+                              (car item))))
+           list))
     (if (< 0 (length retn))
-	(jdee-import-insert-imports-into-buffer retn))))
+        (jdee-import-insert-imports-into-buffer retn))))
 
 (defclass jdee-import-all-dialog(efc-multi-option-dialog) nil)
 
@@ -1056,15 +1056,15 @@ classpath."
   "Sort the options."
   ;; sort the ones with the most options first...
   (sort list
-	(lambda(a b)
-	  ;; sort lexically
-	  (if (= (length a)
-		 (length b))
-	      (string< (car a)
-		       (car b))
-	    ;; or by length
-	    (> (length a)
-	       (length b))))))
+        (lambda(a b)
+          ;; sort lexically
+          (if (= (length a)
+                 (length b))
+              (string< (car a)
+                       (car b))
+            ;; or by length
+            (> (length a)
+               (length b))))))
 
 (defun jdee-import-all (&optional no-exclude)
   "Imports all classes that need to be imported into the current buffer.
@@ -1074,31 +1074,31 @@ Classes specified by `jdee-import-excluded-classes' will be excluded,
 unless the prefix argument NO-EXCLUDE is non-nil."
   (interactive "P")
   (let* ((imports
-	  (jdee-import-all-filter
-	   (jdee-import-all-find-classes-to-import) no-exclude))
-	 (unique-imports
-	  (delq
-	   nil
-	   (mapcar
-	   (lambda (import) (if (= (length import) 1) (car import)))
-	   imports)))
-	 (ambiguous-imports
-	  (delq
-	   nil
-	   (mapcar
-	   (lambda (import) (if (> (length import) 1) import))
-	   imports)))
-	 (dialog
-	  (if ambiguous-imports
-	      (jdee-import-all-dialog
-	       "Multi Classes Option"
-	       :options ambiguous-imports
-	       :text "Select imports to insert."))))
+          (jdee-import-all-filter
+           (jdee-import-all-find-classes-to-import) no-exclude))
+         (unique-imports
+          (delq
+           nil
+           (mapcar
+           (lambda (import) (if (= (length import) 1) (car import)))
+           imports)))
+         (ambiguous-imports
+          (delq
+           nil
+           (mapcar
+           (lambda (import) (if (> (length import) 1) import))
+           imports)))
+         (dialog
+          (if ambiguous-imports
+              (jdee-import-all-dialog
+               "Multi Classes Option"
+               :options ambiguous-imports
+               :text "Select imports to insert."))))
     (if dialog
-	(progn
-	  (efc-dialog-show dialog)
-	  (setq unique-imports
-		(append unique-imports (oref dialog selection)))))
+        (progn
+          (efc-dialog-show dialog)
+          (setq unique-imports
+                (append unique-imports (oref dialog selection)))))
     (jdee-import-insert-imports-into-buffer unique-imports)))
 
 ;;;###autoload

--- a/jdee-java-grammar.el
+++ b/jdee-java-grammar.el
@@ -42,27 +42,27 @@ Should be run when Semantic is ready to parse, that is, via
      ;; Since Semantic 2.0beta2
      ((boundp 'global-semantic-idle-scheduler-mode)
       (or global-semantic-idle-scheduler-mode
-	  (semantic-idle-scheduler-mode 1)))
+          (semantic-idle-scheduler-mode 1)))
      (t
       ;; Default to JDEE's auto-parse
       (add-hook 'semantic-change-hooks
-		'jdee-parse-buffer-changed-hook t t))))
+                'jdee-parse-buffer-changed-hook t t))))
 
   ;; Track full reparses
   (add-hook 'semantic-after-toplevel-cache-change-hook
-	    'jdee-parse-update-after-parse nil t)
+            'jdee-parse-update-after-parse nil t)
 
   ;; Track partial reparses
   (add-hook 'semantic-after-partial-cache-change-hook
-	    'jdee-parse-update-after-partial-parse nil t)
+            'jdee-parse-update-after-partial-parse nil t)
 
   ;; imenu & speedbar setup
   (jdee-imenu-setup)
 
   (if (and jdee-which-method-mode
-	   (not jdee-which-method-idle-timer))
+           (not jdee-which-method-idle-timer))
       (setq jdee-which-method-idle-timer
-	    (run-with-idle-timer .25 t 'jdee-which-method-update)))
+            (run-with-idle-timer .25 t 'jdee-which-method-update)))
 
   ;; initial parsing of the current buffer
   (semantic-fetch-tags))

--- a/jdee-java-properties.el
+++ b/jdee-java-properties.el
@@ -163,13 +163,13 @@ BUFFER is the buffer to get the properties and defaults the current buffer."
     (save-excursion
       (if buffer (set-buffer buffer))
       (save-match-data
-	(goto-char (point-min))
-	(while (re-search-forward "^\\(.*?\\)=\\(.*\\)$" nil t)
-	  (let ((key (match-string 1))
-		(val (match-string 2)))
-	    (set-text-properties 0 (length key) nil key)
-	    (set-text-properties 0 (length val) nil val)
-	    (setq prop-alist (append prop-alist (list (cons key val))))))))
+        (goto-char (point-min))
+        (while (re-search-forward "^\\(.*?\\)=\\(.*\\)$" nil t)
+          (let ((key (match-string 1))
+                (val (match-string 2)))
+            (set-text-properties 0 (length key) nil key)
+            (set-text-properties 0 (length val) nil val)
+            (setq prop-alist (append prop-alist (list (cons key val))))))))
     prop-alist))
 
 ;;;###autoload

--- a/jdee-javadoc-gen.el
+++ b/jdee-javadoc-gen.el
@@ -57,13 +57,13 @@
   -private will show all classes and members"
   :group 'jdee-javadoc
   :type '(list
-	  (radio-button-choice
-	   :format "%t \n%v"
-	   :tag "Select the detail level switch you want:"
-	   (const "-public")
-	   (const "-protected")
-	   (const "-package")
-	   (const "-private"))))
+          (radio-button-choice
+           :format "%t \n%v"
+           :tag "Select the detail level switch you want:"
+           (const "-public")
+           (const "-protected")
+           (const "-package")
+           (const "-private"))))
 
 (defcustom jdee-javadoc-gen-packages nil
   "Specifies which packages or files javadoc should be run on.
@@ -99,9 +99,9 @@ into the javadoc command line."
    from which javadoc is run."
   :group 'jdee-javadoc
   :type '(repeat
-	  (cons :tag "Remote URL and directory holding package-list for that URL"
-		(string :tag "URL")
-		(string :tag "Path"))))
+          (cons :tag "Remote URL and directory holding package-list for that URL"
+                (string :tag "URL")
+                (string :tag "Path"))))
 
 (defcustom jdee-javadoc-gen-group nil
   "Specifies groups of packages with a group heading and package pattern.
@@ -110,9 +110,9 @@ into the javadoc command line."
    packages by separating the package names by a semicolon."
   :group 'jdee-javadoc
   :type '(repeat
-	  (cons :tag "Package group name and contents"
-		(string :tag "Heading")
-		(string :tag "Package Pattern"))))
+          (cons :tag "Package group name and contents"
+                (string :tag "Heading")
+                (string :tag "Package Pattern"))))
 
 (defcustom jdee-javadoc-gen-doc-title ""
   "Specifies the title to be placed near the top of the overview summary file."
@@ -238,9 +238,9 @@ into the javadoc command line."
 
 (defclass jdee-javadoc-maker (efc-compiler)
   ((make-packages-p  :initarg :make-packages-p
-		     :type boolean
-		     :initform t
-		     :documentation "Nonnil generates doc for packages."))
+                     :type boolean
+                     :initform t
+                     :documentation "Nonnil generates doc for packages."))
   "Class of Javadoc generators.")
 
 (defmethod initialize-instance ((this jdee-javadoc-maker) &rest fields)
@@ -254,14 +254,14 @@ into the javadoc command line."
    (lambda (buf msg)
      (message msg)
      (if (and
-	  jdee-javadoc-display-doc
-	  (string-match "finished" msg))
-	 (browse-url-of-file
-	  (expand-file-name
-	   "index.html"
-	   (jdee-normalize-path
-	    jdee-javadoc-gen-destination-directory
-	    'jdee-javadoc-gen-destination-directory))))))
+          jdee-javadoc-display-doc
+          (string-match "finished" msg))
+         (browse-url-of-file
+          (expand-file-name
+           "index.html"
+           (jdee-normalize-path
+            jdee-javadoc-gen-destination-directory
+            'jdee-javadoc-gen-destination-directory))))))
 
   (oset
    this
@@ -272,283 +272,283 @@ into the javadoc command line."
   "Get the arguments to pass to the javadoc process as specified
 by the jdee-javadoc-gen variables."
   (let* ((destination-directory
-	  (jdee-normalize-path
-	   jdee-javadoc-gen-destination-directory
-	   'jdee-javadoc-gen-destination-directory))
-	 (args
-	  (list
-	   "-d" destination-directory
-	   (car jdee-javadoc-gen-detail-switch))))
+          (jdee-normalize-path
+           jdee-javadoc-gen-destination-directory
+           'jdee-javadoc-gen-destination-directory))
+         (args
+          (list
+           "-d" destination-directory
+           (car jdee-javadoc-gen-detail-switch))))
 
     (if (not (file-exists-p destination-directory))
-	(make-directory destination-directory))
+        (make-directory destination-directory))
 
     ;;Insert online links
     (if jdee-javadoc-gen-link-online
-	(setq args
-	      (append
-	       args
-	       (cl-mapcan
-		(lambda (link)  (list "-link" link))
-		jdee-javadoc-gen-link-URL))))
+        (setq args
+              (append
+               args
+               (cl-mapcan
+                (lambda (link)  (list "-link" link))
+                jdee-javadoc-gen-link-URL))))
 
     ;;Insert offline links
     (if jdee-javadoc-gen-link-offline
-	(setq args
-	      (append
-	       args
-	       (cl-mapcan
-		(lambda (link)
-		  (list "-linkoffline" (car  link) (cdr link)))
-		jdee-javadoc-gen-link-offline))))
+        (setq args
+              (append
+               args
+               (cl-mapcan
+                (lambda (link)
+                  (list "-linkoffline" (car  link) (cdr link)))
+                jdee-javadoc-gen-link-offline))))
 
     ;;Insert -group
     (if jdee-javadoc-gen-group
-	(setq args
-	      (append
-	       args
-	       (cl-mapcan
-		(lambda (group)
-		  (list "-group" (car group) (cdr group)))
-		jdee-javadoc-gen-group))))
+        (setq args
+              (append
+               args
+               (cl-mapcan
+                (lambda (group)
+                  (list "-group" (car group) (cdr group)))
+                jdee-javadoc-gen-group))))
 
 
      ;; Insert classpath
     (if jdee-global-classpath
-	(setq args
-	      (append
-	       args
-	       (list
-		"-classpath"
-		(jdee-build-classpath
-		 (jdee-get-global-classpath)
-		 'jdee-global-classpath)))))
+        (setq args
+              (append
+               args
+               (list
+                "-classpath"
+                (jdee-build-classpath
+                 (jdee-get-global-classpath)
+                 'jdee-global-classpath)))))
 
 
     ;; Insert sourcepath
     (if jdee-sourcepath
-	(setq args
-	      (append
-	       args
-	       (list
-		"-sourcepath"
-		(jdee-build-classpath
-		 (jdee-expand-wildcards-and-normalize jdee-sourcepath 'jdee-sourcepath))))))
+        (setq args
+              (append
+               args
+               (list
+                "-sourcepath"
+                (jdee-build-classpath
+                 (jdee-expand-wildcards-and-normalize jdee-sourcepath 'jdee-sourcepath))))))
 
 
     ;; Insert bootclasspath
     (if jdee-compile-option-bootclasspath
-	(setq args
-	      (append
-	       args
-	       (list
-		"-bootclasspath"
-	       (jdee-build-classpath
-		jdee-compile-option-bootclasspath
-		'jdee-compile-option-bootclasspath)))))
+        (setq args
+              (append
+               args
+               (list
+                "-bootclasspath"
+               (jdee-build-classpath
+                jdee-compile-option-bootclasspath
+                'jdee-compile-option-bootclasspath)))))
 
     ;; Insert extdirs
     (if jdee-compile-option-extdirs
-	(setq args
-	      (append
-	       args
-	       (list
-		"-extdirs"
-	       (jdee-build-classpath
-		jdee-compile-option-extdirs
-		'jdee-compile-option-extdirs)))))
+        (setq args
+              (append
+               args
+               (list
+                "-extdirs"
+               (jdee-build-classpath
+                jdee-compile-option-extdirs
+                'jdee-compile-option-extdirs)))))
 
     ;; Insert windowtitle
     (if (not (equal "" jdee-javadoc-gen-window-title))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-windowtitle"
-		jdee-javadoc-gen-window-title))))
+        (setq args
+              (append
+               args
+               (list
+                "-windowtitle"
+                jdee-javadoc-gen-window-title))))
 
     ;; Insert doctitle
     (if (not (equal "" jdee-javadoc-gen-doc-title))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-doctitle"
-		jdee-javadoc-gen-doc-title))))
+        (setq args
+              (append
+               args
+               (list
+                "-doctitle"
+                jdee-javadoc-gen-doc-title))))
 
     ;; Insert header
     (if (not (equal "" jdee-javadoc-gen-header))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-header"
-		jdee-javadoc-gen-header))))
+        (setq args
+              (append
+               args
+               (list
+                "-header"
+                jdee-javadoc-gen-header))))
 
     ;; Insert footer
     (if (not (equal "" jdee-javadoc-gen-footer))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-footer"
-		jdee-javadoc-gen-footer))))
+        (setq args
+              (append
+               args
+               (list
+                "-footer"
+                jdee-javadoc-gen-footer))))
 
     ;; Insert bottom
     (if (not (equal "" jdee-javadoc-gen-bottom))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-bottom"
-		jdee-javadoc-gen-bottom))))
+        (setq args
+              (append
+               args
+               (list
+                "-bottom"
+                jdee-javadoc-gen-bottom))))
 
     ;; Insert helpfile
     (if (not (equal "" jdee-javadoc-gen-helpfile))
-	(setq args
-	      (append
-	       args
-	       (list
-	       "-helpfile"
-	       (jdee-normalize-path 'jdee-javadoc-gen-helpfile)))))
+        (setq args
+              (append
+               args
+               (list
+               "-helpfile"
+               (jdee-normalize-path 'jdee-javadoc-gen-helpfile)))))
 
     ;; Insert stylesheet
     (if (not (equal "" jdee-javadoc-gen-stylesheetfile))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-stylesheetfile"
-		(jdee-normalize-path 'jdee-javadoc-gen-stylesheetfile)))))
+        (setq args
+              (append
+               args
+               (list
+                "-stylesheetfile"
+                (jdee-normalize-path 'jdee-javadoc-gen-stylesheetfile)))))
 
     ;; Insert -overview
     (if (not (equal "" jdee-javadoc-gen-overview))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-overview"
-		jdee-javadoc-gen-overview))))
+        (setq args
+              (append
+               args
+               (list
+                "-overview"
+                jdee-javadoc-gen-overview))))
 
     ;; Insert -doclet
     (if (not (equal "" jdee-javadoc-gen-doclet))
-	(setq args
-	      (append
-	       args
-	       (list
-		"-doclet"
-		jdee-javadoc-gen-doclet))))
+        (setq args
+              (append
+               args
+               (list
+                "-doclet"
+                jdee-javadoc-gen-doclet))))
 
     ;; Insert -docletpath
     (if jdee-javadoc-gen-docletpath
-	(setq args
-	      (append
-	       args
-	       (list
-		"-docletpath"
-	       (jdee-build-classpath
-		jdee-javadoc-gen-docletpath
-		'jdee-javadoc-gen-docletpath)))))
+        (setq args
+              (append
+               args
+               (list
+                "-docletpath"
+               (jdee-build-classpath
+                jdee-javadoc-gen-docletpath
+                'jdee-javadoc-gen-docletpath)))))
 
     ;; Inser -use
     (if jdee-javadoc-gen-use
-	(setq args
-	      (append
-	       args
-	       (list "-use"))))
+        (setq args
+              (append
+               args
+               (list "-use"))))
 
     ;;Insert -author
     (if jdee-javadoc-gen-author
-	(setq args
-	      (append
-	       args
-	       (list "-author"))))
+        (setq args
+              (append
+               args
+               (list "-author"))))
 
     ;;Insert -version
     (if jdee-javadoc-gen-version
-	(setq args
-	      (append
-	       args
-	       (list "-version"))))
+        (setq args
+              (append
+               args
+               (list "-version"))))
 
     ;;Insert -splitindex
     (if jdee-javadoc-gen-split-index
-	(setq args
-	      (append
-	       args
-	       (list "-splitindex"))))
+        (setq args
+              (append
+               args
+               (list "-splitindex"))))
 
     ;;Insert -nodeprecated
     (if jdee-javadoc-gen-nodeprecated
-	(setq args
-	      (append
-	       args
-	       (list "-nodeprecated"))))
+        (setq args
+              (append
+               args
+               (list "-nodeprecated"))))
 
     ;;Insert -nodeprecatedlist
     (if jdee-javadoc-gen-nodeprecatedlist
-	(setq args
-	      (append
-	       args
-	       (list "-nodeprecatedlist"))))
+        (setq args
+              (append
+               args
+               (list "-nodeprecatedlist"))))
 
     ;;Insert -notree
     (if jdee-javadoc-gen-notree
-	(setq args
-	      (append
-	       args
-	       (list "-notree"))))
+        (setq args
+              (append
+               args
+               (list "-notree"))))
 
     ;;Insert -noindex
     (if jdee-javadoc-gen-noindex
-	(setq args
-	      (append
-	       args
-	       (list "-noindex"))))
+        (setq args
+              (append
+               args
+               (list "-noindex"))))
 
     ;;Insert -nohelp
     (if jdee-javadoc-gen-nohelp
-	(setq args
-	      (append
-	       args
-	       (list "-nohelp"))))
+        (setq args
+              (append
+               args
+               (list "-nohelp"))))
 
     ;;Insert -nonavbar
     (if jdee-javadoc-gen-nonavbar
-	(setq args
-	      (append
-	       args
-	       (list "-nonavbar"))))
+        (setq args
+              (append
+               args
+               (list "-nonavbar"))))
 
     ;;Insert -serialwarn
     (if jdee-javadoc-gen-serialwarn
-	(setq args
-	      (append
-	       args
-	       (list  "-serialwarn"))))
+        (setq args
+              (append
+               args
+               (list  "-serialwarn"))))
 
     ;;Insert -verbose
     (if jdee-javadoc-gen-verbose
-	(setq args
-	      (append
-	       args
-	       (list  "-verbose"))))
+        (setq args
+              (append
+               args
+               (list  "-verbose"))))
 
     ;;Insert other tags
     (if jdee-javadoc-gen-args
-	(setq args
-	      (append
-	       args
-	       jdee-javadoc-gen-args)))
+        (setq args
+              (append
+               args
+               jdee-javadoc-gen-args)))
 
     ;;Insert packages/files
     (if (and (oref this make-packages-p) jdee-javadoc-gen-packages)
-	(setq args
-	      (append
-	       args
-	       (mapcar
-		(lambda (packagename) packagename)
-		jdee-javadoc-gen-packages)))
+        (setq args
+              (append
+               args
+               (mapcar
+                (lambda (packagename) packagename)
+                jdee-javadoc-gen-packages)))
       (setq
        args
        (append args (list (buffer-file-name)))))))
@@ -573,9 +573,9 @@ buffer. If `jdee-javadoc-display-doc' is nonnil, this command displays
 the generated documentation in a browser."
   (save-some-buffers)
   (let ((generator
-	 (jdee-javadoc-maker
-	  "javadoc generator"
-	  :make-packages-p make-packages-p)))
+         (jdee-javadoc-maker
+          "javadoc generator"
+          :make-packages-p make-packages-p)))
     (exec generator)))
 
 
@@ -619,11 +619,11 @@ browser."
   "Displays the documentation for the javadoc tool in a browser."
   (interactive)
   (let* ((jdk-url (jdee-jdhelper-jdk-url jdee-jdhelper-singleton))
-	 (javadoc-url
-	  (concat
-	   (substring jdk-url 0 (string-match "index" jdk-url))
-	   (if (eq system-type 'windows-nt) "tooldocs/windows/" "tooldocs/solaris/")
-	   "javadoc.html")))
+         (javadoc-url
+          (concat
+           (substring jdk-url 0 (string-match "index" jdk-url))
+           (if (eq system-type 'windows-nt) "tooldocs/windows/" "tooldocs/solaris/")
+           "javadoc.html")))
     (browse-url javadoc-url)))
 
 

--- a/jdee-javadoc.el
+++ b/jdee-javadoc.el
@@ -47,30 +47,30 @@
 (eval-and-compile
   (or (require 'working nil t)
       (progn
-	(defvar working-message nil
-	  "Message stored when in a status loop.")
-	(defmacro working-status-forms (message donestr &rest forms)
-	  "Contain a block of code during which a working status is shown."
-	  (list 'let (list (list 'msg message) (list 'dstr donestr)
-			   '(ref1 0))
-		(cons 'progn forms)))
+        (defvar working-message nil
+          "Message stored when in a status loop.")
+        (defmacro working-status-forms (message donestr &rest forms)
+          "Contain a block of code during which a working status is shown."
+          (list 'let (list (list 'msg message) (list 'dstr donestr)
+                           '(ref1 0))
+                (cons 'progn forms)))
 
-	(defun working-status (&optional percent &rest args)
-	  "Called within the macro `working-status-forms', show the status."
-	  (message "%s%s" (apply 'format msg args)
-		   (if (eq percent t) (concat "... " dstr)
-		     (format "... %3d%%"
-			     (or percent
-				 (floor (* 100.0 (/ (float (point))
-						    (point-max)))))))))
+        (defun working-status (&optional percent &rest args)
+          "Called within the macro `working-status-forms', show the status."
+          (message "%s%s" (apply 'format msg args)
+                   (if (eq percent t) (concat "... " dstr)
+                     (format "... %3d%%"
+                             (or percent
+                                 (floor (* 100.0 (/ (float (point))
+                                                    (point-max)))))))))
 
-	(defun working-dynamic-status (&optional number &rest args)
-	  "Called within the macro `working-status-forms', show the status."
-	  (message "%s%s" (apply 'format msg args)
-		   (format "... %c" (aref [ ?- ?/ ?| ?\\ ] (% ref1 4))))
-	  (setq ref1 (1+ ref1)))
+        (defun working-dynamic-status (&optional number &rest args)
+          "Called within the macro `working-status-forms', show the status."
+          (message "%s%s" (apply 'format msg args)
+                   (format "... %c" (aref [ ?- ?/ ?| ?\\ ] (% ref1 4))))
+          (setq ref1 (1+ ref1)))
 
-	(put 'working-status-forms 'lisp-indent-function 2))))
+        (put 'working-status-forms 'lisp-indent-function 2))))
 
 ;;;; Customization
 ;;;; -------------
@@ -89,14 +89,14 @@ The template name is the `symbol-name' of SYM from which the
 VAL is the template value.  If VAL is a string it is converted to a
 list of template elements."
   (let* ((name (symbol-name sym))
-	 (template-name
-	  (if (string-match "\\(.*\\)-template$" name)
-	      (match-string 1 name)
-	    (error "Invalid template variable name: %S" name)))
-	 (template-val
-	  (if (stringp val)
-	      (car (read-from-string (format "(%s)" val)))
-	    val)))
+         (template-name
+          (if (string-match "\\(.*\\)-template$" name)
+              (match-string 1 name)
+            (error "Invalid template variable name: %S" name)))
+         (template-val
+          (if (stringp val)
+              (car (read-from-string (format "(%s)" val)))
+            val)))
     (tempo-define-template template-name template-val nil name)
     (set-default sym val)))
 
@@ -109,8 +109,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-describe-class'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-describe-interface-template
@@ -122,8 +122,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-describe-interface'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-describe-constructor-template
@@ -135,8 +135,8 @@ name).  See `jdee-javadoc-autodoc-at-line' for usage.  Define the
 template variable `tempo-template-jdee-javadoc-describe-constructor'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-describe-method-template
@@ -148,8 +148,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-describe-method'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-describe-field-template
@@ -164,8 +164,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-describe-field'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-param-tag-template
@@ -180,8 +180,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-param-tag'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-return-tag-template
@@ -194,8 +194,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-return-tag'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-exception-tag-template
@@ -208,8 +208,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-exception-tag'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-author-tag-template
@@ -221,8 +221,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-author-tag'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 (defcustom jdee-javadoc-version-tag-template
@@ -233,8 +233,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-version-tag'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 ;; (defcustom jdee-javadoc-see-tag-template
@@ -271,8 +271,8 @@ See `jdee-javadoc-autodoc-at-line' for usage.  Define the template
 variable `tempo-template-jdee-javadoc-end-block'."
   :group 'jdee-javadoc
   :type '(choice :tag "Template form"
-		 (text :format "%t\n%v" :tag "String")
-		 (repeat :tag "Lisp Expressions" (sexp :tag "")))
+                 (text :format "%t\n%v" :tag "String")
+                 (repeat :tag "Lisp Expressions" (sexp :tag "")))
   :set 'jdee-javadoc-define-template)
 
 ;;;; Utilities
@@ -306,7 +306,7 @@ See `working-dynamic-status' for meaning of ARGS."
     (while (< (point) end)
       (jdee-javadoc-dynamic-status)
       (or (and (bolp) (eolp))
-	  (jdee-javadoc-indent-line))
+          (jdee-javadoc-indent-line))
       (forward-line 1))
     (move-marker end nil)))
 
@@ -322,25 +322,25 @@ F receives optional ARGS after the current element of L."
 This number may be greater than the number of actual lines in the
 buffer if any wrap on the display due to their length."
   (let ((start (point-min))
-	(end   (point-max)))
+        (end   (point-max)))
     (if (= start end)
-	0
+        0
       (save-excursion
-	(save-restriction
-	  (widen)
-	  (narrow-to-region start end)
-	  (goto-char start)
-	  (vertical-motion (buffer-size)))))))
+        (save-restriction
+          (widen)
+          (narrow-to-region start end)
+          (goto-char start)
+          (vertical-motion (buffer-size)))))))
 
 (defun jdee-javadoc-adjust-window (window)
   "Adjust WINDOW height to fit its buffer contents."
   (save-selected-window
     (select-window window)
     (let ((height (window-height))
-	  (lines  (+ 3 (jdee-javadoc-window-lines))))
+          (lines  (+ 3 (jdee-javadoc-window-lines))))
       ;; ensure window will not be deleted if too small
       (if (< lines window-min-height)
-	  (setq lines window-min-height))
+          (setq lines window-min-height))
       (enlarge-window (- lines height)))))
 
 (defsubst jdee-javadoc-variable-name (name)
@@ -409,7 +409,7 @@ Useful to generate HTML code style."
 
 (defconst jdee-javadoc-end-tag-regexp
   (concat "\\(" jdee-javadoc-start-tag-regexp
-	  "\\|[ \n\r\t]*\\*/\\)")
+          "\\|[ \n\r\t]*\\*/\\)")
   "Regexp matching the end of a tag or description.")
 
 ;; Core comment parser
@@ -418,21 +418,21 @@ Useful to generate HTML code style."
   "Ensure DESC text begins with '\\n* ' and ends with '\\n*\\n'."
   (let ((i (string-match "[^ *\n\r\t]" desc)))
     (if i
-	(setq desc (concat "\n* " (substring desc i))))
+        (setq desc (concat "\n* " (substring desc i))))
     ;; TODO: ensure empty line at end
     desc))
 
 (defun jdee-javadoc-normalize-ref (val)
   "Strip any [* \\n\\r\\t] from VAL."
   (let* ((keep "[^* \n\r\t]+")
-	 (ref  "")
-	 (i    (string-match keep val))
-	 j)
+         (ref  "")
+         (i    (string-match keep val))
+         j)
     (while i
       (jdee-javadoc-dynamic-status)
       (setq j   (match-end 0)
-	    ref (concat ref (substring val i j))
-	    i   (string-match keep val j)))
+            ref (concat ref (substring val i j))
+            i   (string-match keep val j)))
     ref))
 
 (defun jdee-javadoc-parse-description (docstring)
@@ -440,19 +440,19 @@ Useful to generate HTML code style."
 The returned value has the form ((DESC)).  See also
 `jdee-javadoc-parse-tag-values'."
   (let ((matcher "/\\*\\*")
-	(i 0)
-	j tag-val)
+        (i 0)
+        j tag-val)
     (when (string-match matcher docstring)
       (jdee-javadoc-dynamic-status)
       (setq j (match-end 0))
       (setq i (string-match jdee-javadoc-end-tag-regexp docstring j))
       (setq tag-val (if i
-			(substring docstring j i)
-		      (substring docstring j)))
+                        (substring docstring j i)
+                      (substring docstring j)))
       ;; Ensure that a valid description exists
       (if (not (string-equal ""
-			     (jdee-javadoc-normalize-ref tag-val)))
-	  (list (list tag-val))))))
+                             (jdee-javadoc-normalize-ref tag-val)))
+          (list (list tag-val))))))
 
 (defun jdee-javadoc-parse-tag-values (docstring tag &optional with-key)
   "Return from DOCSTRING the list of TAG values or nil if not found.
@@ -461,22 +461,22 @@ is 'name VALUE-KEY is the first word of VALUE-STRING.  If optional
 WITH-KEY is 'ref VALUE-KEY is a normalized VALUE-STRING reference (see
 `jdee-javadoc-normalize-ref').  Otherwise VALUE-KEY is nil."
   (let ((matcher (concat jdee-javadoc-start-tag-regexp tag))
-	(i 0)
-	j tag-val key tag-list)
+        (i 0)
+        j tag-val key tag-list)
     (while (string-match matcher docstring i)
       (jdee-javadoc-dynamic-status)
       (setq j (match-end 0))
       (setq i (or (string-match
-		   jdee-javadoc-end-tag-regexp docstring j)
-		  (length docstring)))
+                   jdee-javadoc-end-tag-regexp docstring j)
+                  (length docstring)))
       (setq tag-val (substring docstring j i))
       (cond ((eq with-key 'name)
-	     (setq key (and (string-match
-			     "[* \n\r\t]*\\([^ \n\r\t]+\\)" tag-val)
-			    (jdee-javadoc-variable-name
-			     (match-string 1 tag-val)))))
-	    ((eq with-key 'ref)
-	     (setq key (jdee-javadoc-normalize-ref tag-val))))
+             (setq key (and (string-match
+                             "[* \n\r\t]*\\([^ \n\r\t]+\\)" tag-val)
+                            (jdee-javadoc-variable-name
+                             (match-string 1 tag-val)))))
+            ((eq with-key 'ref)
+             (setq key (jdee-javadoc-normalize-ref tag-val))))
       (setq tag-list (cons (cons tag-val key) tag-list)))
     (nreverse tag-list)))
 
@@ -485,22 +485,22 @@ WITH-KEY is 'ref VALUE-KEY is a normalized VALUE-STRING reference (see
 Documentation has the form (TAG VALUE-LIST).  See also
 `jdee-javadoc-parse-tag-values'."
   (cond ((string-equal tag jdee-javadoc-desc-tag)
-	 (jdee-javadoc-parse-description docstring))
-	((member tag semantic-java-doc-with-name-tags)
-	 (jdee-javadoc-parse-tag-values docstring tag 'name))
-	((member tag semantic-java-doc-with-ref-tags)
-	 (jdee-javadoc-parse-tag-values docstring tag 'ref))
-	(t
-	 (jdee-javadoc-parse-tag-values docstring tag))
-	))
+         (jdee-javadoc-parse-description docstring))
+        ((member tag semantic-java-doc-with-name-tags)
+         (jdee-javadoc-parse-tag-values docstring tag 'name))
+        ((member tag semantic-java-doc-with-ref-tags)
+         (jdee-javadoc-parse-tag-values docstring tag 'ref))
+        (t
+         (jdee-javadoc-parse-tag-values docstring tag))
+        ))
 
 (defun jdee-javadoc-parse-tag-list (docstring)
   "Return the list of tag found in DOCSTRING."
   (let* ((matcher (concat jdee-javadoc-start-tag-regexp
-			  "\\([^ \n\r\t]+\\)"))
-	 (depth (regexp-opt-depth matcher))
-	 (i (string-match matcher docstring))
-	 j tag-list)
+                          "\\([^ \n\r\t]+\\)"))
+         (depth (regexp-opt-depth matcher))
+         (i (string-match matcher docstring))
+         j tag-list)
     (while i
       (jdee-javadoc-dynamic-status)
       (setq tag-list (cons (match-string depth docstring) tag-list))
@@ -512,45 +512,45 @@ Documentation has the form (TAG VALUE-LIST).  See also
 Result has the following form: (DOCSTRING TAG-LIST TAG-VALUE-ALIST)."
   (if docstring
       (let (tag-list
-	    tag-alist l tag
-	    throws-assoc except-assoc merged-values)
-	(jdee-javadoc-status-forms "Parsing" "done"
-	  (jdee-javadoc-dynamic-status)
-	  (setq tag-list (jdee-javadoc-parse-tag-list docstring))
-	  (setq l (cons jdee-javadoc-desc-tag tag-list))
-	  (while l
-	    (jdee-javadoc-dynamic-status)
-	    (setq tag (car l))
-	    (if (assoc tag tag-alist)
-		nil                     ; tag already processed
-	      (setq tag-alist
-		    (cons (cons tag
-				(jdee-javadoc-parse-tag tag docstring))
-			  tag-alist)))
-	    (setq l (cdr l)))
-	  ;; The 'throws' and 'exception' tags are equivalent, so
-	  ;; their values are merged to allow access to 'exception'
-	  ;; tag using 'throws' and vice versa.
-	  (jdee-javadoc-dynamic-status)
-	  (setq throws-assoc (assoc "throws"    tag-alist))
-	  (jdee-javadoc-dynamic-status)
-	  (setq except-assoc (assoc "exception" tag-alist))
-	  (when (or throws-assoc except-assoc)
-	    (jdee-javadoc-dynamic-status)
-	    (setq merged-values (append (cdr throws-assoc)
-					(cdr except-assoc)))
-	    (jdee-javadoc-dynamic-status)
-	    (if throws-assoc
-		(setcdr throws-assoc merged-values)
-	      (setq tag-alist (cons (cons "throws"    merged-values)
-				    tag-alist)))
-	    (jdee-javadoc-dynamic-status)
-	    (if except-assoc
-		(setcdr except-assoc merged-values)
-	      (setq tag-alist (cons (cons "exception" merged-values)
-				    tag-alist))))
-	  (jdee-javadoc-dynamic-status t))
-	(list docstring tag-list tag-alist))))
+            tag-alist l tag
+            throws-assoc except-assoc merged-values)
+        (jdee-javadoc-status-forms "Parsing" "done"
+          (jdee-javadoc-dynamic-status)
+          (setq tag-list (jdee-javadoc-parse-tag-list docstring))
+          (setq l (cons jdee-javadoc-desc-tag tag-list))
+          (while l
+            (jdee-javadoc-dynamic-status)
+            (setq tag (car l))
+            (if (assoc tag tag-alist)
+                nil                     ; tag already processed
+              (setq tag-alist
+                    (cons (cons tag
+                                (jdee-javadoc-parse-tag tag docstring))
+                          tag-alist)))
+            (setq l (cdr l)))
+          ;; The 'throws' and 'exception' tags are equivalent, so
+          ;; their values are merged to allow access to 'exception'
+          ;; tag using 'throws' and vice versa.
+          (jdee-javadoc-dynamic-status)
+          (setq throws-assoc (assoc "throws"    tag-alist))
+          (jdee-javadoc-dynamic-status)
+          (setq except-assoc (assoc "exception" tag-alist))
+          (when (or throws-assoc except-assoc)
+            (jdee-javadoc-dynamic-status)
+            (setq merged-values (append (cdr throws-assoc)
+                                        (cdr except-assoc)))
+            (jdee-javadoc-dynamic-status)
+            (if throws-assoc
+                (setcdr throws-assoc merged-values)
+              (setq tag-alist (cons (cons "throws"    merged-values)
+                                    tag-alist)))
+            (jdee-javadoc-dynamic-status)
+            (if except-assoc
+                (setcdr except-assoc merged-values)
+              (setq tag-alist (cons (cons "exception" merged-values)
+                                    tag-alist))))
+          (jdee-javadoc-dynamic-status t))
+        (list docstring tag-list tag-alist))))
 
 ;; Handling of javadoc comment parsed tree
 ;;
@@ -570,34 +570,34 @@ Result has the following form: (DOCSTRING TAG-LIST TAG-VALUE-ALIST)."
   "Return from DOCTREE the list of TAG values.
 If optional NAME is non-nil return its specific value."
   (let ((doc (cdr
-	      (assoc
-	       tag
-	       (jdee-javadoc-doctree-tag-value-alist doctree)))))
+              (assoc
+               tag
+               (jdee-javadoc-doctree-tag-value-alist doctree)))))
     (and doc
-	 name
-	 (setq doc (rassoc name doc))
-	 (setq doc (list doc)))
+         name
+         (setq doc (rassoc name doc))
+         (setq doc (list doc)))
     doc))
 
 (defun jdee-javadoc-doctree-known-tag-list (doctree)
   "Return the list of known tags in DOCTREE .
 That is tags in `semantic-java-doc-line-tags'."
   (delq nil
-	(mapcar (function
-		 (lambda (tag)
-		   (and (member tag semantic-java-doc-line-tags)
-			tag)))
-		(jdee-javadoc-doctree-tag-list doctree))))
+        (mapcar (function
+                 (lambda (tag)
+                   (and (member tag semantic-java-doc-line-tags)
+                        tag)))
+                (jdee-javadoc-doctree-tag-list doctree))))
 
 (defun jdee-javadoc-doctree-unknown-tag-list (doctree)
   "Return the list of unknown tags in DOCTREE .
 That is tags not in `semantic-java-doc-line-tags'."
   (delq nil
-	(mapcar (function
-		 (lambda (tag)
-		   (and (not (member tag semantic-java-doc-line-tags))
-			tag)))
-		(jdee-javadoc-doctree-tag-list doctree))))
+        (mapcar (function
+                 (lambda (tag)
+                   (and (not (member tag semantic-java-doc-line-tags))
+                        tag)))
+                (jdee-javadoc-doctree-tag-list doctree))))
 
 ;;;; semantic tags stuff
 ;;;; ---------------------
@@ -611,38 +611,38 @@ That is tags not in `semantic-java-doc-line-tags'."
   "Replace TAG documentation with DOCSTRING.
 If DOCSTRING is nil just delete the existing documentation."
   (let* ((comment (semantic-documentation-for-tag tag 'flex))
-	 start end)
+         start end)
     (when comment
       (set-buffer (semantic-tag-buffer tag))
       (setq start (semantic-lex-token-start comment))
       (setq end   (semantic-lex-token-end   comment))
       (goto-char start)
       (save-excursion
-	(goto-char end)
-	(jdee-javadoc-skip-spaces-forward)
-	(delete-region start (point))
-	(when docstring
-	  (insert docstring)
-	  (jdee-javadoc-indent-documentation tag))))))
+        (goto-char end)
+        (jdee-javadoc-skip-spaces-forward)
+        (delete-region start (point))
+        (when docstring
+          (insert docstring)
+          (jdee-javadoc-indent-documentation tag))))))
 
 (defun jdee-javadoc-delete-documentation (tag &optional noconfirm)
   "Delete TAG documentation.
 Require confirmation if optional NOCONFIRM is non-nil.  Return non-nil
 if done."
   (if (or noconfirm
-	  (y-or-n-p (format "Delete '%s' previous documentation? "
-			    (semantic-tag-name tag))))
+          (y-or-n-p (format "Delete '%s' previous documentation? "
+                            (semantic-tag-name tag))))
       (progn
-	(jdee-javadoc-replace-documentation tag)
-	t)))
+        (jdee-javadoc-replace-documentation tag)
+        t)))
 
 (defun jdee-javadoc-recenter-documentation (tag &optional arg)
   "Center TAG documentation in window and redisplay frame.
 With ARG, put point on line ARG.  See also `recenter'."
   (let ((comment (semantic-documentation-for-tag tag 'flex))
-	start)
+        start)
     (if (not comment)
-	(setq start (semantic-tag-start tag))
+        (setq start (semantic-tag-start tag))
       (set-buffer (semantic-tag-buffer tag))
       (setq start (semantic-lex-token-start comment)))
     (goto-char start)
@@ -652,14 +652,14 @@ With ARG, put point on line ARG.  See also `recenter'."
   "Indent TAG documentation."
   (save-excursion
     (let ((comment (semantic-documentation-for-tag tag 'flex))
-	  start end)
+          start end)
       (when comment
-	(set-buffer (semantic-tag-buffer tag))
-	(setq start (semantic-lex-token-start comment))
-	(setq end   (semantic-lex-token-end   comment))
-	(goto-char end)
-	(jdee-javadoc-skip-spaces-forward)
-	(jdee-javadoc-indent-region start (point))))))
+        (set-buffer (semantic-tag-buffer tag))
+        (setq start (semantic-lex-token-start comment))
+        (setq end   (semantic-lex-token-end   comment))
+        (goto-char end)
+        (jdee-javadoc-skip-spaces-forward)
+        (jdee-javadoc-indent-region start (point))))))
 
 ;;;; Doc checker
 ;;;; -----------
@@ -683,16 +683,16 @@ Local to checker report buffer.")
   (list
    ;; References
    (list "`\\(.*\\)'"
-	 1 'font-lock-warning-face)
+         1 'font-lock-warning-face)
    ;; Javadoc tags
    (list "\\(@[^ \n\r\t]+\\)"
-	 1 (cond ((boundp 'jdee-font-lock-doc-tag-face)
-		  'jdee-font-lock-doc-tag-face)
-		 (t
-		  'font-lock-constant-face)))
+         1 (cond ((boundp 'jdee-font-lock-doc-tag-face)
+                  'jdee-font-lock-doc-tag-face)
+                 (t
+                  'font-lock-constant-face)))
    ;; Misc.
    (list "\\[\\([fnpq]\\)\\]"
-	 1 'font-lock-keyword-face)
+         1 'font-lock-keyword-face)
    )
   "Keywords used to highlight the checker report buffer.")
 
@@ -719,7 +719,7 @@ Local to checker report buffer.")
        paragraph-start)
   (set (make-local-variable 'font-lock-defaults)
        '((jdee-javadoc-checker-report-font-lock-keywords)
-	 t t ((?_ . "w"))))
+         t t ((?_ . "w"))))
   (use-local-map jdee-javadoc-checker-report-mode-map)
   (turn-on-font-lock))
 
@@ -727,7 +727,7 @@ Local to checker report buffer.")
   "Show the `jdee-javadoc-checker' REPORT for TAG."
   (let ((buffer (semantic-tag-buffer tag)))
     (with-current-buffer
-	(get-buffer-create jdee-javadoc-checker-report-buffer)
+        (get-buffer-create jdee-javadoc-checker-report-buffer)
       (setq buffer-read-only nil)
       (erase-buffer)
       (jdee-javadoc-checker-report-mode)
@@ -735,32 +735,32 @@ Local to checker report buffer.")
       (set (make-local-variable 'jdee-javadoc-checker-tag)  tag)
       (cond
        (report
-	(define-key (current-local-map) "f" 'jdee-javadoc-checker-fix)
-	(insert (car report))
-	(newline 2)
-	(mapc   (function
-		 (lambda (line)
-		   (let* ((from (point))
-			  (to (progn
-				(fill-region
-				 (point)
-				 (progn
-				   (insert "  " line)
-				   (newline)
-				   (point)))
-				(point))))
-		     (goto-char from)
-		     (delete-char 1)
-		     (insert-char ?\* 1)
-		     (goto-char to))))
-		(cdr report))
-	(newline)
-	(insert "[f]-try to fix  ")
-	)
+        (define-key (current-local-map) "f" 'jdee-javadoc-checker-fix)
+        (insert (car report))
+        (newline 2)
+        (mapc   (function
+                 (lambda (line)
+                   (let* ((from (point))
+                          (to (progn
+                                (fill-region
+                                 (point)
+                                 (progn
+                                   (insert "  " line)
+                                   (newline)
+                                   (point)))
+                                (point))))
+                     (goto-char from)
+                     (delete-char 1)
+                     (insert-char ?\* 1)
+                     (goto-char to))))
+                (cdr report))
+        (newline)
+        (insert "[f]-try to fix  ")
+        )
        (t
-	(define-key (current-local-map) "f" nil)
-	(insert "Documentation is up-to-date")
-	(newline 2)))
+        (define-key (current-local-map) "f" nil)
+        (insert "Documentation is up-to-date")
+        (newline 2)))
       (insert "[p]-check previous  [n]-check next  [q]-quit")
       (goto-char (point-min))
       (setq buffer-read-only t)
@@ -769,26 +769,26 @@ Local to checker report buffer.")
        (get-buffer-window (current-buffer)))
       (sit-for 0)
       (save-selected-window
-	(let ((window (get-buffer-window buffer)))
-	  (if (not window)
-	      nil
-	    (select-window window)
-	    (goto-char (semantic-tag-start tag))
-	    (jdee-javadoc-skip-spaces-forward)
-	    (when (looking-at "/\\*\\*")
-	      (forward-comment 1)
-	      (jdee-javadoc-skip-spaces-forward))
-	    (recenter -4))))
+        (let ((window (get-buffer-window buffer)))
+          (if (not window)
+              nil
+            (select-window window)
+            (goto-char (semantic-tag-start tag))
+            (jdee-javadoc-skip-spaces-forward)
+            (when (looking-at "/\\*\\*")
+              (forward-comment 1)
+              (jdee-javadoc-skip-spaces-forward))
+            (recenter -4))))
       (semantic-momentary-highlight-tag tag))))
 
 (defun jdee-javadoc-check-add-summary (report type name)
   "Add a summary to REPORT error list, using tag TYPE and NAME."
   (and (setq report (delq nil report))  ;; Clear empty entries
        (let* ((count (length report))
-	      (eword (if (= count 1) "error" "errors")))
-	 (cons (format "%s `%s' has %d documentation %s:"
-		       type name count eword)
-	       (nreverse report)))))
+              (eword (if (= count 1) "error" "errors")))
+         (cons (format "%s `%s' has %d documentation %s:"
+                       type name count eword)
+               (nreverse report)))))
 
 ;; Basic doc checkers
 ;;
@@ -799,7 +799,7 @@ Local to checker report buffer.")
     "Missing description"))
 
 (defun jdee-javadoc-check-required-tags (doctree allowed extra
-						&rest nocheck)
+                                                &rest nocheck)
   "Return a message if DOCTREE is missing a required tag.
 ALLOWED and EXTRA are respectively the listes of allowed tags and
 optional ones.  Optional arguments NOCHECK can be a listes of tags
@@ -807,21 +807,21 @@ that are not checked."
   (let (tag missing)
     (while allowed
       (setq tag     (car allowed)
-	    allowed (cdr allowed))
+            allowed (cdr allowed))
       (or (member tag extra)
-	  (member tag nocheck)
-	  (let ((ignored nocheck) ignore)
-	    (while (and (not ignore) ignored)
-	      (setq ignore  (member tag (car ignored))
-		    ignored (cdr ignored)))
-	    ignore)
+          (member tag nocheck)
+          (let ((ignored nocheck) ignore)
+            (while (and (not ignore) ignored)
+              (setq ignore  (member tag (car ignored))
+                    ignored (cdr ignored)))
+            ignore)
 ;;          (member tag semantic-java-doc-with-name-tags)
-	  (jdee-javadoc-doctree-tag doctree tag)
-	  (setq missing (cons tag missing))))
+          (jdee-javadoc-doctree-tag doctree tag)
+          (setq missing (cons tag missing))))
     (if missing
-	(concat "Missing tag"
-		(if (> (length missing) 1) "s @" " @")
-		(mapconcat 'identity missing ", @")))))
+        (concat "Missing tag"
+                (if (> (length missing) 1) "s @" " @")
+                (mapconcat 'identity missing ", @")))))
 
 (defun jdee-javadoc-check-suggest-tag-order (tag-list reference)
   "Return a list of tags in suggested order from TAG-LIST.
@@ -829,53 +829,53 @@ REFERENCE is the list of tags allowed."
   (let (otl utl)
     (while tag-list
       (if (member (car tag-list) semantic-java-doc-line-tags)
-	  (and (member (car tag-list) reference)
-	       (add-to-list 'otl (car tag-list)))
-	(add-to-list 'utl (car tag-list)))
+          (and (member (car tag-list) reference)
+               (add-to-list 'otl (car tag-list)))
+        (add-to-list 'utl (car tag-list)))
       (setq tag-list (cdr tag-list)))
     (append (sort otl #'semantic-java-doc-keyword-before-p)
-	    (nreverse utl))))
+            (nreverse utl))))
 
 (defun jdee-javadoc-check-tag-ordered (doctree reference)
   "Return a message if tags in DOCTREE are not correctly ordered.
 REFERENCE is the list of allowed tags in correct order.  See variable
 `semantic-java-doc-line-tags'."
   (let* ((tag-list (jdee-javadoc-doctree-tag-list doctree))
-	 (tag      (car tag-list))
-	 (l        (cdr tag-list))
-	 (ok       t))
+         (tag      (car tag-list))
+         (l        (cdr tag-list))
+         (ok       t))
     (while (and l ok)
       (jdee-javadoc-dynamic-status)
       (setq ok  (semantic-java-doc-keyword-before-p tag (car l))
-	    tag (car l)
-	    l   (cdr l)))
+            tag (car l)
+            l   (cdr l)))
     (if ok
-	nil
+        nil
       (concat "Recommended tag order is @"
-	      (mapconcat 'identity
-			 (jdee-javadoc-check-suggest-tag-order
-			  tag-list reference)
-			 ", @")))))
+              (mapconcat 'identity
+                         (jdee-javadoc-check-suggest-tag-order
+                          tag-list reference)
+                         ", @")))))
 
 (defun jdee-javadoc-check-tag-allowed (doctree allowed)
   "Return a message if some tags in DOCTREE are not in ALLOWED.
 Third party tags (not in `semantic-java-doc-line-tags') are allways
 allowed."
   (let ((invalids
-	 (delq nil
-	       (mapcar
-		(function
-		 (lambda (tag)
-		   (jdee-javadoc-dynamic-status)
-		   (and (member tag semantic-java-doc-line-tags)
-			(not (member tag allowed))
-			tag)))
-		(jdee-javadoc-doctree-tag-list doctree)))))
+         (delq nil
+               (mapcar
+                (function
+                 (lambda (tag)
+                   (jdee-javadoc-dynamic-status)
+                   (and (member tag semantic-java-doc-line-tags)
+                        (not (member tag allowed))
+                        tag)))
+                (jdee-javadoc-doctree-tag-list doctree)))))
     (if (not invalids)
-	nil
+        nil
       (concat "Invalid tag"
-	      (if (> (length invalids) 1) "s @" " @")
-	      (mapconcat 'identity invalids ", @")))))
+              (if (> (length invalids) 1) "s @" " @")
+              (mapconcat 'identity invalids ", @")))))
 
 ;; Tag based doc checkers
 ;;
@@ -884,41 +884,41 @@ allowed."
 DOCTREE is the current doctree of TAG.  Return a non-nil report if
 errors were found."
   (let ((name (semantic-tag-name tag))
-	(type (semantic-tag-type tag))
-	(main (jdee-javadoc-checker-main-type-p tag))
-	report)
+        (type (semantic-tag-type tag))
+        (main (jdee-javadoc-checker-main-type-p tag))
+        report)
     ;; Check for missing description
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-description doctree)
-	   report))
+          (cons
+           (jdee-javadoc-check-description doctree)
+           report))
     ;; Check for missing tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-required-tags
-	    doctree semantic-java-doc-type-tags
-	    semantic-java-doc-extra-type-tags
-	    (if main
-		nil
-	      ;; Don't check these tags if internal type.
-	      '("author" "version" "since")))
-	   report))
+          (cons
+           (jdee-javadoc-check-required-tags
+            doctree semantic-java-doc-type-tags
+            semantic-java-doc-extra-type-tags
+            (if main
+                nil
+              ;; Don't check these tags if internal type.
+              '("author" "version" "since")))
+           report))
     ;; Check for incorrect tag order
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-ordered
-	    doctree semantic-java-doc-type-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-ordered
+            doctree semantic-java-doc-type-tags)
+           report))
     ;; Check for invalid tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-allowed
-	    doctree semantic-java-doc-type-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-allowed
+            doctree semantic-java-doc-type-tags)
+           report))
     ;; Setup the error summary
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-check-add-summary report type name)))
@@ -928,35 +928,35 @@ errors were found."
 DOCTREE is the current doctree of TAG.  Return a non-nil report if
 errors were found."
   (let ((name (semantic-tag-name tag))
-	report)
+        report)
     ;; Check for missing description
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-description doctree)
-	   report))
+          (cons
+           (jdee-javadoc-check-description doctree)
+           report))
     ;; Check for missing tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-required-tags
-	    doctree semantic-java-doc-variable-tags
-	    semantic-java-doc-extra-variable-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-required-tags
+            doctree semantic-java-doc-variable-tags
+            semantic-java-doc-extra-variable-tags)
+           report))
     ;; Check for incorrect tag order
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-ordered
-	    doctree semantic-java-doc-variable-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-ordered
+            doctree semantic-java-doc-variable-tags)
+           report))
     ;; Check for invalid tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-allowed
-	    doctree semantic-java-doc-variable-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-allowed
+            doctree semantic-java-doc-variable-tags)
+           report))
     ;; Setup the error summary
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-check-add-summary report "variable" name)))
@@ -966,40 +966,40 @@ errors were found."
 DOCTREE is the current doctree of TAG.  Return a non-nil report if
 errors were found."
   (let ((name   (semantic-tag-name               tag))
-	(type   (semantic-tag-type               tag))
-	(args   (semantic-tag-function-arguments      tag))
-	(throws (semantic-tag-function-throws    tag))
-	report items item)
+        (type   (semantic-tag-type               tag))
+        (args   (semantic-tag-function-arguments      tag))
+        (throws (semantic-tag-function-throws    tag))
+        report items item)
     ;; Check for missing description
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-description doctree)
-	   report))
+          (cons
+           (jdee-javadoc-check-description doctree)
+           report))
     ;; Check for missing tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-required-tags
-	    doctree semantic-java-doc-function-tags
-	    semantic-java-doc-extra-function-tags
-	    ;; Don't check return, param and exception/throws tags.
-	    '("return") semantic-java-doc-with-name-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-required-tags
+            doctree semantic-java-doc-function-tags
+            semantic-java-doc-extra-function-tags
+            ;; Don't check return, param and exception/throws tags.
+            '("return") semantic-java-doc-with-name-tags)
+           report))
     ;; Check for missing @param tags
     (setq items nil)
     (while args
       (jdee-javadoc-dynamic-status)
       (if (semantic-tag-p (car args))
-	  (progn
-	    (setq item (jdee-javadoc-variable-name
-			(semantic-tag-name (car args))))
-	    (setq items (cons item items))
-	    (or (jdee-javadoc-doctree-tag doctree "param" item)
-		(setq report
-		      (cons
-		       (format "Missing @param tag for `%s'" item)
-		       report)))))
+          (progn
+            (setq item (jdee-javadoc-variable-name
+                        (semantic-tag-name (car args))))
+            (setq items (cons item items))
+            (or (jdee-javadoc-doctree-tag doctree "param" item)
+                (setq report
+                      (cons
+                       (format "Missing @param tag for `%s'" item)
+                       report)))))
       (setq args (cdr args)))
     ;; Check for extra @param tags
     (setq args (jdee-javadoc-doctree-tag doctree "param"))
@@ -1007,8 +1007,8 @@ errors were found."
       (jdee-javadoc-dynamic-status)
       (setq item (jdee-javadoc-variable-name (cdr (car args))))
       (or (member item items)
-	  (setq report (cons (format "Invalid @param tag `%s'" item)
-			     report)))
+          (setq report (cons (format "Invalid @param tag `%s'" item)
+                             report)))
       (setq args (cdr args)))
     ;; Check for missing @exception tags
     (setq items nil)
@@ -1018,75 +1018,75 @@ errors were found."
       (setq items (cons item items))
       (setq throws (cdr throws))
       (or (jdee-javadoc-doctree-tag doctree "exception" item)
-	  (setq report
-		(cons
-		 (format "Missing @exception tag for `%s'" item)
-		 report))))
+          (setq report
+                (cons
+                 (format "Missing @exception tag for `%s'" item)
+                 report))))
     ;; Check for extra @exception tags
     (setq args (jdee-javadoc-doctree-tag doctree "exception"))
     (while args
       (jdee-javadoc-dynamic-status)
       (setq item (cdr (car args)))
       (or (member item items)
-	  (and jdee-javadoc-check-undeclared-exception-flag
-	       (jdee-javadoc-implicit-exception-p item))
-	  (setq report
-		(cons
-		 (format
-		  "Extra @exception tag `%s' (maybe not an error)"
-		  item)
-		 report)))
+          (and jdee-javadoc-check-undeclared-exception-flag
+               (jdee-javadoc-implicit-exception-p item))
+          (setq report
+                (cons
+                 (format
+                  "Extra @exception tag `%s' (maybe not an error)"
+                  item)
+                 report)))
       (setq args (cdr args)))
     ;; Check for missing or extra @return tag
     (setq item (jdee-javadoc-doctree-tag doctree "return"))
     (jdee-javadoc-dynamic-status)
     (cond ((and (not type) item)
-	   (setq report (cons "Invalid @return tag for constructor"
-			      report)))
-	  ((and type (string-equal type "void") item)
-	   (setq report (cons "Invalid @return tag for void method"
-			      report)))
-	  ((and type (not (string-equal type "void")) (not item))
-	   (setq report (cons "Missing @return tag"
-			      report))))
+           (setq report (cons "Invalid @return tag for constructor"
+                              report)))
+          ((and type (string-equal type "void") item)
+           (setq report (cons "Invalid @return tag for void method"
+                              report)))
+          ((and type (not (string-equal type "void")) (not item))
+           (setq report (cons "Missing @return tag"
+                              report))))
     ;; Check for incorrect tag order
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-ordered
-	    doctree semantic-java-doc-function-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-ordered
+            doctree semantic-java-doc-function-tags)
+           report))
     ;; Check for invalid tags
     (jdee-javadoc-dynamic-status)
     (setq report
-	  (cons
-	   (jdee-javadoc-check-tag-allowed
-	    doctree semantic-java-doc-function-tags)
-	   report))
+          (cons
+           (jdee-javadoc-check-tag-allowed
+            doctree semantic-java-doc-function-tags)
+           report))
     ;; Setup the error summary
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-check-add-summary report
-				   (if type "method" "constructor")
-				   name)))
+                                   (if type "method" "constructor")
+                                   name)))
 
 (defun jdee-javadoc-checker (tag &optional noreport)
   "Call the javadoc checker associated to TAG.
 If optional NOREPORT is non-nil does not show error report.  Return a
 non-nil report if errors were found."
   (let* ((type    (semantic-tag-class tag))
-	 (checker (intern (format "jdee-javadoc-check-%s" type))))
+         (checker (intern (format "jdee-javadoc-check-%s" type))))
     (or (fboundp checker)
-	(error "No checker found to process '%S' tag" type))
+        (error "No checker found to process '%S' tag" type))
     (goto-char (semantic-tag-start tag))
     (recenter 1)
     (let (doctree report)
       (jdee-javadoc-status-forms "Checking" "done"
-	(jdee-javadoc-dynamic-status)
-	(setq doctree (jdee-javadoc-tag-doctree tag))
-	(setq report  (funcall checker tag doctree))
-	(or noreport
-	    (jdee-javadoc-checker-show-report report tag))
-	(jdee-javadoc-dynamic-status t))
+        (jdee-javadoc-dynamic-status)
+        (setq doctree (jdee-javadoc-tag-doctree tag))
+        (setq report  (funcall checker tag doctree))
+        (or noreport
+            (jdee-javadoc-checker-show-report report tag))
+        (jdee-javadoc-dynamic-status t))
       report)))
 
 (defcustom jdee-javadoc-checker-level 'protected
@@ -1097,16 +1097,16 @@ options.  That is:
 
 - - public    - check only public classes and members.
 - - protected - check only protected and public classes and
-		members.  This is the default.
+                members.  This is the default.
 - - package   - check only package, protected, and public classes
-		and members.
+                and members.
 - - private   - check all classes and members."
   :group 'jdee-javadoc
   :type  '(choice :tag "level"
-		  (const :tag "public"    public)
-		  (const :tag "protected" protected)
-		  (const :tag "package"   package)
-		  (const :tag "private"   private)))
+                  (const :tag "public"    public)
+                  (const :tag "protected" protected)
+                  (const :tag "package"   package)
+                  (const :tag "private"   private)))
 
 (defconst jdee-javadoc-access-level-weights
   '((public    . 8)
@@ -1126,38 +1126,38 @@ That is 'public 'package 'protected or 'private.  If TAG is included
 in other ones its access level is the lowest one found in the
 hierarchy."
   (let ((deps (semantic-find-tag-by-overlay
-	       (semantic-tag-start tag)
-	       (semantic-tag-buffer tag)))
-	last-type tag categ modifiers levels)
+               (semantic-tag-start tag)
+               (semantic-tag-buffer tag)))
+        last-type tag categ modifiers levels)
     (while deps
       (setq tag (car deps))
       (setq deps  (cdr deps))
       (setq categ (semantic-tag-class tag))
       (setq modifiers
-	    (cond
-	     ((eq categ 'type)
-	      (setq last-type (semantic-tag-type tag))
-	      (semantic-tag-modifiers tag))
-	     ((eq categ 'function)
-	      (if (string-equal last-type "interface")
-		  (list "public") ;; interface members are always public
-		(semantic-tag-modifiers tag)))
-	     ((eq categ 'variable)
-	      (if (string-equal last-type "interface")
-		  (list "public") ;; interface members are always public
-		(semantic-tag-modifiers tag)))
-	     (t ;; must never occurs
-	      (error "Invalid %s tag" categ))))
+            (cond
+             ((eq categ 'type)
+              (setq last-type (semantic-tag-type tag))
+              (semantic-tag-modifiers tag))
+             ((eq categ 'function)
+              (if (string-equal last-type "interface")
+                  (list "public") ;; interface members are always public
+                (semantic-tag-modifiers tag)))
+             ((eq categ 'variable)
+              (if (string-equal last-type "interface")
+                  (list "public") ;; interface members are always public
+                (semantic-tag-modifiers tag)))
+             (t ;; must never occurs
+              (error "Invalid %s tag" categ))))
       (setq levels
-	    (cons (cond ((member "public" modifiers)
-			 'public)
-			((member "protected" modifiers)
-			 'protected)
-			((member "private" modifiers)
-			 'private)
-			(t
-			 'package))
-		  levels)))
+            (cons (cond ((member "public" modifiers)
+                         'public)
+                        ((member "protected" modifiers)
+                         'protected)
+                        ((member "private" modifiers)
+                         'private)
+                        (t
+                         'package))
+                  levels)))
     (car (sort levels 'jdee-javadoc-access-level-lower-p))))
 
 (defun jdee-javadoc-checker-at-level-p (tag)
@@ -1168,10 +1168,10 @@ specified by `jdee-javadoc-checker-level'.  TAG category must be
   (let ((level (or jdee-javadoc-checker-level 'protected)))
     ;; if level is 'private check all
     (or (eq level 'private)
-	;; else check if tag access level >= checker level
-	(not (jdee-javadoc-access-level-lower-p
-	      (jdee-javadoc-tag-access-level tag)
-	      level)))))
+        ;; else check if tag access level >= checker level
+        (not (jdee-javadoc-access-level-lower-p
+              (jdee-javadoc-tag-access-level tag)
+              level)))))
 
 (defun jdee-javadoc-checker-main-type-p (&optional tag)
   "Return non-nil if TAG is a main type one.
@@ -1179,10 +1179,10 @@ That is not an internal class or interface."
   (setq tag (or tag (semantic-current-tag)))
   (and (eq (semantic-tag-class tag) 'type)
        (memq tag (semantic-brute-find-tag-by-class
-		    'type (current-buffer)))))
+                    'type (current-buffer)))))
 
 (defun jdee-javadoc-checker-do-find-previous-tag (tags &optional
-							  tag prev)
+                                                          tag prev)
   "Visit TAGS and return the tag before TAG.
 PREV is the last tag visited or nil at start.  If TAG is nil
 return the last tag found.  Return only a 'type 'function or
@@ -1193,25 +1193,25 @@ return the last tag found.  Return only a 'type 'function or
       (setq tags  (cdr tags))
       (setq categ   (semantic-tag-class current))
       (if (memq categ '(type function variable))
-	  (cond
-	   ((null tag)
-	    (if (null tags)
-		(throw 'found prev)))
-	   ((>= (semantic-tag-start current)
-		(semantic-tag-start tag))
-	    (throw 'found prev))
-	   (t
-	    (setq prev
-		  (if (eq categ 'type)
-		      (jdee-javadoc-checker-do-find-previous-tag
-		       (semantic-tag-type-members current)
-		       tag current)
-		    current))))
-	))
+          (cond
+           ((null tag)
+            (if (null tags)
+                (throw 'found prev)))
+           ((>= (semantic-tag-start current)
+                (semantic-tag-start tag))
+            (throw 'found prev))
+           (t
+            (setq prev
+                  (if (eq categ 'type)
+                      (jdee-javadoc-checker-do-find-previous-tag
+                       (semantic-tag-type-members current)
+                       tag current)
+                    current))))
+        ))
     prev))
 
 (defun jdee-javadoc-checker-find-previous-tag (tags
-						&optional tag)
+                                                &optional tag)
   "Visit TAGS and return the tag before TAG.
 If TAG is nil return the last tag found.  Return only a 'type
 'function or 'variable tag."
@@ -1227,14 +1227,14 @@ If TAG is nil return the first tag found.  Return only a 'type
       (setq current (car tags))
       (setq categ   (semantic-tag-class current))
       (if (memq categ '(type function variable))
-	  (if (or (null tag)
-		  (> (semantic-tag-start current)
-		     (semantic-tag-start tag)))
-	      (setq next current)
-	    (if (eq categ 'type)
-		(setq next (jdee-javadoc-checker-find-next-tag
-			    (semantic-tag-type-members current)
-			    tag)))))
+          (if (or (null tag)
+                  (> (semantic-tag-start current)
+                     (semantic-tag-start tag)))
+              (setq next current)
+            (if (eq categ 'type)
+                (setq next (jdee-javadoc-checker-find-next-tag
+                            (semantic-tag-type-members current)
+                            tag)))))
       (setq tags (cdr tags)))
     next))
 
@@ -1243,48 +1243,48 @@ If TAG is nil return the first tag found.  Return only a 'type
 Start checking before TAG if non-nil or at the last tag found."
   (pop-to-buffer buffer)
   (let* ((tags (semantic-fetch-tags))
-	 (prev   (jdee-javadoc-checker-find-previous-tag
-		  tags tag))
-	 (report (and prev
-		      (jdee-javadoc-checker-at-level-p prev)
-		      (jdee-javadoc-checker prev t))))
+         (prev   (jdee-javadoc-checker-find-previous-tag
+                  tags tag))
+         (report (and prev
+                      (jdee-javadoc-checker-at-level-p prev)
+                      (jdee-javadoc-checker prev t))))
     (while (and prev (not report))
       (setq prev   (jdee-javadoc-checker-find-previous-tag
-		    tags prev))
+                    tags prev))
       (setq report (and prev
-			(jdee-javadoc-checker-at-level-p prev)
-			(jdee-javadoc-checker prev t))))
+                        (jdee-javadoc-checker-at-level-p prev)
+                        (jdee-javadoc-checker prev t))))
     (if report
-	(jdee-javadoc-checker-show-report report prev)
+        (jdee-javadoc-checker-show-report report prev)
       (if tag
-	  (if (y-or-n-p "No more doc error found.  Quit? ")
-	      (jdee-javadoc-checker-quit)
-	    (jdee-javadoc-checker tag))
-	(message "No doc errors found")
-	(jdee-javadoc-checker-quit)))))
+          (if (y-or-n-p "No more doc error found.  Quit? ")
+              (jdee-javadoc-checker-quit)
+            (jdee-javadoc-checker tag))
+        (message "No doc errors found")
+        (jdee-javadoc-checker-quit)))))
 
 (defun jdee-javadoc-checker-next-tag (buffer &optional tag)
   "Report the next tag in BUFFER with documentation errors.
 Start checking after TAG if non-nil or at the first tag found."
   (pop-to-buffer buffer)
   (let* ((tags (semantic-fetch-tags))
-	 (next   (jdee-javadoc-checker-find-next-tag tags tag))
-	 (report (and next
-		      (jdee-javadoc-checker-at-level-p next)
-		      (jdee-javadoc-checker next t))))
+         (next   (jdee-javadoc-checker-find-next-tag tags tag))
+         (report (and next
+                      (jdee-javadoc-checker-at-level-p next)
+                      (jdee-javadoc-checker next t))))
     (while (and next (not report))
       (setq next   (jdee-javadoc-checker-find-next-tag tags next))
       (setq report (and next
-			(jdee-javadoc-checker-at-level-p next)
-			(jdee-javadoc-checker next t))))
+                        (jdee-javadoc-checker-at-level-p next)
+                        (jdee-javadoc-checker next t))))
     (if report
-	(jdee-javadoc-checker-show-report report next)
+        (jdee-javadoc-checker-show-report report next)
       (if tag
-	  (if (y-or-n-p "No more doc error found.  Quit? ")
-	      (jdee-javadoc-checker-quit)
-	    (jdee-javadoc-checker tag))
-	(message "No doc errors found")
-	(jdee-javadoc-checker-quit)))))
+          (if (y-or-n-p "No more doc error found.  Quit? ")
+              (jdee-javadoc-checker-quit)
+            (jdee-javadoc-checker tag))
+        (message "No doc errors found")
+        (jdee-javadoc-checker-quit)))))
 
 ;;;; Doc generator
 ;;;; -------------
@@ -1296,11 +1296,11 @@ If *NAME* value is nil *TEXTS* are inserted if non-nil.  If *NAME* and
 The name of variables local to this function are enclosed between
 \"*\" to avoid conflicts with variables used in templates."
   (cond ((and *name* (symbolp *name*) (symbol-value *name*))
-	 (tempo-insert-template *name* nil)
-	 (newline))
-	(*texts*
-	 (apply #'insert *texts*)
-	 (newline))))
+         (tempo-insert-template *name* nil)
+         (newline))
+        (*texts*
+         (apply #'insert *texts*)
+         (newline))))
 
 ;; Basic generators
 ;;
@@ -1322,12 +1322,12 @@ The name of variables local to this function are enclosed between
 (defun jdee-javadoc-insert-previous-description (doctree)
   "Insert a javadoc description if it already exists in DOCTREE."
   (let ((previous (jdee-javadoc-doctree-tag
-		   doctree jdee-javadoc-desc-tag)))
+                   doctree jdee-javadoc-desc-tag)))
     (if previous
-	(jdee-javadoc-insert
-	 nil
-	 "/**"
-	 (jdee-javadoc-normalize-description (car (car previous)))))
+        (jdee-javadoc-insert
+         nil
+         "/**"
+         (jdee-javadoc-normalize-description (car (car previous)))))
     previous))
 
 (defun jdee-javadoc-insert-previous-tag (doctree tag &optional key)
@@ -1335,12 +1335,12 @@ The name of variables local to this function are enclosed between
 If optional KEY is non-nil insert its specific value."
   (let ((previous (jdee-javadoc-doctree-tag doctree tag key)))
     (if previous
-	(jdee-javadoc-map
-	 (function
-	  (lambda (item)
-	    (jdee-javadoc-dynamic-status)
-	    (jdee-javadoc-insert nil "* @" tag (car item))))
-	 previous))
+        (jdee-javadoc-map
+         (function
+          (lambda (item)
+            (jdee-javadoc-dynamic-status)
+            (jdee-javadoc-insert nil "* @" tag (car item))))
+         previous))
     previous))
 
 (defun jdee-javadoc-insert-unknown-tags (doctree)
@@ -1393,9 +1393,9 @@ If tag already exists in DOCTREE keep it, else insert a new default
 one using parameter TYPE and NAME."
   (or (jdee-javadoc-insert-previous-tag doctree "param" name)
       (and type (not (string= type ""))
-	   name (not (string= name ""))
-	   (jdee-javadoc-insert
-	    'tempo-template-jdee-javadoc-param-tag))))
+           name (not (string= name ""))
+           (jdee-javadoc-insert
+            'tempo-template-jdee-javadoc-param-tag))))
 
 (defun jdee-javadoc-insert-exception-tag (doctree types)
   "Insert javadoc @exception tags.
@@ -1406,9 +1406,9 @@ one for each exception in TYPES."
     (lambda (type)
       (jdee-javadoc-dynamic-status)
       (or (jdee-javadoc-insert-previous-tag doctree "exception" type)
-	  (and type (not (string= type ""))
-	       (jdee-javadoc-insert
-		'tempo-template-jdee-javadoc-exception-tag)))))
+          (and type (not (string= type ""))
+               (jdee-javadoc-insert
+                'tempo-template-jdee-javadoc-exception-tag)))))
    types)
   ;; Keep extra exception tags (maybe not invalid tags)
   (jdee-javadoc-map
@@ -1417,10 +1417,10 @@ one for each exception in TYPES."
       (jdee-javadoc-dynamic-status)
       (setq type (cdr type))
       (or (member type types)
-	  (if (or (not jdee-javadoc-check-undeclared-exception-flag)
-		  (jdee-javadoc-implicit-exception-p type))
-	      (jdee-javadoc-insert-previous-tag
-	       doctree "exception" type)))))
+          (if (or (not jdee-javadoc-check-undeclared-exception-flag)
+                  (jdee-javadoc-implicit-exception-p type))
+              (jdee-javadoc-insert-previous-tag
+               doctree "exception" type)))))
    (jdee-javadoc-doctree-tag doctree "exception")))
 
 (defun jdee-javadoc-insert-return-tag (doctree type)
@@ -1429,8 +1429,8 @@ If tag already exists in DOCTREE keep it, else insert a new default
 one using return TYPE."
   (and type (not (string= type "void"))
        (or (jdee-javadoc-insert-previous-tag doctree "return")
-	   (jdee-javadoc-insert
-	    'tempo-template-jdee-javadoc-return-tag))))
+           (jdee-javadoc-insert
+            'tempo-template-jdee-javadoc-return-tag))))
 
 (defun jdee-javadoc-insert-field-desc (doctree modifiers type name)
   "Insert a field description.
@@ -1451,10 +1451,10 @@ default constructor description."
       nil
     (jdee-javadoc-insert-start-block)
     (if (and name (not (string= name "")))
-	(jdee-javadoc-insert
-	 (if (and type (not (string= type "")))
-	     'tempo-template-jdee-javadoc-describe-method
-	   'tempo-template-jdee-javadoc-describe-constructor)))
+        (jdee-javadoc-insert
+         (if (and type (not (string= type "")))
+             'tempo-template-jdee-javadoc-describe-method
+           'tempo-template-jdee-javadoc-describe-constructor)))
     (jdee-javadoc-insert-empty-line)))
 
 (defun jdee-javadoc-insert-class-desc (doctree name)
@@ -1481,7 +1481,7 @@ default one using interface NAME."
 ;; Main generators
 ;;
 (defun jdee-javadoc-type-doc (modifiers type name parents main
-				       &optional doctree)
+                                       &optional doctree)
   "Document a class or interface using MODIFIERS TYPE NAME PARENTS.
 If MAIN is non-nil this is a main class or interface (not internal).
 If description and tags already exist in DOCTREE keep them."
@@ -1500,9 +1500,9 @@ If description and tags already exist in DOCTREE keep them."
   ;; Keep extra optional tags if they already exist
   (jdee-javadoc-dynamic-status)
   (jdee-javadoc-map (function
-		    (lambda (tag)
-		      (jdee-javadoc-insert-previous-tag doctree tag)))
-		   semantic-java-doc-extra-type-tags)
+                    (lambda (tag)
+                      (jdee-javadoc-insert-previous-tag doctree tag)))
+                   semantic-java-doc-extra-type-tags)
   ;; Keep unknown (not Sun's) tags
   (jdee-javadoc-insert-unknown-tags doctree)
   ;; The end of comment block
@@ -1510,16 +1510,16 @@ If description and tags already exist in DOCTREE keep them."
   (jdee-javadoc-insert-end-block t))
 
 (defun jdee-javadoc-variable-doc (modifiers type name
-					   &optional doctree)
+                                           &optional doctree)
   "Document a field using MODIFIERS TYPE NAME.
 If description and tags already exist in DOCTREE keep them."
   ;; description
   (jdee-javadoc-insert-field-desc doctree modifiers type name)
   ;; Keep extra optional tags if they already exist
   (jdee-javadoc-map (function
-		    (lambda (tag)
-		      (jdee-javadoc-insert-previous-tag doctree tag)))
-		   semantic-java-doc-extra-variable-tags)
+                    (lambda (tag)
+                      (jdee-javadoc-insert-previous-tag doctree tag)))
+                   semantic-java-doc-extra-variable-tags)
   ;; Keep unknown (not Sun's) tags
   (jdee-javadoc-insert-unknown-tags doctree)
   ;; The end of comment block
@@ -1532,14 +1532,14 @@ If tags already exist in DOCTREE keep them."
    (function
     (lambda (tag)
       (if (semantic-tag-p tag)      ; because TAGS can be (nil)
-	  (let ((modifiers (semantic-tag-modifiers tag))
-		(type      (semantic-tag-type               tag))
-		(name      (semantic-tag-name               tag)))
-	    (jdee-javadoc-insert-param-tag doctree type name)))))
+          (let ((modifiers (semantic-tag-modifiers tag))
+                (type      (semantic-tag-type               tag))
+                (name      (semantic-tag-name               tag)))
+            (jdee-javadoc-insert-param-tag doctree type name)))))
    tags))
 
 (defun jdee-javadoc-function-doc (modifiers type name args throws
-					   &optional doctree)
+                                           &optional doctree)
   "Document a function using MODIFIERS TYPE NAME ARGS THROWS.
 If description and tags already exist in DOCTREE keep them."
   ;; description
@@ -1552,9 +1552,9 @@ If description and tags already exist in DOCTREE keep them."
   (jdee-javadoc-insert-exception-tag doctree throws)
   ;; Keep extra optional tags if they already exist
   (jdee-javadoc-map (function
-		    (lambda (tag)
-		      (jdee-javadoc-insert-previous-tag doctree tag)))
-		   semantic-java-doc-extra-function-tags)
+                    (lambda (tag)
+                      (jdee-javadoc-insert-previous-tag doctree tag)))
+                   semantic-java-doc-extra-function-tags)
   ;; Keep unknown (not Sun's) tags
   (jdee-javadoc-insert-unknown-tags doctree)
   ;; The end of comment block
@@ -1566,10 +1566,10 @@ If description and tags already exist in DOCTREE keep them."
   "Document a 'type' (class or interface) TAG.
 DOCTREE is the current doctree of TAG."
   (let ((modifiers  (semantic-tag-modifiers tag))
-	(type       (semantic-tag-type               tag))
-	(name       (semantic-tag-name               tag))
-	(parents    (semantic-tag-type-superclasses  tag))
-	(main       (jdee-javadoc-checker-main-type-p tag)))
+        (type       (semantic-tag-type               tag))
+        (name       (semantic-tag-name               tag))
+        (parents    (semantic-tag-type-superclasses  tag))
+        (main       (jdee-javadoc-checker-main-type-p tag)))
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-type-doc modifiers type name parents main doctree)))
 
@@ -1577,8 +1577,8 @@ DOCTREE is the current doctree of TAG."
   "Document a 'variable' (field) TAG.
 DOCTREE is the current doctree of TAG."
   (let ((modifiers  (semantic-tag-modifiers tag))
-	(type       (semantic-tag-type               tag))
-	(name       (semantic-tag-name               tag)))
+        (type       (semantic-tag-type               tag))
+        (name       (semantic-tag-name               tag)))
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-variable-doc modifiers type name doctree)))
 
@@ -1586,10 +1586,10 @@ DOCTREE is the current doctree of TAG."
   "Document a 'function' (method or constructor) TAG.
 DOCTREE is the current doctree of TAG."
   (let ((modifiers  (semantic-tag-modifiers tag))
-	(type       (semantic-tag-type               tag))
-	(name       (semantic-tag-name               tag))
-	(args       (semantic-tag-function-arguments tag))
-	(throws     (semantic-tag-function-throws    tag)))
+        (type       (semantic-tag-type               tag))
+        (name       (semantic-tag-name               tag))
+        (args       (semantic-tag-function-arguments tag))
+        (throws     (semantic-tag-function-throws    tag)))
     (jdee-javadoc-dynamic-status)
     (jdee-javadoc-function-doc
      modifiers type name args throws doctree)))
@@ -1599,32 +1599,32 @@ DOCTREE is the current doctree of TAG."
 Require confirmation to delete existing documentation if optional
 NOCONFIRM is non-nil."
   (let* ((type      (semantic-tag-class tag))
-	 (generator (intern (format "jdee-javadoc-%s" type)))
-	 (checker   (intern (format "jdee-javadoc-check-%s" type))))
+         (generator (intern (format "jdee-javadoc-%s" type)))
+         (checker   (intern (format "jdee-javadoc-check-%s" type))))
     (or (fboundp generator)
-	(error "No generator found to process '%S' tag" type))
+        (error "No generator found to process '%S' tag" type))
     (goto-char (semantic-tag-start tag))
     (let ((report t) doctree)
       (jdee-javadoc-status-forms "Updating" "done"
-	(jdee-javadoc-dynamic-status)
-	(setq doctree (jdee-javadoc-tag-doctree tag))
-	(if (and (fboundp checker)
-		 (not (funcall checker tag doctree)))
-	    (setq report nil)
-	  (let ((seas semantic-edits-are-safe))
-	    (make-local-variable 'semantic-edits-are-safe)
-	    (unwind-protect
-		(progn
-		  (setq semantic-edits-are-safe t)
-		  (when (or (not doctree)
-			    (jdee-javadoc-delete-documentation
-			     tag noconfirm))
-		    (funcall generator tag doctree)
-		    (jdee-javadoc-indent-documentation tag)))
-	      (setq semantic-edits-are-safe seas))))
-	(jdee-javadoc-dynamic-status t))
+        (jdee-javadoc-dynamic-status)
+        (setq doctree (jdee-javadoc-tag-doctree tag))
+        (if (and (fboundp checker)
+                 (not (funcall checker tag doctree)))
+            (setq report nil)
+          (let ((seas semantic-edits-are-safe))
+            (make-local-variable 'semantic-edits-are-safe)
+            (unwind-protect
+                (progn
+                  (setq semantic-edits-are-safe t)
+                  (when (or (not doctree)
+                            (jdee-javadoc-delete-documentation
+                             tag noconfirm))
+                    (funcall generator tag doctree)
+                    (jdee-javadoc-indent-documentation tag)))
+              (setq semantic-edits-are-safe seas))))
+        (jdee-javadoc-dynamic-status t))
       (or report
-	  (message "Documentation is up-to-date")))))
+          (message "Documentation is up-to-date")))))
 
 ;;;; Misc command auxiliaries
 ;;;; ------------------------
@@ -1635,10 +1635,10 @@ NOCONFIRM is non-nil."
     ;; Preserve current tags when the lexer fails (when there is an
     ;; unclosed block or an unterminated string for example).
     (let ((semantic-flex-unterminated-syntax-end-function
-	   #'(lambda (syntax &rest ignore)
-	       (throw 'jdee-javadoc-flex-error syntax))))
+           #'(lambda (syntax &rest ignore)
+               (throw 'jdee-javadoc-flex-error syntax))))
       (catch 'jdee-javadoc-flex-error
-	(semantic-fetch-tags))))
+        (semantic-fetch-tags))))
   (save-excursion
     ;; Move the point to the first non-blank character found.  Skip
     ;; spaces, tabs and newlines.
@@ -1661,21 +1661,21 @@ See also variable `jdee-javadoc-checkdoc-excursion'."
   "Save window configuration and point.
 See also function `jdee-javadoc-checkdoc-restore-excursion'."
   (setq jdee-javadoc-checkdoc-excursion
-	(vector (current-window-configuration)
-		(point))))
+        (vector (current-window-configuration)
+                (point))))
 
 (defun jdee-javadoc-checkdoc-restore-excursion ()
   "Restore window configuration and point.
 See also function `jdee-javadoc-checkdoc-save-excursion'."
   (let ((ex jdee-javadoc-checkdoc-excursion))
     (and (vectorp ex)
-	 (window-configuration-p (aref ex 0))
-	 (integer-or-marker-p    (aref ex 1))
-	 (condition-case nil
-	     (progn
-	       (set-window-configuration (aref ex 0))
-	       (goto-char                (aref ex 1)))
-	   (error nil)))
+         (window-configuration-p (aref ex 0))
+         (integer-or-marker-p    (aref ex 1))
+         (condition-case nil
+             (progn
+               (set-window-configuration (aref ex 0))
+               (goto-char                (aref ex 1)))
+           (error nil)))
     (jdee-javadoc-checkdoc-clear-excursion)))
 
 ;;;; Commands
@@ -1687,7 +1687,7 @@ See also function `jdee-javadoc-checkdoc-save-excursion'."
   (interactive)
   (and (eq major-mode 'jdee-javadoc-checker-report-mode)
        (jdee-javadoc-checker-previous-tag
-	jdee-javadoc-checker-buffer jdee-javadoc-checker-tag)))
+        jdee-javadoc-checker-buffer jdee-javadoc-checker-tag)))
 
 ;;;###autoload
 (defun jdee-javadoc-checker-next ()
@@ -1695,7 +1695,7 @@ See also function `jdee-javadoc-checkdoc-save-excursion'."
   (interactive)
   (and (eq major-mode 'jdee-javadoc-checker-report-mode)
        (jdee-javadoc-checker-next-tag jdee-javadoc-checker-buffer
-				       jdee-javadoc-checker-tag)))
+                                       jdee-javadoc-checker-tag)))
 ;;;###autoload
 (defun jdee-javadoc-checker-fix ()
   "Fix documentation of checked tag.
@@ -1703,14 +1703,14 @@ Used in `jdee-javadoc-checker-report-mode'."
   (interactive)
   (and (eq major-mode 'jdee-javadoc-checker-report-mode)
        (let ((tag  jdee-javadoc-checker-tag)
-	     (buffer jdee-javadoc-checker-buffer))
-	 (when (and tag buffer)
-	   (pop-to-buffer buffer)
-	   (goto-char (semantic-tag-start tag))
-	   ;; do the fix (THE POINT STAY AT TAG START POSITION)
-	   (jdee-javadoc-generator tag t)
-	   ;; recheck the tag
-	   (jdee-javadoc-checker tag)))))
+             (buffer jdee-javadoc-checker-buffer))
+         (when (and tag buffer)
+           (pop-to-buffer buffer)
+           (goto-char (semantic-tag-start tag))
+           ;; do the fix (THE POINT STAY AT TAG START POSITION)
+           (jdee-javadoc-generator tag t)
+           ;; recheck the tag
+           (jdee-javadoc-checker tag)))))
 
 ;;;###autoload
 (defun jdee-javadoc-checker-quit ()
@@ -1719,7 +1719,7 @@ Used in `jdee-javadoc-checker-report-mode'."
   (interactive)
   (let ((buffer (get-buffer jdee-javadoc-checker-report-buffer)))
     (if (bufferp buffer)
-	(kill-buffer buffer))
+        (kill-buffer buffer))
     (jdee-javadoc-checkdoc-restore-excursion)))
 
 ;;;###autoload
@@ -1833,7 +1833,7 @@ See also the `jdee-javadoc-field-type', `jdee-javadoc-a' and
       (error "Major mode must be 'jdee-mode'"))
   (let ((found (jdee-javadoc-nonterminal-at-line)))
     (if found
-	(jdee-javadoc-generator found)
+        (jdee-javadoc-generator found)
       (error "No tag found at point"))))
 
 ;;;###autoload
@@ -1846,7 +1846,7 @@ This uses `jdee-javadoc-nonterminal-at-line' to find declarations."
   (jdee-assert-source-buffer)
   (let ((found (jdee-javadoc-nonterminal-at-line)))
     (if (not found)
-	(error "No tag found at point")
+        (error "No tag found at point")
       (jdee-javadoc-delete-documentation found current-prefix-arg))))
 
 ;;;###autoload
@@ -1862,7 +1862,7 @@ LINE OF THE CLASS OR METHOD DECLARATION.  IF NOT RESULT IS UNCERTAIN."
   (jdee-assert-source-buffer)
   (let ((found (jdee-javadoc-nonterminal-at-line)))
     (if (not found)
-	(error "No tag found at point")
+        (error "No tag found at point")
       (jdee-javadoc-checkdoc-save-excursion)
       (jdee-javadoc-checker found))))
 
@@ -1889,18 +1889,18 @@ Report the next tag with documentation errors."
 START, the start position in the buffer.
 END, the end position in the buffer."
   (interactive (if mark-active
-		   (list (region-beginning) (region-end))
-		 (list (point-min) (point-max))))
+                   (list (region-beginning) (region-end))
+                 (list (point-min) (point-max))))
   (save-excursion
     (save-restriction
       (narrow-to-region start end)
       (goto-char (point-min))
       (while (re-search-forward
-	      "^\\([ \t]*\\/\\*\\(?:.\\|[.\n]\\)*?\\*\\/[ \t]*\n\\)"
-	      nil t)
-	(replace-match ""))
+              "^\\([ \t]*\\/\\*\\(?:.\\|[.\n]\\)*?\\*\\/[ \t]*\n\\)"
+              nil t)
+        (replace-match ""))
       (while (re-search-forward "^[ \t]*\\/\\/.*\n" nil t)
-	(replace-match "")))))
+        (replace-match "")))))
 
 ;;;###autoload
 (defun jdee-javadoc-enable-menu-p ()
@@ -1908,23 +1908,23 @@ END, the end position in the buffer."
 That is point is on the first line of a class, method, or field
 definition."
   (let ((p (save-excursion (beginning-of-line) (point)))
-	(tag-at-line (jdee-javadoc-nonterminal-at-line))
-	start end)
+        (tag-at-line (jdee-javadoc-nonterminal-at-line))
+        start end)
     (and tag-at-line
-	 (memq (semantic-tag-class tag-at-line)
-	       '(function type variable))
-	 (save-excursion
-	   (setq start
-		 (progn
-		   (goto-char (semantic-tag-start tag-at-line))
-		   (beginning-of-line)
-		   (point)))
-	   (setq end (or (re-search-forward "[;={]")
-			 (progn
-			   (goto-char p)
-			   (end-of-line)
-			   (point))))
-	   (and (>= p start) (<= p end))))))
+         (memq (semantic-tag-class tag-at-line)
+               '(function type variable))
+         (save-excursion
+           (setq start
+                 (progn
+                   (goto-char (semantic-tag-start tag-at-line))
+                   (beginning-of-line)
+                   (point)))
+           (setq end (or (re-search-forward "[;={]")
+                         (progn
+                           (goto-char p)
+                           (end-of-line)
+                           (point))))
+           (and (>= p start) (<= p end))))))
 
 ;; Register and initialize the customization variables defined
 ;; by this package.

--- a/jdee-jdb.el
+++ b/jdee-jdb.el
@@ -86,32 +86,32 @@ step command." nil)
 command. Launch the debuggee process."
   (let ((debugger (oref this debugger)))
     (if (or
-	 (not (slot-boundp debugger 'buffer))
-	 (not (oref debugger :buffer))
-	 (not (comint-check-proc (oref debugger :buffer))))
-	(let* ((debuggee
-		(oref debugger debuggee))
-	       (source-directory default-directory)
-	       (working-directory
-		(jdee-db-debugger-get-working-dir debugger))
-	       (prog-args (jdee-db-debugger-get-prog-args debugger))
-	       (cmd-path (jdee-db-cmd-launch-cmd-path this))
-	       (command-string
-		(concat
-		 cmd-path " "
-		 (jdee-run-make-arg-string prog-args) "\n\n")))
+         (not (slot-boundp debugger 'buffer))
+         (not (oref debugger :buffer))
+         (not (comint-check-proc (oref debugger :buffer))))
+        (let* ((debuggee
+                (oref debugger debuggee))
+               (source-directory default-directory)
+               (working-directory
+                (jdee-db-debugger-get-working-dir debugger))
+               (prog-args (jdee-db-debugger-get-prog-args debugger))
+               (cmd-path (jdee-db-cmd-launch-cmd-path this))
+               (command-string
+                (concat
+                 cmd-path " "
+                 (jdee-run-make-arg-string prog-args) "\n\n")))
 
-	(oset debugger :buffer-name (jdee-db-cmd-launch-buffer-name this))
-	(oset debugger :buffer (get-buffer-create (oref debugger :buffer-name)))
+        (oset debugger :buffer-name (jdee-db-cmd-launch-buffer-name this))
+        (oset debugger :buffer (get-buffer-create (oref debugger :buffer-name)))
 
-	(jdee-db-cmd-launch-startup-cmds this)
+        (jdee-db-cmd-launch-startup-cmds this)
 
-	(oset debugger :path cmd-path)
-	(jdee-db-jdb-start debugger prog-args command-string)
+        (oset debugger :path cmd-path)
+        (jdee-db-jdb-start debugger prog-args command-string)
 
-	(let ((debuggee-status (oref debuggee status)))
-	  (oset debuggee-status running-p t)
-	  (oset debuggee-status stopped-p t)))
+        (let ((debuggee-status (oref debuggee status)))
+          (oset debuggee-status running-p t)
+          (oset debuggee-status stopped-p t)))
     (progn
       (message "An instance of %s is running." (oref this :buffer-name))
       (pop-to-buffer (oref this :buffer-name))))))
@@ -124,7 +124,7 @@ when it is started." nil)
 ;; Launch application command
 
 (defclass jdee-jdb-cmd-launch-app (jdee-jdb-cmd-launch
-				  jdee-db-cmd-launch-app) ()
+                                  jdee-db-cmd-launch-app) ()
   "Asks jdb to launch the debuggee application.")
 
 (defmethod initialize-instance ((this jdee-jdb-cmd-launch-app) &rest fields)
@@ -138,8 +138,8 @@ when it is started." nil)
 
 (defmethod jdee-db-cmd-launch-buffer-name ((this jdee-jdb-cmd-launch-app))
   (let* ((debugger (oref this :debugger))
-	 (debuggee (oref debugger :debuggee))
-	 (main-class (oref debuggee :main-class)))
+         (debuggee (oref debugger :debuggee))
+         (main-class (oref debuggee :main-class)))
     (concat  "*debug"  main-class "*")))
 
 (defmethod jdee-db-cmd-launch-startup-cmds ((this jdee-jdb-cmd-launch-app))
@@ -147,15 +147,15 @@ when it is started." nil)
 debugger's startup command queue."
   (if jdee-db-initial-step-p
       (let*  ((debugger (oref this debugger))
-	      (step-cmd (oref (oref debugger cmd-set) step-into)))
-	(oset debugger next-cmd
-		    (append (oref debugger next-cmd) (list step-cmd))))))
+              (step-cmd (oref (oref debugger cmd-set) step-into)))
+        (oset debugger next-cmd
+                    (append (oref debugger next-cmd) (list step-cmd))))))
 
 
 ;; Launch applet command
 
 (defclass jdee-jdb-cmd-launch-applet (jdee-jdb-cmd-launch
-				     jdee-db-cmd-launch-applet) ()
+                                     jdee-db-cmd-launch-applet) ()
   "Asks jdb to launch the debuggee applet.")
 
 (defmethod initialize-instance ((this jdee-jdb-cmd-launch-applet) &rest fields)
@@ -168,14 +168,14 @@ classes should override this method to return a path appropriate to
 the command to be used to launch the debuggee process, e.g., jdb or
 appletviewer."
   (let* ((debugger (oref this :debugger))
-	 (jdb-path (oref debugger :path))
-	 (jdb-dir (file-name-directory jdb-path)))
+         (jdb-path (oref debugger :path))
+         (jdb-dir (file-name-directory jdb-path)))
     (expand-file-name "appletviewer" jdb-dir)))
 
 (defmethod jdee-db-cmd-launch-buffer-name ((this jdee-jdb-cmd-launch-applet))
   (let* ((debugger (oref this :debugger))
-	 (debuggee (oref debugger :debuggee))
-	 (doc (oref debuggee :doc)))
+         (debuggee (oref debugger :debuggee))
+         (doc (oref debuggee :doc)))
     (concat  "*debug"  (file-name-nondirectory doc) "*")))
 
 (defmethod jdee-db-cmd-launch-startup-cmds ((this jdee-jdb-cmd-launch-applet))
@@ -183,14 +183,14 @@ appletviewer."
 step command to the debugger's startup command queue."
   (if jdee-db-initial-step-p
       (let*  ((debugger (oref this debugger))
-	      (cmd-set (oref debugger cmd-set))
-	      (run-cmd (oref cmd-set run))
-	      (step-cmd (oref cmd-set step-into)))
-	(oset debugger next-cmd
-		    (append
-		     (oref debugger next-cmd)
-		     (list run-cmd)
-		     (list step-cmd))))))
+              (cmd-set (oref debugger cmd-set))
+              (run-cmd (oref cmd-set run))
+              (step-cmd (oref cmd-set step-into)))
+        (oset debugger next-cmd
+                    (append
+                     (oref debugger next-cmd)
+                     (list run-cmd)
+                     (list step-cmd))))))
 
 
 
@@ -294,8 +294,8 @@ command in order to position the debug pointer at the
 current stack location."
   ;; (jdee-debug-where)
   (let* ((jdb (oref this debugger))
-	 (cmds (oref jdb cmd-set))
-	 (cmd (oref cmds where)))
+         (cmds (oref jdb cmd-set))
+         (cmd (oref cmds where)))
     (jdee-db-exec-cmd jdb cmd)))
 
 ;; Down stack command
@@ -318,8 +318,8 @@ command in order to position the debug pointer at the
 current stack location."
   ;;(jdee-debug-where)
   (let* ((jdb (oref this debugger))
-	 (cmds (oref jdb cmd-set))
-	 (cmd (oref cmds where)))
+         (cmds (oref jdb cmd-set))
+         (cmd (oref cmds where)))
     (jdee-db-exec-cmd jdb cmd)))
 
 
@@ -349,31 +349,31 @@ current stack location."
  matches the current location of the debugger in the program's
  stack (set by the jdb up and down stack commands)."
   (let* ((jdb (oref this debugger))
-	 (debuggee (oref jdb debuggee)))
+         (debuggee (oref jdb debuggee)))
     ;; if the stack depth is not set default to 1
     (if (string-equal "" (oref debuggee :stack-depth))
-	(oset debuggee :stack-depth "1"))
+        (oset debuggee :stack-depth "1"))
     (if (string-match
-	 (concat "^  \\["
-		 (oref debuggee :stack-depth)
-		 "\\] .*(\\([^\$\n]*\\).*:\\([0-9]*[^[:digit:]]?[0-9]+\\))")
-	 output)
-	(let ((marker (match-string 0 output))
-	      (class (match-string 1 output))
-	      (line-no (jdee-jdb-string-to-int (match-string 2 output)))
-	      (package ""))
+         (concat "^  \\["
+                 (oref debuggee :stack-depth)
+                 "\\] .*(\\([^\$\n]*\\).*:\\([0-9]*[^[:digit:]]?[0-9]+\\))")
+         output)
+        (let ((marker (match-string 0 output))
+              (class (match-string 1 output))
+              (line-no (jdee-jdb-string-to-int (match-string 2 output)))
+              (package ""))
 
-	  (if (equal ".java" (substring class -5))
-	      (setq class (substring class 0 -5)))
+          (if (equal ".java" (substring class -5))
+              (setq class (substring class 0 -5)))
 
-	  ;; Extract package path from input.
-	  (let ((case-fold-search nil))	;; Make sure search is case-sensitive
-	    (and (string-match (jdee-jdb-make-qualified-class-name-regexp class) marker)
-		 (setq package
-		       (substring marker (match-beginning 2) (match-end 2)))))
-	  (jdee-db-set-debug-cursor
-	   (if package (concat package class) class)
-	   (concat class ".java") line-no)))
+          ;; Extract package path from input.
+          (let ((case-fold-search nil))        ;; Make sure search is case-sensitive
+            (and (string-match (jdee-jdb-make-qualified-class-name-regexp class) marker)
+                 (setq package
+                       (substring marker (match-beginning 2) (match-end 2)))))
+          (jdee-db-set-debug-cursor
+           (if package (concat package class) class)
+           (concat class ".java") line-no)))
     output))
 
 ;; Set Breakpoint command
@@ -389,10 +389,10 @@ breakpoint field.")
 (defmethod jdee-db-cmd-make-command-line ((this jdee-jdb-cmd-set-breakpoint))
   "Creates command line for jdb set breakpoint command."
   (let* ((bps (oref this breakpoints))
-	 (bp (car bps)))
+         (bp (car bps)))
     (format "stop at %s:%d"
-	    (oref bp class)
-	    (jdee-db-breakpoint-get-line bp))))
+            (oref bp class)
+            (jdee-db-breakpoint-get-line bp))))
 
 (defmethod jdee-db-cmd-notify-response ((this jdee-jdb-cmd-set-breakpoint) output)
   "Called when the debugger responds to the last set-breakpoint
@@ -407,34 +407,34 @@ on the list."
        (string-match "Set breakpoint" output)
        (string-match "Unable to set" output))
       (let* ((bps (oref this breakpoints))
-	     (bp (car bps)) file line)
-	(if (not (null bp))
-	    (progn
-	      (setq file (oref bp file))
-	      (setq line (jdee-db-breakpoint-get-line bp))
-	      (if (string-match "Unable to set breakpoint" output)
-		  (jdee-db-delete-breakpoint bp)
-		(if (string-match "Unable to set deferred breakpoint" output)
-		    (if (jdee-db-debuggee-running-p)
-			(let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-			       (bp-cmd
-				(oref (oref debugger cmd-set) clear-bp)))
-			  (oset bp-cmd breakpoints (list bp))
-			  (jdee-db-exec-cmd debugger bp-cmd))
-		      (jdee-db-delete-breakpoint bp))
-		  (if (string-match "Deferring breakpoint" output)
-		      (progn
-			(oset bp status 'requested)
-			(jdee-db-mark-breakpoint-requested file line))
-		    (if (string-match "Set breakpoint" output)
-			(progn
-			  (oset bp status 'active)
-			  (jdee-db-mark-breakpoint-active file line))))))
-	      (setq bps (cdr bps))
-	      (oset this breakpoints bps)
-	      (if bps
-		  (let ((jdb (oref this debugger)))
-		    (jdee-db-exec-cmd jdb this))))))))
+             (bp (car bps)) file line)
+        (if (not (null bp))
+            (progn
+              (setq file (oref bp file))
+              (setq line (jdee-db-breakpoint-get-line bp))
+              (if (string-match "Unable to set breakpoint" output)
+                  (jdee-db-delete-breakpoint bp)
+                (if (string-match "Unable to set deferred breakpoint" output)
+                    (if (jdee-db-debuggee-running-p)
+                        (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                               (bp-cmd
+                                (oref (oref debugger cmd-set) clear-bp)))
+                          (oset bp-cmd breakpoints (list bp))
+                          (jdee-db-exec-cmd debugger bp-cmd))
+                      (jdee-db-delete-breakpoint bp))
+                  (if (string-match "Deferring breakpoint" output)
+                      (progn
+                        (oset bp status 'requested)
+                        (jdee-db-mark-breakpoint-requested file line))
+                    (if (string-match "Set breakpoint" output)
+                        (progn
+                          (oset bp status 'active)
+                          (jdee-db-mark-breakpoint-active file line))))))
+              (setq bps (cdr bps))
+              (oset this breakpoints bps)
+              (if bps
+                  (let ((jdb (oref this debugger)))
+                    (jdee-db-exec-cmd jdb this))))))))
 
 ;; Clear Breakpoint command
 
@@ -449,10 +449,10 @@ breakpoint field.")
 (defmethod jdee-db-cmd-make-command-line ((this jdee-jdb-cmd-clear-breakpoint))
   "Creates command line for jdb clear breakpoint command."
   (let* ((bps (oref this breakpoints))
-	 (bp (car bps)))
+         (bp (car bps)))
     (format "clear %s:%d"
-	    (oref bp class)
-	    (jdee-db-breakpoint-get-line bp))))
+            (oref bp class)
+            (jdee-db-breakpoint-get-line bp))))
 
 (defmethod jdee-db-cmd-notify-response ((this jdee-jdb-cmd-clear-breakpoint) output)
   "Called when the debugger responds to the last clear-breakpoint command.
@@ -460,23 +460,23 @@ Removes the breakpoint from the command's breakpoint list. If the list contains
 more breakpoints, this method reissues the clear command on the next breakpoint
 on the list."
   (let* ((bps (oref this breakpoints))
-	 (bp (car bps)))
+         (bp (car bps)))
     (jdee-db-delete-breakpoint bp)
     (setq bps (cdr bps))
     (oset this breakpoints bps)
     (if bps
-	(let ((jdb (oref this debugger)))
-	  (jdee-db-exec-cmd jdb this)))))
+        (let ((jdb (oref this debugger)))
+          (jdee-db-exec-cmd jdb this)))))
 
 ;; Print command
 (defvar jdee-jdb-cmd-print-history  nil)
 
 (defclass jdee-jdb-cmd-print (jdee-db-cmd)
-  ((expr	:initarg :expr
-		:type string
-		:initform ""
-		:documentation
-		"Expression passed to jdb"))
+  ((expr        :initarg :expr
+                :type string
+                :initform ""
+                :documentation
+                "Expression passed to jdb"))
   "Asks jdb to print value of expression at point")
 
 (defmethod initialize-instance ((this jdee-jdb-cmd-print) &rest fields)
@@ -488,13 +488,13 @@ on the list."
   "The debugger invokes this method before executing the
 command."
   (oset this expr (read-from-minibuffer "expr: " (thing-at-point 'word)
-					nil nil 'jdee-jdb-cmd-print-history)))
+                                        nil nil 'jdee-jdb-cmd-print-history)))
 
 (defmethod jdee-db-cmd-make-command-line ((this jdee-jdb-cmd-print))
   "Creates a command line for jdb print command."
   (format "%s %s"
-	  (oref this name)
-	  (oref this expr)))
+          (oref this name)
+          (oref this expr)))
 
 ;; Dump command
 (defclass jdee-jdb-cmd-dump (jdee-jdb-cmd-print) ()
@@ -515,10 +515,10 @@ command."
 ;; Set command
 (defclass jdee-jdb-cmd-set-var (jdee-jdb-cmd-print)
   ((value :initarg :value
-	  :type string
-	  :initform "null"
-	  :document
-	  "Value to assign to the variable"))
+          :type string
+          :initform "null"
+          :document
+          "Value to assign to the variable"))
   "Ask jdb to assign new value to a field/variable/array element")
 
 (defmethod initialize-instance ((this jdee-jdb-cmd-set-var) &rest fields)
@@ -529,16 +529,16 @@ command."
   "The debugger invokes this method before executing the
 command."
   (oset this expr (read-from-minibuffer "variable: " (thing-at-point 'word)
-					nil nil 'jdee-jdb-cmd-print-history))
+                                        nil nil 'jdee-jdb-cmd-print-history))
   (oset this value (read-from-minibuffer "value: " nil
-					nil nil '(null))))
+                                        nil nil '(null))))
 
 (defmethod jdee-db-cmd-make-command-line ((this jdee-jdb-cmd-set-var))
   "Creates a command line for jdb print command."
   (format "%s %s = %s"
-	  (oref this name)
-	  (oref this expr)
-	  (oref this value)))
+          (oref this name)
+          (oref this expr)
+          (oref this value)))
 
 ;; Locals commands
 (defclass jdee-jdb-cmd-locals (jdee-jdb-cmd-print) ()
@@ -557,26 +557,26 @@ command."
 
 (defclass jdee-jdb-cmd-set (jdee-db-cmd-set)
   ((print :initarg :print
-	  :type jdee-jdb-cmd-print
-	  :documentation
-	  "Asks jdb to print the value of expression at point")
+          :type jdee-jdb-cmd-print
+          :documentation
+          "Asks jdb to print the value of expression at point")
    (dump :initarg :dump
-	 :type jdee-jdb-cmd-dump
-	 :documentation
-	 "Ask jdb to print all object information from the
+         :type jdee-jdb-cmd-dump
+         :documentation
+         "Ask jdb to print all object information from the
 expression at poing")
    (eval :initarg :eval
-	 :type jdee-jdb-cmd-eval
-	 :documentation
-	 "Ask jdb to evaluate the expression at point")
+         :type jdee-jdb-cmd-eval
+         :documentation
+         "Ask jdb to evaluate the expression at point")
    (set-var :initarg :set-var
-	    :type jdee-jdb-cmd-set-var
-	    :documentation
-	    "Ask jdb to assign a new value to the expression at point")
+            :type jdee-jdb-cmd-set-var
+            :documentation
+            "Ask jdb to assign a new value to the expression at point")
    (locals :initarg :locals
-	 :type jdee-jdb-cmd-locals
-	 :documentation
-	 "Ask jdb to print all local variables in current stack frame")
+         :type jdee-jdb-cmd-locals
+         :documentation
+         "Ask jdb to print all local variables in current stack frame")
    )
   "Set of debugger commands implemented by jdb.")
 
@@ -585,41 +585,41 @@ expression at poing")
   (call-next-method)
   (let ((jdb (oref this debugger)))
     (oset this launch-app
-	  (jdee-jdb-cmd-launch-app "launch" :debugger jdb))
+          (jdee-jdb-cmd-launch-app "launch" :debugger jdb))
     (oset this launch-applet
-	  (jdee-jdb-cmd-launch-applet "launch" :debugger jdb))
+          (jdee-jdb-cmd-launch-applet "launch" :debugger jdb))
     (oset this run
-	  (jdee-jdb-cmd-run "run" :debugger jdb))
+          (jdee-jdb-cmd-run "run" :debugger jdb))
     (oset this cont
-	  (jdee-jdb-cmd-cont "cont" :debugger jdb))
+          (jdee-jdb-cmd-cont "cont" :debugger jdb))
     (oset this quit
-	  (jdee-jdb-cmd-quit "jdb quit" :debugger jdb))
+          (jdee-jdb-cmd-quit "jdb quit" :debugger jdb))
     (oset this step-over
-	  (jdee-jdb-cmd-step-over "jdb step-over cmd" :debugger jdb))
+          (jdee-jdb-cmd-step-over "jdb step-over cmd" :debugger jdb))
     (oset this step-into
-	  (jdee-jdb-cmd-step-into "jdb step-into cmd" :debugger jdb))
+          (jdee-jdb-cmd-step-into "jdb step-into cmd" :debugger jdb))
     (oset this step-out
-	  (jdee-jdb-cmd-step-out "jdb step-out cmd" :debugger jdb))
+          (jdee-jdb-cmd-step-out "jdb step-out cmd" :debugger jdb))
     (oset this up
-	  (jdee-jdb-cmd-up "jdb up cmd" :debugger jdb))
+          (jdee-jdb-cmd-up "jdb up cmd" :debugger jdb))
     (oset this down
-	  (jdee-jdb-cmd-down "jdb down cmd" :debugger jdb))
+          (jdee-jdb-cmd-down "jdb down cmd" :debugger jdb))
     (oset this where
-	  (jdee-jdb-cmd-where "jdb where cmd" :debugger jdb))
+          (jdee-jdb-cmd-where "jdb where cmd" :debugger jdb))
     (oset this set-bp
-	  (jdee-jdb-cmd-set-breakpoint "jdb set breakpoint" :debugger jdb))
+          (jdee-jdb-cmd-set-breakpoint "jdb set breakpoint" :debugger jdb))
     (oset this clear-bp
-	  (jdee-jdb-cmd-clear-breakpoint "jdb clear breakpoint" :debugger jdb))
+          (jdee-jdb-cmd-clear-breakpoint "jdb clear breakpoint" :debugger jdb))
     (oset this print
-	  (jdee-jdb-cmd-print "jdb print cmd" :debugger jdb))
+          (jdee-jdb-cmd-print "jdb print cmd" :debugger jdb))
     (oset this dump
-	  (jdee-jdb-cmd-dump "jdb dump cmd" :debugger jdb))
+          (jdee-jdb-cmd-dump "jdb dump cmd" :debugger jdb))
     (oset this eval
-	  (jdee-jdb-cmd-eval "jdb eval cmd" :debugger jdb))
+          (jdee-jdb-cmd-eval "jdb eval cmd" :debugger jdb))
     (oset this set-var
-	  (jdee-jdb-cmd-set-var "jdb set cmd" :debugger jdb))
+          (jdee-jdb-cmd-set-var "jdb set cmd" :debugger jdb))
     (oset this locals
-	  (jdee-jdb-cmd-locals "jdb locals cmd" :debugger jdb))
+          (jdee-jdb-cmd-locals "jdb locals cmd" :debugger jdb))
     ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -629,23 +629,23 @@ expression at poing")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-jdb-breakpoint-listener (jdee-db-listener)
   ((marker-regexp   :initarg :marker-regexp
-		    :type string
-		    :documentation
-		    "Regular expression for parsing breakpoint messages.")
+                    :type string
+                    :documentation
+                    "Regular expression for parsing breakpoint messages.")
    (class-index     :initarg :class-index
-		    :type integer
-		    :initform 3
-		    :documentation
-		    "Index of class name parsed by marker-regex")
+                    :type integer
+                    :initform 3
+                    :documentation
+                    "Index of class name parsed by marker-regex")
    (line-index      :initarg :line-index
-		    :type integer
-		    :initform 5
-		    :documentation
-		    "Index of line number parsed by marker-regex")
+                    :type integer
+                    :initform 5
+                    :documentation
+                    "Index of line number parsed by marker-regex")
    (noline-regexp   :initarg :noline-regexp
-		    :type string
-		    :documentation
-		    "Regular expression for parsing breakpoint messages without line numbers.")
+                    :type string
+                    :documentation
+                    "Regular expression for parsing breakpoint messages without line numbers.")
    ;; There's no guarantee that Emacs will hand the filter the entire
    ;; marker at once; it could be broken up across several strings.  We
    ;; might even receive a big chunk with several markers in it.  If we
@@ -653,10 +653,10 @@ expression at poing")
    ;; beginning of a marker, we save it here between calls to the
    ;; filter.
    (marker-acc      :initarg :marker-acc
-		    :type string
-		    :initform ""
-		    :documentation
-		    "Debug output accumulator")
+                    :type string
+                    :initform ""
+                    :documentation
+                    "Debug output accumulator")
 
    )
   "Handles jdb breakpoint events.")
@@ -691,10 +691,10 @@ expression at poing")
     ;; This is a hack to accommodate reorder of message chunks
     ;; on Solaris at debugger startup.
     (if (string-match "running ...\n" (oref this :marker-acc))
-	(oset this :marker-acc
-	      (concat "running ...\n"
-		      (substring (oref this :marker-acc) 0 (match-beginning 0))
-		      (substring (oref this :marker-acc) (match-end 0)))))
+        (oset this :marker-acc
+              (concat "running ...\n"
+                      (substring (oref this :marker-acc) 0 (match-beginning 0))
+                      (substring (oref this :marker-acc) (match-end 0)))))
 
 
     ;; This is a hack to fix reordering of message chunks on Windows 2000
@@ -704,11 +704,11 @@ expression at poing")
     ;; This seems to show up most often with step commands.
     ;;(message "checking string %s" (oref jdb :marker-acc))
     (if (string-match "^.*: \\([-a-zA-Z0-9_$]+\\[[0-9]+\\] \\)thread="
-		      (oref this :marker-acc))
-	(oset this :marker-acc
-	      (concat (match-string 1 (oref this :marker-acc))
-		      (substring (oref this :marker-acc) 0 (match-beginning 1))
-		      (substring (oref this :marker-acc) (match-end 1)))))
+                      (oref this :marker-acc))
+        (oset this :marker-acc
+              (concat (match-string 1 (oref this :marker-acc))
+                      (substring (oref this :marker-acc) 0 (match-beginning 1))
+                      (substring (oref this :marker-acc) (match-end 1)))))
     ;; (message "fixed string is %s" jdee-db-marker-acc)
     )
 
@@ -717,100 +717,100 @@ expression at poing")
   "Listens for set breakpoint messages."
   (let ((msgs (split-string output "\n")))
     (loop for msg in msgs do
-	  (if (and (string-match
-		    "^.*Set .*breakpoint \\(.*\\):\\([0-9]+\\)"
-		    msg)
-		   (not (string-match "Unable to set.*" msg)))
-	      (let* ((class (substring
-			     msg
-			     (match-beginning 1)
-			     (match-end 1)))
-		     (line (string-to-number
-			    (substring
-			     msg
-			     (match-beginning 2)
-			     (match-end 2))))
-		     (source-buffer (jdee-db-find-class-source class))
-		     (path (buffer-file-name source-buffer))
-		     (bp (jdee-db-find-breakpoint path line)))
-		(oset bp status 'active)
-		(jdee-db-mark-breakpoint-active path  line))))))
+          (if (and (string-match
+                    "^.*Set .*breakpoint \\(.*\\):\\([0-9]+\\)"
+                    msg)
+                   (not (string-match "Unable to set.*" msg)))
+              (let* ((class (substring
+                             msg
+                             (match-beginning 1)
+                             (match-end 1)))
+                     (line (string-to-number
+                            (substring
+                             msg
+                             (match-beginning 2)
+                             (match-end 2))))
+                     (source-buffer (jdee-db-find-class-source class))
+                     (path (buffer-file-name source-buffer))
+                     (bp (jdee-db-find-breakpoint path line)))
+                (oset bp status 'active)
+                (jdee-db-mark-breakpoint-active path  line))))))
 
 (defmethod jdee-db-listener-filter-output ((this jdee-jdb-breakpoint-listener) input)
   "Filters the output of the debugger."
   (let ((jdb (oref this debugger))
-	(output ""))
+        (output ""))
 
     ;; Accumulate next chunk of debugger output.
     (oset this
-	  :marker-acc (concat
-		       (oref this :marker-acc)
-		       (string-make-unibyte input)))
+          :marker-acc (concat
+                       (oref this :marker-acc)
+                       (string-make-unibyte input)))
 
     ;; (message (format "<acc-start>%s<acc-end>" (oref this :marker-acc)))
 
     (jdee-jdb-fixup-output this)
 
     (let* ((marker-regexp (oref this :marker-regexp))
-	   (marker-regexp-class-index (oref this :class-index))
-	   (marker-regexp-line-index (oref this :line-index)))
+           (marker-regexp-class-index (oref this :class-index))
+           (marker-regexp-line-index (oref this :line-index)))
 
       ;; (message (concat "jdb output:" input))
       ;; (message (concat "acc = " jdee-db-marker-acc))
 
       ;; Process all the complete markers in this chunk.
       (if (string-match marker-regexp (oref this :marker-acc))
-	  ;; Extract the frame position from the marker.
-	  (let ((premarker (substring
-			    (oref this :marker-acc) 0 (match-beginning 0)))
-		(marker (substring (oref this :marker-acc)
-				   (match-beginning 0) (match-end 0)))
-		(rest (substring (oref this :marker-acc) (match-end 0)))
-		(class (substring
-			(oref this :marker-acc)
-			(match-beginning marker-regexp-class-index)
-			(match-end marker-regexp-class-index)))
-		(line-no (jdee-jdb-string-to-int
-			  (substring
-			   (oref this :marker-acc)
-			   (match-beginning marker-regexp-line-index)
-			   (match-end marker-regexp-line-index))))
-		(package ""))
-	    ;; Extract package path from input.
-	    (let ((case-fold-search nil)) ;; Make sure search is case-sensitive
-	      (and (string-match (jdee-jdb-make-qualified-class-name-regexp class) marker)
-		   (setq package
-			 (substring marker (match-beginning 2) (match-end 2))))
+          ;; Extract the frame position from the marker.
+          (let ((premarker (substring
+                            (oref this :marker-acc) 0 (match-beginning 0)))
+                (marker (substring (oref this :marker-acc)
+                                   (match-beginning 0) (match-end 0)))
+                (rest (substring (oref this :marker-acc) (match-end 0)))
+                (class (substring
+                        (oref this :marker-acc)
+                        (match-beginning marker-regexp-class-index)
+                        (match-end marker-regexp-class-index)))
+                (line-no (jdee-jdb-string-to-int
+                          (substring
+                           (oref this :marker-acc)
+                           (match-beginning marker-regexp-line-index)
+                           (match-end marker-regexp-line-index))))
+                (package ""))
+            ;; Extract package path from input.
+            (let ((case-fold-search nil)) ;; Make sure search is case-sensitive
+              (and (string-match (jdee-jdb-make-qualified-class-name-regexp class) marker)
+                   (setq package
+                         (substring marker (match-beginning 2) (match-end 2))))
 
-	       ;; (message "jdee-db package: %s. marker = %s" jdee-db-last-package marker)
-	       ;;(message "case-fold-search = %s" (if case-fold-search "true" "false"))
-	      )
+               ;; (message "jdee-db package: %s. marker = %s" jdee-db-last-package marker)
+               ;;(message "case-fold-search = %s" (if case-fold-search "true" "false"))
+              )
 
-	    ;; Insert debugger output into debugger buffer.
-	    (setq output (concat premarker marker))
+            ;; Insert debugger output into debugger buffer.
+            (setq output (concat premarker marker))
 
-	    ;; Set the accumulator to the remaining text.
-	    (oset this :marker-acc rest)
+            ;; Set the accumulator to the remaining text.
+            (oset this :marker-acc rest)
 
-	    (jdee-db-set-debug-cursor
-	     (concat package class) (concat class ".java") line-no)
+            (jdee-db-set-debug-cursor
+             (concat package class) (concat class ".java") line-no)
 
-	    (let* ((debuggee (oref jdb debuggee))
-		   (status (oref debuggee status)))
-	      (oset status stopped-p t)))))
+            (let* ((debuggee (oref jdb debuggee))
+                   (status (oref debuggee status)))
+              (oset status stopped-p t)))))
 
    ;; Handle case where there is no line number info in current class.
     (if (string-match (oref this noline-regexp) (oref this marker-acc))
-	(let ((premarker (substring
-			  (oref this :marker-acc) 0 (match-beginning 0)))
-	      (marker (substring (oref this :marker-acc)
-				 (match-beginning 0) (match-end 0)))
-	      (pc (substring (oref this :marker-acc)
-			     (match-beginning 1) (match-end 1)))
-	      (rest (substring (oref this :marker-acc) (match-end 0))))
+        (let ((premarker (substring
+                          (oref this :marker-acc) 0 (match-beginning 0)))
+              (marker (substring (oref this :marker-acc)
+                                 (match-beginning 0) (match-end 0)))
+              (pc (substring (oref this :marker-acc)
+                             (match-beginning 1) (match-end 1)))
+              (rest (substring (oref this :marker-acc) (match-end 0))))
 
-	  (setq output (concat premarker marker))
-	  (oset this :marker-acc rest)))
+          (setq output (concat premarker marker))
+          (oset this :marker-acc rest)))
 
     ;; Does the remaining text look like it might end with the
     ;; beginning of another marker?  If it does, then keep it in
@@ -818,19 +818,19 @@ expression at poing")
     ;; know the full marker regexp above failed, it's pretty simple to
     ;; test for marker starts.
     (if (string-match "\\(^Breakpoint hit:\\)\\|\\(^Step completed:\\)"
-		      (oref this :marker-acc))
-	(progn
-	;; Everything before the potential marker start can be output.
-	  (setq output (concat output
-			       (substring (oref this :marker-acc)
-					  0 (match-beginning 0))))
+                      (oref this :marker-acc))
+        (progn
+        ;; Everything before the potential marker start can be output.
+          (setq output (concat output
+                               (substring (oref this :marker-acc)
+                                          0 (match-beginning 0))))
 
-	  ;; Everything after, we save, to combine with later input.
-	  (oset this
-		:marker-acc
-		(substring (oref this :marker-acc) (match-beginning 0))))
+          ;; Everything after, we save, to combine with later input.
+          (oset this
+                :marker-acc
+                (substring (oref this :marker-acc) (match-beginning 0))))
       (setq output
-	    (concat output (oref this :marker-acc)))
+            (concat output (oref this :marker-acc)))
       (oset this :marker-acc ""))
 
     (jdee-jdb-set-breakpoint-listener this output)
@@ -844,10 +844,10 @@ expression at poing")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-jdb-stack-listener (jdee-db-listener)
   ((stack-depth     :initarg :stack-depth
-		    :type string
-		    :initform ""
-		    :documentation
-		    "Stack depth."))
+                    :type string
+                    :initform ""
+                    :documentation
+                    "Stack depth."))
   "Listens for changes in the current stack frame.")
 
 
@@ -868,9 +868,9 @@ expression at poing")
 ;; stack index portion of its prompt.
 (defmethod jdee-db-listener-filter-output ((this jdee-jdb-stack-listener) output)
   (let* ((jdb (oref this debugger))
-	 (debuggee (oref jdb debuggee)))
+         (debuggee (oref jdb debuggee)))
     (if (string-match "^[-a-zA-Z0-9_$ -]+\\[\\([0-9]*,?[0-9]+\\)\\] " output)
-	(oset debuggee :stack-depth (match-string 1 output)))
+        (oset debuggee :stack-depth (match-string 1 output)))
     output))
 
 
@@ -908,18 +908,18 @@ expression at poing")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass jdee-db-jdb (jdee-db-debugger)
   ((exec-name       :initarg :exec-name
-		    :type string
-		    :initform "jdb"
-		    :documentation
-		    "Name of the jdb executable.")
+                    :type string
+                    :initform "jdb"
+                    :documentation
+                    "Name of the jdb executable.")
    (path            :initarg :path
-		    :type string
-		    :initform "jdb"
-		    :documentation
-		    "Path of the jdb executable.")
+                    :type string
+                    :initform "jdb"
+                    :documentation
+                    "Path of the jdb executable.")
    (bp-listener     :initarg :bp-listener
-		    :type jdee-jdb-breakpoint-listener
-		    :documentation "Breakpoint listener."))
+                    :type jdee-jdb-breakpoint-listener
+                    :documentation "Breakpoint listener."))
   (:allow-nil-initform t)
 "Class of generic jdb debuggers")
 
@@ -948,23 +948,23 @@ expression at poing")
   (oset
    this
    :debuggee (jdee-jdb-debuggee-app
-	      (concat "Application: " main-class)
-	      :main-class main-class)))
+              (concat "Application: " main-class)
+              :main-class main-class)))
 
 (defmethod jdee-db-create-debuggee-applet ((this jdee-db-jdb) applet-doc)
   (oset
    this
    :debuggee (jdee-jdb-debuggee-applet
-	      (concat "Applet: " applet-doc)
-	      :doc applet-doc)))
+              (concat "Applet: " applet-doc)
+              :doc applet-doc)))
 
 (defmethod jdee-db-jdb-start ((this jdee-db-jdb) prog-args cmdstr)
   "Start the debugger."
   (let ((w32-quote-process-args ?\")
-	(win32-quote-process-args ?\") ;; XEmacs
-	(source-directory default-directory)
-	(working-directory
-	 (jdee-db-debugger-get-working-dir this)))
+        (win32-quote-process-args ?\") ;; XEmacs
+        (source-directory default-directory)
+        (working-directory
+         (jdee-db-debugger-get-working-dir this)))
 
     (oset this :buffer (get-buffer-create (oref this :buffer-name)))
 
@@ -983,13 +983,13 @@ expression at poing")
 
       (let ((process-connection-type nil))
        (comint-exec (oref this :buffer)
-		   (oref this :buffer-name)
-		   (oref this :path)
-		   nil
-		   prog-args))
+                   (oref this :buffer-name)
+                   (oref this :path)
+                   nil
+                   prog-args))
 
       (oset this process
-	    (get-buffer-process (oref this buffer)))
+            (get-buffer-process (oref this buffer)))
 
       (cd source-directory)
 
@@ -1009,84 +1009,84 @@ expression at poing")
        (not (oref this :buffer))
        (not (comint-check-proc (oref this :buffer))))
       (let* ((debuggee (oref this debuggee))
-	     (source-directory default-directory)
-	     (connector (oref debuggee connector))
-	     (working-directory
-	      (jdee-db-debugger-get-working-dir this))
-	     (prog-args
-	      (if (typep connector 'jdee-db-listen-connector)
-		  (if (typep connector 'jdee-db-socket-connector)
-		      (list
-		       "-connect"
-		       (format
-			"com.sun.jdi.SocketListen:port=%s"
-			(oref connector port)))
-		    (if (typep connector 'jdee-db-shared-memory-connector)
-			(list
-			 "-connect"
-			 (format
-			  "com.sun.jdi.SharedMemoryListen:name=%s"
-			  (oref connector name)))
-		      (error "Invalid connector type.")))
-		(if (typep connector 'jdee-db-attach-connector)
-		    (if (typep connector 'jdee-db-socket-connector)
-			(let ((host (oref connector host))
-			      (port (oref connector port)))
-			  (if host
-			      (list
-			       "-connect"
-			       (format
-				"com.sun.jdi.SocketAttach:hostname=%s,port=%s"
-				host port))
-			  (list
-			   "-connect"
-			   (format
-			    "com.sun.jdi.SocketAttach:port=%s"
-			    port))))
-		    (if (typep connector 'jdee-db-shared-memory-connector)
-			(list
-			 "-connect"
-			 (format
-			  "com.sun.jdi.SharedMemoryAttach:name=%s"
-			  (oref connector name)))
-		      (error "Invalid connector type."))))))
-	     (command-string
-	      (format "%s %s\n\n"
-	       (oref this :path)
-	       (mapconcat (lambda (x) x) prog-args " "))))
+             (source-directory default-directory)
+             (connector (oref debuggee connector))
+             (working-directory
+              (jdee-db-debugger-get-working-dir this))
+             (prog-args
+              (if (typep connector 'jdee-db-listen-connector)
+                  (if (typep connector 'jdee-db-socket-connector)
+                      (list
+                       "-connect"
+                       (format
+                        "com.sun.jdi.SocketListen:port=%s"
+                        (oref connector port)))
+                    (if (typep connector 'jdee-db-shared-memory-connector)
+                        (list
+                         "-connect"
+                         (format
+                          "com.sun.jdi.SharedMemoryListen:name=%s"
+                          (oref connector name)))
+                      (error "Invalid connector type.")))
+                (if (typep connector 'jdee-db-attach-connector)
+                    (if (typep connector 'jdee-db-socket-connector)
+                        (let ((host (oref connector host))
+                              (port (oref connector port)))
+                          (if host
+                              (list
+                               "-connect"
+                               (format
+                                "com.sun.jdi.SocketAttach:hostname=%s,port=%s"
+                                host port))
+                          (list
+                           "-connect"
+                           (format
+                            "com.sun.jdi.SocketAttach:port=%s"
+                            port))))
+                    (if (typep connector 'jdee-db-shared-memory-connector)
+                        (list
+                         "-connect"
+                         (format
+                          "com.sun.jdi.SharedMemoryAttach:name=%s"
+                          (oref connector name)))
+                      (error "Invalid connector type."))))))
+             (command-string
+              (format "%s %s\n\n"
+               (oref this :path)
+               (mapconcat (lambda (x) x) prog-args " "))))
 
-	(oset
-	 this
-	 :buffer-name
-	 (if (typep connector 'jdee-db-shared-memory-connector)
-	     (format "*debug %s* debugee-shmem-name" (oref connector name))
-	   (format
-	    "*debug %s:%s*"
-	    (if (or (typep connector 'jdee-db-listen-connector)
-		    (not (oref connector port)))
-		"localhost" (oref connector host))
-	    (oref connector port))))
+        (oset
+         this
+         :buffer-name
+         (if (typep connector 'jdee-db-shared-memory-connector)
+             (format "*debug %s* debugee-shmem-name" (oref connector name))
+           (format
+            "*debug %s:%s*"
+            (if (or (typep connector 'jdee-db-listen-connector)
+                    (not (oref connector port)))
+                "localhost" (oref connector host))
+            (oref connector port))))
 
-	(oset this :buffer (get-buffer-create (oref this :buffer-name)))
+        (oset this :buffer (get-buffer-create (oref this :buffer-name)))
 
-	;; Forward to the debugger any breakpoint requests made
-	;; by the user before launching the application.
-	(if jdee-db-breakpoints
-	    (let ((bp-cmd (oref (oref this cmd-set) set-bp)))
-	      (oset
-	       bp-cmd
-	       breakpoints
-	       (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
+        ;; Forward to the debugger any breakpoint requests made
+        ;; by the user before launching the application.
+        (if jdee-db-breakpoints
+            (let ((bp-cmd (oref (oref this cmd-set) set-bp)))
+              (oset
+               bp-cmd
+               breakpoints
+               (mapcar (lambda (assoc-x) (cdr assoc-x)) jdee-db-breakpoints))
 
-	      (oset this next-cmd
-		    (append (oref this next-cmd) (list bp-cmd)))))
+              (oset this next-cmd
+                    (append (oref this next-cmd) (list bp-cmd)))))
 
-	(jdee-db-jdb-start this prog-args command-string)
+        (jdee-db-jdb-start this prog-args command-string)
 
-	(let* ((debuggee (oref this debuggee))
-	       (debuggee-status (oref debuggee status)))
-	  (oset debuggee-status running-p t)
-	  (oset debuggee-status stopped-p t)))
+        (let* ((debuggee (oref this debuggee))
+               (debuggee-status (oref debuggee status)))
+          (oset debuggee-status running-p t)
+          (oset debuggee-status stopped-p t)))
     (progn
       (message "An instance of %s is running." (oref this :buffer-name))
       (pop-to-buffer (oref this :buffer-name)))))
@@ -1097,7 +1097,7 @@ expression at poing")
 when the jdb process terminates."
   (call-next-method)
   (let* ((debuggee (oref this debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee-status (oref debuggee status)))
     (oset this running-p nil)
     (oset debuggee-status running-p nil)
     (oset debuggee-status stopped-p nil)
@@ -1119,7 +1119,7 @@ when the jdb process terminates."
      (jdee-db-get-app-args-from-user)))
    ((typep (oref this debuggee) 'jdee-db-debuggee-applet)
     (list "-debug"
-	  (oref (oref this debuggee) doc)))
+          (oref (oref this debuggee) doc)))
    (t
     (error "Unrecognized jdb debuggee type."))))
 
@@ -1222,25 +1222,25 @@ current project."
      ((string= (car jdee-debugger) "jdb")
       (cond
        ((< (jdee-java-major-version) 2)
-	(cond
-	 ((< (jdee-java-minor-version) 2)
-	  (setq jdb (jdee-db-jdb-1-1 "jdb 1.1")))
-	 ((= (jdee-java-minor-version) 3)
-	  (setq jdb (jdee-db-jdb-1-3 "jdb 1.3")))
-	 ((= (jdee-java-minor-version) 4)
-	  (setq jdb (jdee-db-jdb-1-4 "jdb 1.4")))
-	 (t
-	  (setq jdb (jdee-db-jdb-1-6 "jdb 1.6")))))
+        (cond
+         ((< (jdee-java-minor-version) 2)
+          (setq jdb (jdee-db-jdb-1-1 "jdb 1.1")))
+         ((= (jdee-java-minor-version) 3)
+          (setq jdb (jdee-db-jdb-1-3 "jdb 1.3")))
+         ((= (jdee-java-minor-version) 4)
+          (setq jdb (jdee-db-jdb-1-4 "jdb 1.4")))
+         (t
+          (setq jdb (jdee-db-jdb-1-6 "jdb 1.6")))))
        (t
-	(setq jdb (jdee-db-jdb-1-6 "jdb 1.6")))))
+        (setq jdb (jdee-db-jdb-1-6 "jdb 1.6")))))
      ((string= (car jdee-debugger) "old jdb")
       (if (and (< (jdee-java-major-version) 2)
-	       (< (jdee-java-minor-version) 2))
-	  (setq jdb (jdee-db-jdb-1-1 "jdb 1.1"))
-	(setq jdb (jdee-db-old-jdb "old jdb"))))
+               (< (jdee-java-minor-version) 2))
+          (setq jdb (jdee-db-jdb-1-1 "jdb 1.1"))
+        (setq jdb (jdee-db-old-jdb "old jdb"))))
      (t
       (error "%s is not a valid jdb debugger choice."
-	     (car jdee-debugger))))
+             (car jdee-debugger))))
     (oset
      jdb
      :path (jdee-get-jdk-prog (oref jdb :exec-name)))
@@ -1250,12 +1250,12 @@ current project."
   (if jdee-db-option-connect-socket
       jdee-db-option-connect-socket
     (let ((host
-	   (read-from-minibuffer  "Debuggee host: " "local"))
-	  (port
-	   (read-from-minibuffer "Debuggee port: " "4444")))
+           (read-from-minibuffer  "Debuggee host: " "local"))
+          (port
+           (read-from-minibuffer "Debuggee port: " "4444")))
       (list
        (if (not (string= host "local"))
-	   host)
+           host)
        port))))
 
 
@@ -1281,27 +1281,27 @@ address specified by `jdee-db-option-connect-socket'. If this variable
 is nil, this command prompts you to enter the address."
   (interactive)
   (let* ((socket (jdee-jdb-get-socket-address))
-	 (host (nth 0 socket))
-	 (port (nth 1 socket)))
+         (host (nth 0 socket))
+         (port (nth 1 socket)))
     (if (string= port "")
-	(error "You must specify the port of the debuggee process.")
+        (error "You must specify the port of the debuggee process.")
       (let* ((debugger (jdee-jdb-get-jdb))
-	     (connector
-	      (jdee-db-socket-attach-connector
-	       "connector"
-	       :host host
-	       :port port))
-	     (debuggee
-	      (jdee-jdb-debuggee-app
-	      "debuggee"
-	      :main-class (format
-			   "Attached to socket %s:%s"
-			   (if host host "localhost")
-			   port)
-	      :connector connector)))
-	(oset debugger the-debugger debugger)
-	(oset debugger :debuggee debuggee)
-	(jdee-jdb-connect debugger)))))
+             (connector
+              (jdee-db-socket-attach-connector
+               "connector"
+               :host host
+               :port port))
+             (debuggee
+              (jdee-jdb-debuggee-app
+              "debuggee"
+              :main-class (format
+                           "Attached to socket %s:%s"
+                           (if host host "localhost")
+                           port)
+              :connector connector)))
+        (oset debugger the-debugger debugger)
+        (oset debugger :debuggee debuggee)
+        (jdee-jdb-connect debugger)))))
 
 
 (defun jdee-jdb-get-shared-memory-name ()
@@ -1336,22 +1336,22 @@ this variable is nil, this command prompts you to enter a name."
    "The debugger does not support shared memory connections on this platform.")
   (let ((shmem-name (jdee-jdb-get-shared-memory-name)))
     (if (string= shmem-name "")
-	(error "Shared memory name required.")
+        (error "Shared memory name required.")
       (let* ((debugger (jdee-jdb-get-jdb))
-	     (connector
-	      (jdee-db-shared-memory-attach-connector
-	       "connector"
-	       :name shmem-name))
-	     (debuggee
-	      (jdee-jdb-debuggee-app
-	       "debuggee"
-	       :main-class (format
-			    "Attached via shared memory: %s."
-			    shmem-name)
-	       :connector connector)))
-	(oset debugger the-debugger debugger)
-	(oset debugger :debuggee debuggee)
-	(jdee-jdb-connect debugger)))))
+             (connector
+              (jdee-db-shared-memory-attach-connector
+               "connector"
+               :name shmem-name))
+             (debuggee
+              (jdee-jdb-debuggee-app
+               "debuggee"
+               :main-class (format
+                            "Attached via shared memory: %s."
+                            shmem-name)
+               :connector connector)))
+        (oset debugger the-debugger debugger)
+        (oset debugger :debuggee debuggee)
+        (jdee-jdb-connect debugger)))))
 
 
 (defun jdee-jdb-get-socket-listen-port ()
@@ -1387,16 +1387,16 @@ any debuggee process started in debugger client mode, regardless of
 address."
   (interactive)
   (let* ((debugger (jdee-jdb-get-jdb))
-	 (port (jdee-jdb-get-socket-listen-port))
-	 (connector
-	   (jdee-db-socket-listen-connector
-	       "connector"
-	       :port port))
-	 (debuggee
-	  (jdee-jdb-debuggee-app
-	   "debuggee"
-	  :main-class (concat "Listening at port " port)
-	  :connector connector)))
+         (port (jdee-jdb-get-socket-listen-port))
+         (connector
+           (jdee-db-socket-listen-connector
+               "connector"
+               :port port))
+         (debuggee
+          (jdee-jdb-debuggee-app
+           "debuggee"
+          :main-class (concat "Listening at port " port)
+          :connector connector)))
     (oset debugger the-debugger debugger)
     (oset debugger :debuggee debuggee)
     (jdee-jdb-connect debugger)))
@@ -1430,16 +1430,16 @@ the debuggee process at (e.g., jdbconn)."
    (eq system-type 'windows-nt)
    "The debugger does not support shared memory connections on this platform.")
   (let* ((debugger (jdee-jdb-get-jdb))
-	 (name (jdee-jdb-get-shared-memory-name))
-	 (connector
-	   (jdee-db-shared-memory-listen-connector
-	       "connector"
-	       :name name))
-	 (debuggee
-	  (jdee-jdb-debuggee-app
-	   "debuggee"
-	  :main-class (concat "Listening to " name)
-	  :connector connector)))
+         (name (jdee-jdb-get-shared-memory-name))
+         (connector
+           (jdee-db-shared-memory-listen-connector
+               "connector"
+               :name name))
+         (debuggee
+          (jdee-jdb-debuggee-app
+           "debuggee"
+          :main-class (concat "Listening to " name)
+          :connector connector)))
     (oset debugger the-debugger debugger)
     (oset debugger :debuggee debuggee)
     (jdee-jdb-connect debugger)))
@@ -1449,25 +1449,25 @@ the debuggee process at (e.g., jdbconn)."
   (interactive "sExpression: ")
   (jdee-assert-source-or-debug-buffer)
   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-	 (debuggee (oref debugger debuggee))
-	 (debuggee-status (oref debuggee status)))
+         (debuggee (oref debugger debuggee))
+         (debuggee-status (oref debuggee status)))
     (if (and (oref debugger running-p)
-	     (oref debuggee-status stopped-p))
-	(let* ((cmd-set (oref debugger cmd-set))
-	       cmd)
-	  (cond ((string= "print" key)
+             (oref debuggee-status stopped-p))
+        (let* ((cmd-set (oref debugger cmd-set))
+               cmd)
+          (cond ((string= "print" key)
                  (setq cmd (oref cmd-set print)))
                 ((string= "dump" key)
                  (setq cmd (oref cmd-set dump)))
                 ((string= "eval" key)
                  (setq cmd (oref cmd-set eval)))
-		((string= "set" key)
+                ((string= "set" key)
                  (setq cmd (oref cmd-set set-var)))
                 ((string= "locals" key)
                  (setq cmd (oref cmd-set locals))))
-	  (jdee-db-exec-cmd debugger cmd))
+          (jdee-db-exec-cmd debugger cmd))
       (let ((class (oref debuggee main-class)))
-	(error "Application %s is not stopped" class)))))
+        (error "Application %s is not stopped" class)))))
 
 (defun jdee-jdb-print ()
   (interactive)
@@ -1492,13 +1492,13 @@ the debuggee process at (e.g., jdbconn)."
 (defun jdee-jdb-help ()
   (interactive)
   (let* ((jdee-dir (jdee-find-jdee-doc-directory))
-	 (jdb-ug-path
-	  (if jdee-dir
-	      (expand-file-name "doc/html/jdb-ug/jdb-ug-frame.html" jdee-dir))))
+         (jdb-ug-path
+          (if jdee-dir
+              (expand-file-name "doc/html/jdb-ug/jdb-ug-frame.html" jdee-dir))))
     (if (and
-	 jdb-ug-path
-	 (file-exists-p jdb-ug-path))
-	(browse-url (concat "file://" (jdee-convert-cygwin-path jdb-ug-path)))
+         jdb-ug-path
+         (file-exists-p jdb-ug-path))
+        (browse-url (concat "file://" (jdee-convert-cygwin-path jdb-ug-path)))
       (signal 'error '("Cannot find jdb user guide.")))))
 
 
@@ -1512,160 +1512,160 @@ the debuggee process at (e.g., jdbconn)."
 (defvar jdee-jdb-emacs-menu-spec
   (list "Jdb"
 
-	["Step Over"
+        ["Step Over"
          jdee-debug-step-over
          :active (jdee-db-debuggee-stopped-p)
          :help "Step over the next method."]
 
 
-	["Step Into"
-	 jdee-debug-step-into
-	 :active (jdee-db-debuggee-stopped-p)
-	 :help "Step into the next method."]
+        ["Step Into"
+         jdee-debug-step-into
+         :active (jdee-db-debuggee-stopped-p)
+         :help "Step into the next method."]
 
-	["Step Out"
-	 jdee-debug-step-out
-	 :active (jdee-db-debuggee-stopped-p)
-	 :help "Step out of the current method."]
+        ["Step Out"
+         jdee-debug-step-out
+         :active (jdee-db-debuggee-stopped-p)
+         :help "Step out of the current method."]
 
-	["Run"
-	 jdee-debug-run
-	 :active   (and
-		    (slot-boundp 'jdee-db-debugger 'the-debugger)
-		    (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-			   (debuggee (oref debugger debuggee))
-			   (debuggee-status (oref debuggee status)))
-		      (and (oref debugger running-p)
-			   (not (oref debuggee-status running-p)))))
+        ["Run"
+         jdee-debug-run
+         :active   (and
+                    (slot-boundp 'jdee-db-debugger 'the-debugger)
+                    (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                           (debuggee (oref debugger debuggee))
+                           (debuggee-status (oref debuggee status)))
+                      (and (oref debugger running-p)
+                           (not (oref debuggee-status running-p)))))
 
-	 :included (or
-		    (not (slot-boundp 'jdee-db-debugger 'the-debugger))
-		    (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-			   (debuggee (oref debugger debuggee))
-			   (debuggee-status (oref debuggee status)))
-		      (or (not (oref debugger running-p))
-			  (not (oref debuggee-status running-p)))))
-	 :help "Start the current program."]
+         :included (or
+                    (not (slot-boundp 'jdee-db-debugger 'the-debugger))
+                    (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                           (debuggee (oref debugger debuggee))
+                           (debuggee-status (oref debuggee status)))
+                      (or (not (oref debugger running-p))
+                          (not (oref debuggee-status running-p)))))
+         :help "Start the current program."]
 
-	["Continue"
-	 jdee-debug-cont
-	 :active   (or
-		    (jdee-db-debuggee-stopped-p)
-		    (jdee-db-debuggee-suspended-p))
+        ["Continue"
+         jdee-debug-cont
+         :active   (or
+                    (jdee-db-debuggee-stopped-p)
+                    (jdee-db-debuggee-suspended-p))
 
-	 :included  (jdee-db-debuggee-running-p)
-	 :help "Continue the current program."]
+         :included  (jdee-db-debuggee-running-p)
+         :help "Continue the current program."]
 
-	["Quit"
-	 jdee-debug-quit
-	 :active  (jdee-db-debuggee-running-p)
-	 :help "Terminate the current debugging session."]
+        ["Quit"
+         jdee-debug-quit
+         :active  (jdee-db-debuggee-running-p)
+         :help "Terminate the current debugging session."]
 
-	"-"
+        "-"
 
-	["Toggle Breakpoint"
-	 jdee-debug-toggle-breakpoint
-	 :active t
-	 :help "Set (or remove) a breakpoint at the current line."]
+        ["Toggle Breakpoint"
+         jdee-debug-toggle-breakpoint
+         :active t
+         :help "Set (or remove) a breakpoint at the current line."]
 
-	["Clear Breakpoints"
-	 jdee-debug-clear-breakpoints
-	 :active  jdee-db-breakpoints
-	 :help "Remove all breakpoints."]
+        ["Clear Breakpoints"
+         jdee-debug-clear-breakpoints
+         :active  jdee-db-breakpoints
+         :help "Remove all breakpoints."]
 
-	["List Breakpoints"
-	 jdee-debug-list-breakpoints
-	 :active  jdee-db-breakpoints
-	 :help "Display a list of breakpoints."]
+        ["List Breakpoints"
+         jdee-debug-list-breakpoints
+         :active  jdee-db-breakpoints
+         :help "Display a list of breakpoints."]
 
-	"-"
+        "-"
 
-	(list
-	 "Display"
+        (list
+         "Display"
 
-	 ["Expression"
-	  jdee-jdb-print
-	  :active  (jdee-db-debuggee-stopped-p)
-	  :help "Evaluate an expression and display the results."]
+         ["Expression"
+          jdee-jdb-print
+          :active  (jdee-db-debuggee-stopped-p)
+          :help "Evaluate an expression and display the results."]
 
-	 ["Object"
-	  jdee-jdb-dump
-	  :active  (jdee-db-debuggee-stopped-p)
-	  :help "Display the fields of an object referenced by a variable."]
+         ["Object"
+          jdee-jdb-dump
+          :active  (jdee-db-debuggee-stopped-p)
+          :help "Display the fields of an object referenced by a variable."]
 
 
-	 ["Locals"
-	  jdee-jdb-locals
-	  :active  (jdee-db-debuggee-stopped-p)
-	  :help "Display the variables in scope at the current line."]
-	 )
+         ["Locals"
+          jdee-jdb-locals
+          :active  (jdee-db-debuggee-stopped-p)
+          :help "Display the variables in scope at the current line."]
+         )
 
         ["Set Variable"
          jdee-jdb-set
          :active  (jdee-db-debuggee-stopped-p)
          :help "Change the value of an in-scope variable."]
 
-	(list
-	 "Stack"
+        (list
+         "Stack"
 
-	 ["Up"
-	  jdee-debug-up
-	  :active  (jdee-db-debuggee-stopped-p)
-	  :help "Move the debug cursor up the method call stack."]
+         ["Up"
+          jdee-debug-up
+          :active  (jdee-db-debuggee-stopped-p)
+          :help "Move the debug cursor up the method call stack."]
 
-	 ["Down"
-	  jdee-debug-down
-	  :active (and
-		   (jdee-db-debuggee-stopped-p)
-		   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
-			  (debuggee (oref debugger debuggee)))
-		     (> (jdee-jdb-string-to-int
-			 (oref debuggee :stack-depth)) 1)))
-	  :help "Move the debug cursor down the method call stack." ]
+         ["Down"
+          jdee-debug-down
+          :active (and
+                   (jdee-db-debuggee-stopped-p)
+                   (let* ((debugger (oref-default 'jdee-db-debugger the-debugger))
+                          (debuggee (oref debugger debuggee)))
+                     (> (jdee-jdb-string-to-int
+                         (oref debuggee :stack-depth)) 1)))
+          :help "Move the debug cursor down the method call stack." ]
 
-	 ["Where"
-	  jdee-debug-where
-	  :active (jdee-db-debuggee-stopped-p)
-	  :help "Display the call stack."]
+         ["Where"
+          jdee-debug-where
+          :active (jdee-db-debuggee-stopped-p)
+          :help "Display the call stack."]
 
-	 )
-	"-"
-	(list
-	 "External Process"
-	 ["Attach Via Socket"
-	  jdee-jdb-attach-via-socket
-	  :active (not (jdee-db-debuggee-running-p))
-	  :help "Attach the debugger to an external process via a socket."]
-	 ["Attach Via Shared Memory"
-	  jdee-jdb-attach-via-shared-memory
-	  :active (and
-		   (eq system-type 'windows-nt)
-		   (not (jdee-db-debuggee-running-p)))
-	  :help "Attach the debugger to an external process via a shared memory connection."]
-	 ["Listen Via Socket"
-	  jdee-jdb-listen-via-socket
-	  :active (not (jdee-db-debuggee-running-p))
-	  :help "Listen at a socket for an external process."]
-	 ["Listen Via Shared Memory"
-	  jdee-jdb-listen-via-shared-memory
-	  :active (and
-		   (eq system-type 'windows-nt)
-		   (not (jdee-db-debuggee-running-p)))
-	  :help "Listen in shared memory for an external process."]
-	 )
-	"-"
+         )
+        "-"
+        (list
+         "External Process"
+         ["Attach Via Socket"
+          jdee-jdb-attach-via-socket
+          :active (not (jdee-db-debuggee-running-p))
+          :help "Attach the debugger to an external process via a socket."]
+         ["Attach Via Shared Memory"
+          jdee-jdb-attach-via-shared-memory
+          :active (and
+                   (eq system-type 'windows-nt)
+                   (not (jdee-db-debuggee-running-p)))
+          :help "Attach the debugger to an external process via a shared memory connection."]
+         ["Listen Via Socket"
+          jdee-jdb-listen-via-socket
+          :active (not (jdee-db-debuggee-running-p))
+          :help "Listen at a socket for an external process."]
+         ["Listen Via Shared Memory"
+          jdee-jdb-listen-via-shared-memory
+          :active (and
+                   (eq system-type 'windows-nt)
+                   (not (jdee-db-debuggee-running-p)))
+          :help "Listen in shared memory for an external process."]
+         )
+        "-"
 
-	["Preferences"
-	 jdee-bug-show-preferences
-	 :active nil
-	 :help "Not yet implemented."]
+        ["Preferences"
+         jdee-bug-show-preferences
+         :active nil
+         :help "Not yet implemented."]
 
-	"-"
-	["Help"
-	 jdee-jdb-help
-	 :active t
-	 :help "Display the JDEE's jdb user's guide in an HTML browser."]
-	)
+        "-"
+        ["Help"
+         jdee-jdb-help
+         :active t
+         :help "Display the JDEE's jdb user's guide in an HTML browser."]
+        )
   "Defines the Jdb menu for Emacs.")
 
 (defvar jdee-jdb-mode-map
@@ -1684,18 +1684,18 @@ the debuggee process at (e.g., jdbconn)."
 ;; (fmakunbound 'jdee-jdb-key-bindings)
 (defcustom jdee-jdb-key-bindings
   (list (cons "[?\C-c ?\C-a ?\C-s]" 'jdee-debug-step-over)
-	(cons "[?\C-c ?\C-a ?\C-n]" 'jdee-debug-step-into)
-	(cons "[?\C-c ?\C-a ?\C-o]" 'jdee-debug-step-out)
-	(cons "[?\C-c ?\C-a ?\C-c]" 'jdee-debug-cont)
-	(cons "[?\C-c ?\C-a ?\C-r]" 'jdee-debug-run)
-	(cons "[?\C-c ?\C-a ?\C-b]" 'jdee-debug-toggle-breakpoint)
-	(cons "[?\C-c ?\C-a ?\C-u]" 'jdee-debug-up)
-	(cons "[?\C-c ?\C-a ?\C-d]" 'jdee-debug-down)
-	(cons "[?\C-c ?\C-a ?\C-p]" 'jdee-jdb-print)
-	(cons "[?\C-c ?\C-a ?\C-x]" 'jdee-jdb-dump)
-	(cons "[?\C-c ?\C-a ?\C-e]" 'jdee-jdb-eval)
-	(cons "[?\C-c ?\C-a ?\C-v]" 'jdee-jdb-set)
-	(cons "[?\C-c ?\C-a ?\C-l]" 'jdee-jdb-locals))
+        (cons "[?\C-c ?\C-a ?\C-n]" 'jdee-debug-step-into)
+        (cons "[?\C-c ?\C-a ?\C-o]" 'jdee-debug-step-out)
+        (cons "[?\C-c ?\C-a ?\C-c]" 'jdee-debug-cont)
+        (cons "[?\C-c ?\C-a ?\C-r]" 'jdee-debug-run)
+        (cons "[?\C-c ?\C-a ?\C-b]" 'jdee-debug-toggle-breakpoint)
+        (cons "[?\C-c ?\C-a ?\C-u]" 'jdee-debug-up)
+        (cons "[?\C-c ?\C-a ?\C-d]" 'jdee-debug-down)
+        (cons "[?\C-c ?\C-a ?\C-p]" 'jdee-jdb-print)
+        (cons "[?\C-c ?\C-a ?\C-x]" 'jdee-jdb-dump)
+        (cons "[?\C-c ?\C-a ?\C-e]" 'jdee-jdb-eval)
+        (cons "[?\C-c ?\C-a ?\C-v]" 'jdee-jdb-set)
+        (cons "[?\C-c ?\C-a ?\C-l]" 'jdee-jdb-locals))
   "*Specifies key bindings for jdb debug commands.
 The value of this variable is an association list. The car of
 each element specifies a key sequence. The cdr specifies
@@ -1706,32 +1706,32 @@ bound, type C-q C-s in the key field in the customization buffer.
 You can use the notation [f1], [f2], etc., to specify function keys."
   :group 'jdee-project
   :type '(repeat
-	  (cons :tag "Key binding"
-	   (string :tag "Key")
-	   (function :tag "Command")))
+          (cons :tag "Key binding"
+           (string :tag "Key")
+           (function :tag "Command")))
   :set '(lambda (sym val)
-	  ;; Unmap existing key bindings
-	  (if (and
-	       (boundp 'jdee-jdb-key-bindings)
-	       jdee-jdb-key-bindings)
-	      (mapc
-	       (lambda (binding)
-		 (let ((key (car binding))
-		       (fcn (cdr binding)))
-		   (if (string-match "\\[.+]" key)
-		       (setq key (car (read-from-string key))))
-		   (define-key jdee-jdb-mode-map key nil)))
-	       jdee-jdb-key-bindings))
-	  ;; Map new key bindings.
-	  (mapc
-	   (lambda (binding)
-	     (let ((key (car binding))
-		   (fcn (cdr binding)))
-	       (if (string-match "\\[.+]" key)
-		   (setq key (car (read-from-string key))))
-	       (define-key jdee-jdb-mode-map key fcn)))
-	   val)
-	  (set-default sym val)))
+          ;; Unmap existing key bindings
+          (if (and
+               (boundp 'jdee-jdb-key-bindings)
+               jdee-jdb-key-bindings)
+              (mapc
+               (lambda (binding)
+                 (let ((key (car binding))
+                       (fcn (cdr binding)))
+                   (if (string-match "\\[.+]" key)
+                       (setq key (car (read-from-string key))))
+                   (define-key jdee-jdb-mode-map key nil)))
+               jdee-jdb-key-bindings))
+          ;; Map new key bindings.
+          (mapc
+           (lambda (binding)
+             (let ((key (car binding))
+                   (fcn (cdr binding)))
+               (if (string-match "\\[.+]" key)
+                   (setq key (car (read-from-string key))))
+               (define-key jdee-jdb-mode-map key fcn)))
+           val)
+          (set-default sym val)))
 
 (defun jdee-jdb-string-to-int (number)
   "This method removes punctuation from a string, e.g, 1,200 (1.200 in Danish),

--- a/jdee-jdk-manager.el
+++ b/jdee-jdk-manager.el
@@ -34,36 +34,36 @@
   "Get the version of the Java VM on the system command path."
   (if (not jdee-java-version-cache)
       (let ((buf (get-buffer-create "java version"))
-	    proc)
-	(with-current-buffer buf
-	  (setq proc
-		(start-process
-		 "java version" buf "java" "-version"))
-	  (set-process-query-on-exit-flag proc nil)
-	  (accept-process-output proc 10)
-	  (goto-char (point-min))
+            proc)
+        (with-current-buffer buf
+          (setq proc
+                (start-process
+                 "java version" buf "java" "-version"))
+          (set-process-query-on-exit-flag proc nil)
+          (accept-process-output proc 10)
+          (goto-char (point-min))
           (re-search-forward "[1-9]\\([.][1-9]\\)?" (point-max) t)
-	  (setq jdee-java-version-cache (match-string 0)))
-	(kill-buffer buf)))
+          (setq jdee-java-version-cache (match-string 0)))
+        (kill-buffer buf)))
   jdee-java-version-cache)
 
 (defun jdee-java-version ()
   "Get the version of Java used by the JDEE."
   (interactive)
   (let ((java-version (if jdee-jdk (car jdee-jdk)
-			(getenv
-			 (nth 0 jdee-java-environment-variables)))))
+                        (getenv
+                         (nth 0 jdee-java-environment-variables)))))
     (if (not java-version)
-	(if jdee-java-version-cache
-	    (setq java-version jdee-java-version-cache)
-	  (if (jdee-backend-running-p)
-	      (progn
-		(setq jdee-java-version-cache
+        (if jdee-java-version-cache
+            (setq java-version jdee-java-version-cache)
+          (if (jdee-backend-running-p)
+              (progn
+                (setq jdee-java-version-cache
                       (jdee-backend-get-java-version))
-		(setq java-version jdee-java-version-cache))
-	    (setq java-version (jdee-java-version-via-java)))))
+                (setq java-version jdee-java-version-cache))
+            (setq java-version (jdee-java-version-via-java)))))
     (if (called-interactively-p 'interactive)
-	(message java-version)
+        (message java-version)
       java-version)))
 
 (defun jdee-java-major-version ()
@@ -93,23 +93,23 @@ by the current project."
 (defun jdee--jdk-set-dir-type (sym val)
   (if val
       (let ((type
-	     (list
-	      (quote radio-button-choice)
-	      )))
-	(loop for jdk in val do
-	      (setq
-	       type
-	       (append
-		type
-		(list (list (quote item) (car jdk))))))
-	(put 'jdee-jdk
-	     'custom-type
-	     (list (quote list) type))
-	(put 'jdee-jdk 'customized-value nil)
-	(put 'jdee-jdk
-	     'standard-value
-	     (list (list (quote list) (car (car val)))))
-	(customize-set-value 'jdee-jdk (list (car (car val)))))
+             (list
+              (quote radio-button-choice)
+              )))
+        (loop for jdk in val do
+              (setq
+               type
+               (append
+                type
+                (list (list (quote item) (car jdk))))))
+        (put 'jdee-jdk
+             'custom-type
+             (list (quote list) type))
+        (put 'jdee-jdk 'customized-value nil)
+        (put 'jdee-jdk
+             'standard-value
+             (list (list (quote list) (car (car val)))))
+        (customize-set-value 'jdee-jdk (list (car (car val)))))
     (progn
       (put 'jdee-jdk 'custom-type 'symbol)
       (put 'jdee-jdk 'standard-value nil)
@@ -123,12 +123,12 @@ by the current project."
   (let (dirs)
     (dolist (path paths dirs)
       (let ((all-files (ignore-errors (directory-files path t))))
-	(setq all-files (delete (concat path "/" ".") all-files))
-	(setq all-files (delete (concat path "/" "..") all-files))
-	(dolist (f all-files dirs)
-	  (when (and (file-directory-p f)
-		     (not (file-symlink-p f)))
-	    (setq dirs (cons f dirs))))))))
+        (setq all-files (delete (concat path "/" ".") all-files))
+        (setq all-files (delete (concat path "/" "..") all-files))
+        (dolist (f all-files dirs)
+          (when (and (file-directory-p f)
+                     (not (file-symlink-p f)))
+            (setq dirs (cons f dirs))))))))
 
 (defun jdee--jdk-p (path)
   "Return t if given `PATH' is path to JDK (has Java compiler)."
@@ -157,16 +157,16 @@ Mac OS X default."
   (let (version dir)
     (when (file-executable-p "/usr/libexec/java_home")
       (setq dir (substring (shell-command-to-string "/usr/libexec/java_home")
-			   0 -1))
+                           0 -1))
       (if (string-match "\\(1\\.[45678]\\)\\.[0-9]" dir)
-	  (setq version (match-string 1 dir))))
+          (setq version (match-string 1 dir))))
     (and version dir (list (cons version dir)))))
 
 (defun jdee--jdk-newest-first (jdks)
   "Sort `JDKS' ordering from newest to oldest or nil when empty."
   (sort jdks
-	(lambda (c1 c2) ; Compare only versions:
-	  (string< (first c2) (first c1)))))
+        (lambda (c1 c2) ; Compare only versions:
+          (string< (first c2) (first c1)))))
 
 (defun jdee--jdk-find-linux-jdk ()
   "Return a (VERSION . DIR) pair or nil when not found."
@@ -177,19 +177,19 @@ Mac OS X default."
 
     (dolist (dir (jdee--jdk-find-dirs '("/usr/lib/jvm" "/usr/lib64/jvm")))
       (let ((version (jdee--jdk-get-version dir)))
-	(when (and version (jdee--jdk-p dir))
-	  (setq jdks (cons (cons version dir) jdks)))))
+        (when (and version (jdee--jdk-p dir))
+          (setq jdks (cons (cons version dir) jdks)))))
 
     ;; On Linux use the default javac if it is installed.
     (let (version dir)
       (when (file-executable-p "/usr/bin/javac")
-	(let ((javac "/usr/bin/javac"))
-	  (while (file-symlink-p javac)
-	    (setq javac (file-symlink-p javac)))
-	  (setq dir (expand-file-name ".." (file-name-directory javac)))
-	  (setq version (jdee--jdk-get-version dir))))
+        (let ((javac "/usr/bin/javac"))
+          (while (file-symlink-p javac)
+            (setq javac (file-symlink-p javac)))
+          (setq dir (expand-file-name ".." (file-name-directory javac)))
+          (setq version (jdee--jdk-get-version dir))))
       (when (and version dir)
-	(setq jdks (cons (cons version dir) jdks))))
+        (setq jdks (cons (cons version dir) jdks))))
 
     ;; Path scan and /usr/bin/javac may resolve to the same values:
     (delete-dups jdks)
@@ -227,10 +227,10 @@ field. Setting this variable determines the choices offered by the
 first."
   :group 'jdee-project
   :type '(repeat
-	  (cons
-	   :tag "JDK"
-	   (string :tag "Version")
-	   (string :tag "Path")))
+          (cons
+           :tag "JDK"
+           (string :tag "Version")
+           (string :tag "Path")))
   :set 'jdee--jdk-set-dir-type)
 
 (defcustom jdee-java-environment-variables '("JAVA_VERSION" "JAVA_HOME")
@@ -240,14 +240,14 @@ If set, the `jdee-jdk' customization variable overrides the
 java enviroment variables."
   :group 'jdee-project
   :type '(list
-	  (string :tag "Java Version")
-	  (string :tag "Java Home")))
+          (string :tag "Java Version")
+          (string :tag "Java Home")))
 
 (defcustom jdee-jdk
   (if (and (null (getenv
-		  (nth 1
-		       jdee-java-environment-variables)))
-	   jdee-jdk-registry)
+                  (nth 1
+                       jdee-java-environment-variables)))
+           jdee-jdk-registry)
       (list (caar jdee-jdk-registry))
     nil)
   "Specifies the JDK version used to develop the current project.
@@ -292,46 +292,46 @@ function displays an error message."
    ;; make sure the directory exists
    (jdee-jdk
     (let* ((jdk-alias (car jdee-jdk))
-	   (registry-entry (assoc jdk-alias jdee-jdk-registry)))
+           (registry-entry (assoc jdk-alias jdee-jdk-registry)))
       (if (null registry-entry)
-	  (error (format
-		  "No mapping in the jdee-jdk-registry found for JDK version %s"
-		  jdk-alias))
-	;; check if directory exists. Originally this was only done if
-	;; the string was non-empty I'm not sure why, I have not
-	;; preserved that (shyamalprasad)
-	(let ((jdk-dir (substitute-in-file-name (cdr registry-entry))))
-	  (if (file-exists-p jdk-dir)
-	      jdk-dir
-	    (error (format "The path specified for JDK %s does not exist: %s"
-			   jdk-alias jdk-dir)))))))
+          (error (format
+                  "No mapping in the jdee-jdk-registry found for JDK version %s"
+                  jdk-alias))
+        ;; check if directory exists. Originally this was only done if
+        ;; the string was non-empty I'm not sure why, I have not
+        ;; preserved that (shyamalprasad)
+        (let ((jdk-dir (substitute-in-file-name (cdr registry-entry))))
+          (if (file-exists-p jdk-dir)
+              jdk-dir
+            (error (format "The path specified for JDK %s does not exist: %s"
+                           jdk-alias jdk-dir)))))))
 
    ;; otherwise use JAVA_HOME if set
    ((getenv (nth 1 jdee-java-environment-variables))
     (let ((jdk-dir (substitute-in-file-name
-		    (getenv (nth 1 jdee-java-environment-variables)))))
+                    (getenv (nth 1 jdee-java-environment-variables)))))
       (if (file-exists-p jdk-dir)
-	  jdk-dir
-	(error (format "The path specified by %s does not exist: %s"
-		       (nth 1 jdee-java-environment-variables) jdk-dir)))))
+          jdk-dir
+        (error (format "The path specified by %s does not exist: %s"
+                       (nth 1 jdee-java-environment-variables) jdk-dir)))))
 
    ;; otherwise, use Apple Java Policy on Mac OS X
    ((and (eq system-type 'darwin)
-	 (file-executable-p "/usr/libexec/java_home"))
+         (file-executable-p "/usr/libexec/java_home"))
     (substring (shell-command-to-string "/usr/libexec/java_home") 0 -1))
 
    ;; Otherwise default to java in $PATH
    (t
     (let* ((javac (executable-find "javac")))
       (if javac
-	  ;; follow symbolic links since gnu/linux systems might be
-	  ;; using /etc/alternatives to the final installation
-	  (let ((javac-symlink (file-symlink-p javac)))
-	    (while javac-symlink
-	      (setq javac javac-symlink)
-	      (setq javac-symlink (file-symlink-p javac)))
-	    (expand-file-name ".." (file-name-directory javac)))
-	(error "Cannot find the JDK directory.  See `jdee-jdk'"))))))
+          ;; follow symbolic links since gnu/linux systems might be
+          ;; using /etc/alternatives to the final installation
+          (let ((javac-symlink (file-symlink-p javac)))
+            (while javac-symlink
+              (setq javac javac-symlink)
+              (setq javac-symlink (file-symlink-p javac)))
+            (expand-file-name ".." (file-name-directory javac)))
+        (error "Cannot find the JDK directory.  See `jdee-jdk'"))))))
 
 (defun jdee-get-jdk-prog (progname)
   "Return the full path of the program `PROGNAME' passed in.
@@ -359,31 +359,31 @@ but if not, look in the environment's command path."
 Signals an error if it cannot find the jar."
   (let* ((jdk-dir (jdee-get-jdk-dir))
          (tools
-	  (expand-file-name
-	   (if (eq system-type 'darwin)
-	       (let ((classes-jar
-		      (cond
-		       ((file-exists-p
-			 (expand-file-name
-			  "Classes/classes.jar" jdk-dir))
-			"Classes/classes.jar")
-		       ((file-exists-p
-			 (expand-file-name
-			  "../Classes/classes.jar" jdk-dir))
-			"../Classes/classes.jar")
-		       ((file-exists-p
-			 (expand-file-name
-			  "bundle/Classes/classes.jar" jdk-dir))
-			"bundle/Classes/classes.jar")
-		       ;; starting with 1.7 (Oracle's JDK release) the
-		       ;; tools.jar location has become a little more
-		       ;; standardized
-		       (t "lib/tools.jar"))))
-		 classes-jar)
-	     "lib/tools.jar")
-	   jdk-dir)))
+          (expand-file-name
+           (if (eq system-type 'darwin)
+               (let ((classes-jar
+                      (cond
+                       ((file-exists-p
+                         (expand-file-name
+                          "Classes/classes.jar" jdk-dir))
+                        "Classes/classes.jar")
+                       ((file-exists-p
+                         (expand-file-name
+                          "../Classes/classes.jar" jdk-dir))
+                        "../Classes/classes.jar")
+                       ((file-exists-p
+                         (expand-file-name
+                          "bundle/Classes/classes.jar" jdk-dir))
+                        "bundle/Classes/classes.jar")
+                       ;; starting with 1.7 (Oracle's JDK release) the
+                       ;; tools.jar location has become a little more
+                       ;; standardized
+                       (t "lib/tools.jar"))))
+                 classes-jar)
+             "lib/tools.jar")
+           jdk-dir)))
     (if (file-exists-p tools)
-	tools
+        tools
       nil)))
 
 (provide 'jdee-jdk-manager)

--- a/jdee-juci.el
+++ b/jdee-juci.el
@@ -64,12 +64,12 @@ unavailable.")
 invocation."
   (or jdee-juci-has-proxy
       (and (not jdee-juci-checked-proxy)
-	   (condition-case nil
-	       (progn
-		 (setq jdee-juci-checked-proxy t)
-		 (jdee-jeval "java.lang.reflect.Proxy.class;")
-		 (setq jdee-juci-has-proxy t))
-	     (error (setq jdee-juci-has-proxy nil))))
+           (condition-case nil
+               (progn
+                 (setq jdee-juci-checked-proxy t)
+                 (jdee-jeval "java.lang.reflect.Proxy.class;")
+                 (setq jdee-juci-has-proxy t))
+             (error (setq jdee-juci-has-proxy nil))))
       (error "JDK version 1.3 or higher required for JUCI (needs java.lang.reflect.Proxy)")))
 
 (defun jdee-juci-invoke-java (java-class method-name &rest method-args)
@@ -87,9 +87,9 @@ method called `getStockPrice' (and an implementation in `TickerImpl'):
       public TickerImpl() {}
 
       public double getStockPrice(String symbol) {
-	  double price;
-	  // implementation details ...
-	  return price;
+          double price;
+          // implementation details ...
+          return price;
       }
   }
 
@@ -111,31 +111,31 @@ script is done by the function `jdee-juci-bshify-object'."
   (jdee-juci-check-proxy)
   (let ((cnt 0) converted-args arg-ptr)
     (jdee-juci-eval (concat jdee-juci-java-connection-name
-			   " = jde.juci.ConnectionFactory.getConnection("
-			   (jdee-juci-connection-class java-class)
-			   ", this, \""
-			   jdee-juci-java-connection-name "\");"))
+                           " = jde.juci.ConnectionFactory.getConnection("
+                           (jdee-juci-connection-class java-class)
+                           ", this, \""
+                           jdee-juci-java-connection-name "\");"))
     (condition-case err
-	(progn
-	  (jdee-juci-eval (concat jdee-juci-java-connection-name ".begin();"))
-	  (jdee-juci-setup-logger)
-	  (setq arg-ptr method-args)
-	  (while arg-ptr
-	    (setq converted-args (nconc converted-args
-					(list (jdee-juci-setup-method-arg (car arg-ptr) cnt))))
-	    (setq arg-ptr (cdr arg-ptr))
-	    (setq cnt (1+ cnt)))
-	  (if (null java-class)
-	      (jdee-juci-eval-r (concat jdee-juci-java-connection-name ".evalBshScript(\"" method-name
-				     "(" (mapconcat 'identity converted-args ",") ");\");"))
-	    (jdee-juci-eval-r (concat jdee-juci-java-connection-name "." method-name
-				   "(" (mapconcat 'identity converted-args ",") ");")))
-	  (jdee-juci-eval-r (concat jdee-juci-java-connection-name ".end();")))
+        (progn
+          (jdee-juci-eval (concat jdee-juci-java-connection-name ".begin();"))
+          (jdee-juci-setup-logger)
+          (setq arg-ptr method-args)
+          (while arg-ptr
+            (setq converted-args (nconc converted-args
+                                        (list (jdee-juci-setup-method-arg (car arg-ptr) cnt))))
+            (setq arg-ptr (cdr arg-ptr))
+            (setq cnt (1+ cnt)))
+          (if (null java-class)
+              (jdee-juci-eval-r (concat jdee-juci-java-connection-name ".evalBshScript(\"" method-name
+                                     "(" (mapconcat 'identity converted-args ",") ");\");"))
+            (jdee-juci-eval-r (concat jdee-juci-java-connection-name "." method-name
+                                   "(" (mapconcat 'identity converted-args ",") ");")))
+          (jdee-juci-eval-r (concat jdee-juci-java-connection-name ".end();")))
       (error
        (progn
-	 (jdee-log-msg "juci-invoke-java: error signaled %S" err)
-	 (jdee-juci-eval (concat jdee-juci-java-connection-name ".reset();"))
-	 (signal (car err) (cdr err)))))))
+         (jdee-log-msg "juci-invoke-java: error signaled %S" err)
+         (jdee-juci-eval (concat jdee-juci-java-connection-name ".reset();"))
+         (signal (car err) (cdr err)))))))
 
 (defun jdee-juci-invoke-script (script-name &rest script-args)
   "Invoke a Beanshell command script via JUCI, returning the result to
@@ -154,15 +154,15 @@ beanshell.  JUCI only allows at most a inter-boundary call stack of
 depth 2, i.e., elisp calls java/java calls elisp."
   (let (result arg-name)
     (condition-case err
-	(progn
-	  (setq result (eval form))
-	  (setq arg-name (jdee-juci-setup-method-arg result 0)))
+        (progn
+          (setq result (eval form))
+          (setq arg-name (jdee-juci-setup-method-arg result 0)))
       (error
        (setq arg-name "error")
        (jdee-juci-eval (concat arg-name " = new jde.juci.ElispError("
-			      (jdee-juci-bshify-object err) ");"))))
+                              (jdee-juci-bshify-object err) ");"))))
     (jdee-juci-eval (concat jdee-juci-java-connection-name
-			   ".pushResult(" arg-name ");"))))
+                           ".pushResult(" arg-name ");"))))
 
 (defun jdee-juci-connection-class (java-class)
   "Prepare the connection class argument to the JUCI
@@ -172,10 +172,10 @@ ConnectionFactory.getConnection() call."
     (concat java-class ".class"))
    ((listp java-class)
     (concat "new Class[] {"
-	    (mapconcat #'(lambda (cls)
-			   (concat cls ".class"))
-		       java-class ",")
-	    "}"))
+            (mapconcat #'(lambda (cls)
+                           (concat cls ".class"))
+                       java-class ",")
+            "}"))
    (t
     (error "java-class must be a string or a list of strings"))))
 
@@ -183,7 +183,7 @@ ConnectionFactory.getConnection() call."
   "Setup and save a JUCI java method argument inside of a beanshell
 variable.  Returns the name of the beanshell variable assigned to."
   (let ((arg-name (concat jdee-juci-java-connection-name "Arg"
-			  (number-to-string arg-num))))
+                          (number-to-string arg-num))))
     (jdee-juci-eval (concat arg-name " = " (jdee-juci-bshify-object arg) ";"))
     arg-name))
 
@@ -192,16 +192,16 @@ variable.  Returns the name of the beanshell variable assigned to."
 `jdee-juci-logger-filename' is non-nil."
   (if jdee-juci-logger-filename
       (jdee-juci-eval (concat jdee-juci-java-connection-name
-			     ".setLoggerFilename(\"" jdee-juci-logger-filename "\");"))))
+                             ".setLoggerFilename(\"" jdee-juci-logger-filename "\");"))))
 
 (defun jdee-juci-eval (expr &optional eval-return)
   "Evaluate a JUCI expression in the JDEE's beanshell."
   (let (result)
     (prog1
-	(setq result (jdee-jeval expr eval-return))
+        (setq result (jdee-jeval expr eval-return))
       (if eval-return
-	  (jdee-log-msg "juci-eval: %s produced result: %S" expr result)
-	(jdee-log-msg "juci-eval: %s" expr)))))
+          (jdee-log-msg "juci-eval: %s produced result: %S" expr result)
+        (jdee-log-msg "juci-eval: %s" expr)))))
 
 (defun jdee-juci-eval-r (expr)
   "Evaluate a JUCI expression in the JDEE's beanshell."
@@ -234,39 +234,39 @@ script.  Conversion of lisp types is done as follows:
     (concat "\"" (jdee-juci-escape-string arg) "\""))
    ((symbolp arg)
     (concat "new jde.juci.Symbol(\"" (symbol-name arg) "\")"))
-   ((and (consp arg)			; dotted-pair cons cell
-	 (not (consp (cdr arg))))
+   ((and (consp arg)                        ; dotted-pair cons cell
+         (not (consp (cdr arg))))
     (concat "new jde.juci.Cons("
-	    (jdee-juci-bshify-object (car arg)) ","
-	    (jdee-juci-bshify-object (cdr arg))
-	    ")"))
+            (jdee-juci-bshify-object (car arg)) ","
+            (jdee-juci-bshify-object (cdr arg))
+            ")"))
    ((sequencep arg)
     (concat "Arrays.asList(new Object[] {" (mapconcat 'jdee-juci-bshify-object arg ",") "})"))))
 
 (defun jdee-juci-escape-string (string)
   "Escape a string for transport across the JUCI boundary."
   (mapconcat #'(lambda (c)
-		 (cond
-		  ;; TODO: more escapes here?
-		  ((eq c ?\\)
-		   "\\\\")
-		  ((eq c ?\")
-		   "\\\"")
-		  ((eq c ?\')
-		   "\\\'")
-		  ((eq c ?\n)
-		   "\\n")
-		  ((eq c ?\t)
-		   "\\t")
-		  ((eq c ?\b)
-		   "\\b")
-		  ((eq c ?\f)
-		   "\\f")
-		  ((eq c ?\r)
-		   "\\r")
-		  (t
-		   (char-to-string c))))
-	     (string-to-list string) ""))
+                 (cond
+                  ;; TODO: more escapes here?
+                  ((eq c ?\\)
+                   "\\\\")
+                  ((eq c ?\")
+                   "\\\"")
+                  ((eq c ?\')
+                   "\\\'")
+                  ((eq c ?\n)
+                   "\\n")
+                  ((eq c ?\t)
+                   "\\t")
+                  ((eq c ?\b)
+                   "\\b")
+                  ((eq c ?\f)
+                   "\\f")
+                  ((eq c ?\r)
+                   "\\r")
+                  (t
+                   (char-to-string c))))
+             (string-to-list string) ""))
 
 
 
@@ -302,9 +302,9 @@ that EXPECTED is `equal' to ACTUAL.  Signal an error if not."
 that a FORM, when executed, produces an error.  If no error is
 signaled, then signal an error."
   `(condition-case nil
-       (let ((message-log-max))	;; quiet (message)
-	 ,form
-	 (error "No error generated.  %S" (or ,msg "")))
+       (let ((message-log-max))        ;; quiet (message)
+         ,form
+         (error "No error generated.  %S" (or ,msg "")))
      (error (message nil) t)))
 
 (defun jdee-juci-test-roundtrips ()

--- a/jdee-junit.el
+++ b/jdee-junit.el
@@ -70,10 +70,10 @@ of the test runner in the edit field."
   :group 'jdee-junit
   :tag "Test Runner"
   :type '(choice
-	  (const :tag "Text UI" :value "junit.textui.TestRunner")
-	  (const :tag "Swing GUI" :value "junit.swingui.TestRunner")
-	  (const :tag "AWT GUI" :value "junit.awtui.TestRunner")
-	  (string :tag "Custom UI")))
+          (const :tag "Text UI" :value "junit.textui.TestRunner")
+          (const :tag "Swing GUI" :value "junit.swingui.TestRunner")
+          (const :tag "AWT GUI" :value "junit.awtui.TestRunner")
+          (string :tag "Custom UI")))
 
 (defcustom jdee-junit-tester-name-tag (cons "Test" nil)
   "Specifies a prefix or suffix to use in test class name.
@@ -82,8 +82,8 @@ or FooTest.  Having a test suffix plays nicely with `projectile-mode'."
   :group 'jdee-junit
   :tag "Test Class Name Tag"
   :type '(cons
-	  (string :tag "Tag" :value "T")
-	  (choice :tag "Tag Type"
+          (string :tag "Tag" :value "T")
+          (choice :tag "Tag Type"
                   (const :tag "Prefix" :value t)
                   (const :tag "Suffix" :value nil))))
 
@@ -93,7 +93,7 @@ or FooTest.  Having a test suffix plays nicely with `projectile-mode'."
   "Get the name of a tester class based on `TESTEE-NAME'.
 The `testee-name' is joined with `jdee-junit-tester-name-tag'."
   (let ((tag (car jdee-junit-tester-name-tag))
-	(prefixp (cdr jdee-junit-tester-name-tag)))
+        (prefixp (cdr jdee-junit-tester-name-tag)))
     (if prefixp
         (concat tag testee-name)
       (concat testee-name tag))))
@@ -102,16 +102,16 @@ The `testee-name' is joined with `jdee-junit-tester-name-tag'."
   "Get the name of a testee class from the `TESTER-NAME'.
 The result comes from removing prefixed or affixed `jdee-junit-tester-name-tag'."
   (let ((tag (car jdee-junit-tester-name-tag))
-	(prefixp (cdr jdee-junit-tester-name-tag)))
+        (prefixp (cdr jdee-junit-tester-name-tag)))
     (if prefixp
-	(progn
-	  (string-match
-	   (concat "^" tag "\\(.*\\)")
-	   tester-name))
+        (progn
+          (string-match
+           (concat "^" tag "\\(.*\\)")
+           tester-name))
       (progn
-	(string-match
-	 (concat "\\(.*\\)" tag "$")
-	 tester-name)))
+        (string-match
+         (concat "\\(.*\\)" tag "$")
+         tester-name)))
     (substring tester-name (match-beginning 1) (match-end 1))))
 
 (defcustom jdee-junit-test-class-template
@@ -201,13 +201,13 @@ command `jdee-junit-test-class', as a side-effect."
   :group 'jdee-junit
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-junit-test-class-internal
-	    (tempo-define-template
-	     "java-junit-test-class-buffer-template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert a generic JUnit test class buffer skeleton."))
-	  (set-default sym val)))
+          (defalias 'jdee-junit-test-class-internal
+            (tempo-define-template
+             "java-junit-test-class-buffer-template"
+             (jdee-gen-read-template val)
+             nil
+             "Insert a generic JUnit test class buffer skeleton."))
+          (set-default sym val)))
 
 (defalias 'jdee-junit-test-class-internal
   (tempo-define-template
@@ -302,13 +302,13 @@ command `jdee-junit4-test-class', as a side-effect."
   :group 'jdee-junit
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-junit4-test-class-internal
-	    (tempo-define-template
-	     "java-junit4-test-class-buffer-template"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert a generic JUnit 4 test class buffer skeleton."))
-	  (set-default sym val)))
+          (defalias 'jdee-junit4-test-class-internal
+            (tempo-define-template
+             "java-junit4-test-class-buffer-template"
+             (jdee-gen-read-template val)
+             nil
+             "Insert a generic JUnit 4 test class buffer skeleton."))
+          (set-default sym val)))
 
 (defalias 'jdee-junit4-test-class-internal
   (tempo-define-template
@@ -383,9 +383,9 @@ tests generated with this template requires the JUnit test framework."
   "Create a buffer containing a JUnit4 test skeleton."
   (interactive)
   (let ((tester-name
-	 (jdee-junit-get-tester-name
-	  (file-name-sans-extension
-	   (file-name-nondirectory buffer-file-name)))))
+         (jdee-junit-get-tester-name
+          (file-name-sans-extension
+           (file-name-nondirectory buffer-file-name)))))
     (find-file (concat tester-name ".java"))
     (jdee-junit4-test-class-internal)
     (goto-char (point-min))
@@ -420,13 +420,13 @@ tests generated with this template requires the JUnit test framework."
   :group 'jdee-junit
   :type '(repeat string)
   :set '(lambda (sym val)
-	  (defalias 'jdee-junit-add-test-to-suite-internal
-	    (tempo-define-template
-	     "Adding JUnit test to suit"
-	     (jdee-gen-read-template val)
-	     nil
-	     "Insert JUnit test to suite."))
-	  (set-default sym val)))
+          (defalias 'jdee-junit-add-test-to-suite-internal
+            (tempo-define-template
+             "Adding JUnit test to suit"
+             (jdee-gen-read-template val)
+             nil
+             "Insert JUnit test to suite."))
+          (set-default sym val)))
 
 (defalias 'jdee-junit-add-test-to-suite-internal
   (tempo-define-template
@@ -453,8 +453,8 @@ tests generated with this template requires the JUnit test framework."
                (jdee-normalize-path 'jdee-junit-working-directory))))
         (oset vm :main-class jdee-junit-testrunner-type )
         (jdee-run-set-app-args (concat (jdee-parse-get-package)
-				       (file-name-sans-extension
-					(file-name-nondirectory (buffer-file-name)))))
+                                       (file-name-sans-extension
+                                        (file-name-nondirectory (buffer-file-name)))))
         (cd working-directory)
         (jdee-run-vm-launch vm))
     (error "The jdee-junit-run command works only in a Java source buffer")))

--- a/jdee-make.el
+++ b/jdee-make.el
@@ -89,20 +89,20 @@ list of arguments entered in the minibuffer."
 (defun jdee-make-make-command (more-args)
   "Constructs the java compile command as: jdee-compiler + options + buffer file name."
   (concat jdee-make-program " " jdee-make-args
-	  (if (not (string= more-args ""))
-	      (concat " " more-args))
-	  " "))
+          (if (not (string= more-args ""))
+              (concat " " more-args))
+          " "))
 
 (defun jdee-make-find-build-file (dir)
   "Find the next Makefile upwards in the directory tree from DIR.
 Returns nil if it cannot find a project file in DIR or an ascendmake directory."
   (let ((file (cl-find "Makefile"
-		       (directory-files dir) :test 'string=)))
+                       (directory-files dir) :test 'string=)))
 
     (if file
-	(setq file (expand-file-name file dir))
+        (setq file (expand-file-name file dir))
       (if (not (jdee-root-dir-p dir))
-	  (setq file (jdee-make-find-build-file (concat dir "../")))))
+          (setq file (jdee-make-find-build-file (concat dir "../")))))
 
     file))
 
@@ -125,19 +125,19 @@ enter to the make program along with the arguments specified by
     (setq jdee-interactive-make-args ""))
 
   (let ((make-command
-	 (jdee-make-make-command
-	  jdee-interactive-make-args))
-	(save-default-directory default-directory)
-	(default-directory
-	  (if (string= jdee-make-working-directory "")
-	      (if jdee-make-enable-find
-		  (let ((jdee-make-buildfile
-			 (jdee-make-find-build-file default-directory)))
-		    (if jdee-make-buildfile
-			(file-name-directory jdee-make-buildfile)
-		      default-directory))
-		default-directory)
-	    (jdee-normalize-path 'jdee-make-working-directory))))
+         (jdee-make-make-command
+          jdee-interactive-make-args))
+        (save-default-directory default-directory)
+        (default-directory
+          (if (string= jdee-make-working-directory "")
+              (if jdee-make-enable-find
+                  (let ((jdee-make-buildfile
+                         (jdee-make-find-build-file default-directory)))
+                    (if jdee-make-buildfile
+                        (file-name-directory jdee-make-buildfile)
+                      default-directory))
+                default-directory)
+            (jdee-normalize-path 'jdee-make-working-directory))))
 
 
     ;; Force save-some-buffers to use the minibuffer
@@ -147,13 +147,13 @@ enter to the make program along with the arguments specified by
     ;; which seems not to be supported--at least on
     ;; the PC.
     (if (eq system-type 'windows-nt)
-	(let ((temp last-nonmenu-event))
-	  ;; The next line makes emacs think that jdee-make
-	  ;; was invoked from the minibuffer, even when it
-	  ;; is actually invoked from the menu-bar.
-	  (setq last-nonmenu-event t)
-	  (save-some-buffers (not compilation-ask-about-save) nil)
-	  (setq last-nonmenu-event temp))
+        (let ((temp last-nonmenu-event))
+          ;; The next line makes emacs think that jdee-make
+          ;; was invoked from the minibuffer, even when it
+          ;; is actually invoked from the menu-bar.
+          (setq last-nonmenu-event t)
+          (save-some-buffers (not compilation-ask-about-save) nil)
+          (setq last-nonmenu-event temp))
       (save-some-buffers (not compilation-ask-about-save) nil))
 
     (setq compilation-finish-functions

--- a/jdee-package.el
+++ b/jdee-package.el
@@ -138,10 +138,10 @@ The first one which has a non nil value will be used by jdee-package."
 That is to say the first non-nil value found in the variables given by
 `jdee-package-search-classpath-variables'."
   (let ((search-in jdee-package-search-classpath-variables)
-	(classpath))
+        (classpath))
     (while (and search-in (not classpath))
       (setq classpath (symbol-value (car search-in))
-	    search-in (cdr search-in)))
+            search-in (cdr search-in)))
     classpath))
 
 (defun jdee-package-get-directories-in-classpath ()
@@ -149,36 +149,36 @@ That is to say the first non-nil value found in the variables given by
   (cl-mapcan
    (lambda (path)
        (if (or jdee-resolve-relative-paths-p
-	      (not   (string= path "."))) ; "." is ignored in classpath
-	   (let ((path (jdee-normalize-path path)))
-	     (if (file-directory-p path)
-		 (list (file-name-as-directory path))))))
+              (not   (string= path "."))) ; "." is ignored in classpath
+           (let ((path (jdee-normalize-path path)))
+             (if (file-directory-p path)
+                 (list (file-name-as-directory path))))))
    (jdee-package-get-classpath)))
 
 
 (defun jdee-package-search-package-directories ()
   "Return a list of package directory candidates or nil if not found."
   (let ((dir (jdee-normalize-path default-directory))
-	;; case-insensitive for Windows
-	(case-fold-search (eq system-type 'windows-nt)))
+        ;; case-insensitive for Windows
+        (case-fold-search (eq system-type 'windows-nt)))
     (cl-mapcan
      (lambda (root)
-	 (let ((root (regexp-quote root)))
-	   (message "Seaching %S in %S..." root dir)
-	   (and (string-match root dir)
-		(list (substring dir (match-end 0))))))
+         (let ((root (regexp-quote root)))
+           (message "Seaching %S in %S..." root dir)
+           (and (string-match root dir)
+                (list (substring dir (match-end 0))))))
      (append (jdee-package-get-directories-in-classpath)
-	     (mapcar
-	      (lambda (p)
-		(file-name-as-directory p))
-	      (jdee-expand-wildcards-and-normalize jdee-sourcepath 'jdee-sourcepath))))))
+             (mapcar
+              (lambda (p)
+                (file-name-as-directory p))
+              (jdee-expand-wildcards-and-normalize jdee-sourcepath 'jdee-sourcepath))))))
 
 (defun jdee-package-best-package-candidate (candidates)
   "Return the best package directory candidate from CANDIDATES.
 The best is the shortest one that could be found."
   (car (sort candidates
-	     (lambda (dir1 dir2)
-		 (string-match (regexp-quote dir1) dir2)))))
+             (lambda (dir1 dir2)
+                 (string-match (regexp-quote dir1) dir2)))))
 
 (defun jdee-package-get-package-directory ()
   "Return the package directory, if found; otherwise,
@@ -206,10 +206,10 @@ Replace ?/ by ?. and remove extra ?/ at end."
 current buffer, if the package name can be determined; otherwise,
 an empty string."
   (let* (
-	 ;; The JDE always uses ?/ as directory separator so ensure
-	 ;; [X]Emacs uses the same one when running on Windows!
-	 (directory-sep-char ?/)
-	 (package-name (jdee-package-get-package-directory)))
+         ;; The JDE always uses ?/ as directory separator so ensure
+         ;; [X]Emacs uses the same one when running on Windows!
+         (directory-sep-char ?/)
+         (package-name (jdee-package-get-package-directory)))
     (cond
      ((string= package-name jdee-package-unknown-package-name)
       (message
@@ -220,8 +220,8 @@ an empty string."
       jdee-package-default-package-comment)
      (t
       (message "package %s;%s"
-	       (jdee-package-convert-directory-to-package package-name)
-	       jdee-package-package-comment)))))
+               (jdee-package-convert-directory-to-package package-name)
+               jdee-package-package-comment)))))
 
 ;;;###autoload
 (defun jdee-package-update ()
@@ -246,9 +246,9 @@ spuriously marking the buffer as modified.
       (goto-char (point-min))
       (if (re-search-forward jdee-package-package-regexp nil t)
           (unless (string-equal package (match-string 0))
-	        (replace-match package))
-	    (insert package)
-	    (newline)))))
+                (replace-match package))
+            (insert package)
+            (newline)))))
 
 ;; Register and initialize the customization variables defined
 ;; by this package.

--- a/jdee-parse-expr.el
+++ b/jdee-parse-expr.el
@@ -56,20 +56,20 @@ replacement.  This adds a `this.' to each replacment."
        (error "No region selected")
      (list (region-beginning) (region-end) current-prefix-arg)))
   (let ((case-fold-search nil)
-	(reg "\\(?:oa\\|[onbfs]\\)\\([A-Z]\\)\\([a-zA-Z0-9]+\\)"))
+        (reg "\\(?:oa\\|[onbfs]\\)\\([A-Z]\\)\\([a-zA-Z0-9]+\\)"))
     (save-excursion
       (save-restriction
-	(narrow-to-region start end)
-	(save-match-data
-	  (goto-char (point-min))
-	  (while (re-search-forward (concat "m_" reg) nil t)
-	    (replace-match (concat (and local-replacement-p "this.")
-				   (downcase (match-string 1))
-				   (match-string 2))))
-	  (goto-char (point-min))
-	  (while (re-search-forward (concat "\\<" reg "\\>") nil t)
-	    (replace-match (concat (downcase (match-string 1))
-				   (match-string 2)))))))))
+        (narrow-to-region start end)
+        (save-match-data
+          (goto-char (point-min))
+          (while (re-search-forward (concat "m_" reg) nil t)
+            (replace-match (concat (and local-replacement-p "this.")
+                                   (downcase (match-string 1))
+                                   (match-string 2))))
+          (goto-char (point-min))
+          (while (re-search-forward (concat "\\<" reg "\\>") nil t)
+            (replace-match (concat (downcase (match-string 1))
+                                   (match-string 2)))))))))
 
 (defun jdee-split-by-camel-notation (to-parse)
   "Parse tokens based on \(reverse) camel notation.
@@ -77,26 +77,26 @@ TO-PARSE is the string to parse."
   (if (or nil (= 0 (length to-parse)))
       nil
     (let ((last-cap 0)
-	  toks)
+          toks)
       (setq to-parse (append (vconcat to-parse) nil))
       (cl-flet ((upperp
-		 (pos)
-		 (if (<= pos 0)
-		     t
-		   (let ((char (elt to-parse pos)))
-		     (and (eq char (upcase char))))))
-		(handle
-		 (pos)
-		 (prog1
-		     (apply 'string (cl-subseq to-parse last-cap pos))
-		   (setq last-cap pos))))
-	(cl-do ((pos 0 (cl-incf pos)))
-	    ((> pos (1- (length to-parse))))
-	  (if (and (upperp pos)
-		   ;;(> (- pos last-cap) 2))
-		   (> (- pos last-cap) 0))
-	      (setq toks (append toks (cons (handle pos) nil)))))
-	(append toks (cons (handle (length to-parse)) nil))))))
+                 (pos)
+                 (if (<= pos 0)
+                     t
+                   (let ((char (elt to-parse pos)))
+                     (and (eq char (upcase char))))))
+                (handle
+                 (pos)
+                 (prog1
+                     (apply 'string (cl-subseq to-parse last-cap pos))
+                   (setq last-cap pos))))
+        (cl-do ((pos 0 (cl-incf pos)))
+            ((> pos (1- (length to-parse))))
+          (if (and (upperp pos)
+                   ;;(> (- pos last-cap) 2))
+                   (> (- pos last-cap) 0))
+              (setq toks (append toks (cons (handle pos) nil)))))
+        (append toks (cons (handle (length to-parse)) nil))))))
 
 (defconst jdee-camel-tok-skip-chars " \t\n().'\""
   "Characters used top a traveral of a reverse camel notation string." )
@@ -105,38 +105,38 @@ TO-PARSE is the string to parse."
   "Go to the beginning of a reverese camel case token."
   (interactive)
   (let ((space-regex (format "[%s]" jdee-camel-tok-skip-chars))
-	(n-space-regex (format "[^%s]" jdee-camel-tok-skip-chars))
-	start end reg toks)
+        (n-space-regex (format "[^%s]" jdee-camel-tok-skip-chars))
+        start end reg toks)
     (save-excursion
       (save-match-data
-	(if (and (> (point) (- 2 (point-min)))
-		 (save-excursion
-		   (forward-char -1)
-		   (looking-at space-regex)))
-	    (re-search-backward n-space-regex nil t))
-	(setq end (point))
-	(setq start (or (when (re-search-backward space-regex nil t)
-			  (forward-char 1)
-			  (point))
-			(point-min)))))
+        (if (and (> (point) (- 2 (point-min)))
+                 (save-excursion
+                   (forward-char -1)
+                   (looking-at space-regex)))
+            (re-search-backward n-space-regex nil t))
+        (setq end (point))
+        (setq start (or (when (re-search-backward space-regex nil t)
+                          (forward-char 1)
+                          (point))
+                        (point-min)))))
     (setq reg (buffer-substring start end)
-	  toks (jdee-split-by-camel-notation reg))
+          toks (jdee-split-by-camel-notation reg))
     (goto-char (- end (length (car (last toks)))))))
 
 (defun jdee-end-of-camel-tok ()
   "Go to the beginning of a reverese camel case token."
   (interactive)
   (let ((space-regex (format "[%s]" jdee-camel-tok-skip-chars))
-	(n-space-regex (format "[^%s]" jdee-camel-tok-skip-chars)))
+        (n-space-regex (format "[^%s]" jdee-camel-tok-skip-chars)))
     (if (looking-at space-regex) (re-search-forward n-space-regex))
     (let ((start (point))
-	  (end (or (save-excursion
-		     (save-match-data
-		       (re-search-forward space-regex nil t)))
-		   (point-max)))
-	  reg toks)
+          (end (or (save-excursion
+                     (save-match-data
+                       (re-search-forward space-regex nil t)))
+                   (point-max)))
+          reg toks)
       (setq reg (buffer-substring start end)
-	    toks (jdee-split-by-camel-notation reg))
+            toks (jdee-split-by-camel-notation reg))
       (goto-char (+ start (length (car toks)))))))
 
 (defun jdee-forward-camel-tok (arg)
@@ -172,7 +172,7 @@ back after the deletion.  This is usually something like
 
 DELIMITER the delimiter used to place between each camel token."
   (let ((toks (jdee-split-by-camel-notation
-	       (buffer-substring start end))))
+               (buffer-substring start end))))
     (save-excursion
       (delete-region start end)
       (goto-char start)
@@ -223,15 +223,15 @@ GETTERP, if non-nil, make it a getter, otherwise make it a setter.  If
 setter, otherwise, make a getter."
   (interactive (list (thing-at-point 'word) (not current-prefix-arg)))
   (let* ((toks (jdee-split-by-camel-notation member-name))
-	 (attr (apply 'concat
-		      (append (list (if getterp "get" "set")
-				    (capitalize (substring (car toks) 0 1))
-				    (substring (car toks) 1))
-			      (cdr toks)))))
+         (attr (apply 'concat
+                      (append (list (if getterp "get" "set")
+                                    (capitalize (substring (car toks) 0 1))
+                                    (substring (car toks) 1))
+                              (cdr toks)))))
     (if (called-interactively-p 'interactive)
-	(let ((bounds (bounds-of-thing-at-point 'word)))
-	  (delete-region (car bounds) (cdr bounds))
-	  (insert (concat attr "(" (if getterp ")")))))
+        (let ((bounds (bounds-of-thing-at-point 'word)))
+          (delete-region (car bounds) (cdr bounds))
+          (insert (concat attr "(" (if getterp ")")))))
     attr))
 
 (eval-after-load

--- a/jdee-parse.el
+++ b/jdee-parse.el
@@ -88,7 +88,7 @@ size."
   "The end of the region where the last completion was inserted.")
 
 (defvar jdee-parse-primitive-types '("byte" "char" "double" "float"
-				    "int" "long" "short" "boolean")
+                                    "int" "long" "short" "boolean")
   "Primitive Java types.")
 
 (defvar jdee-parse-attempted-to-import nil
@@ -100,14 +100,14 @@ the type of a class could not be found an it tried to import it")
   (rx
    (1+              ;; A Java symbol comprises one or more of the following:
     (char (?A . ?Z)   ;;   - upper case characters
-	  (?a . ?z)   ;;   - lower case characters
-	  (?0 . ?9)   ;;   - digits
-	  "[]"        ;;   - square brackets
-	  "?"         ;;   - question mark
-	  "_"         ;;   - underscore
-	  "."         ;;   - period
-	  (160 . 255) ;;   - accented characters
-	  )))
+          (?a . ?z)   ;;   - lower case characters
+          (?0 . ?9)   ;;   - digits
+          "[]"        ;;   - square brackets
+          "?"         ;;   - question mark
+          "_"         ;;   - underscore
+          "."         ;;   - period
+          (160 . 255) ;;   - accented characters
+          )))
   "Regular expression that matches any Java symbol.")
 
 (defun jdee-parse-java-name-parts-re (&optional sep)
@@ -151,8 +151,8 @@ match `jdee-auto-parse-max-buffer-size' threshold."
   "Return non-nil if the JDE should automatically reparse the buffer."
   (and jdee-auto-parse-enable
        (or
-	(<= jdee-auto-parse-max-buffer-size 0)
-	(< (buffer-size) jdee-auto-parse-max-buffer-size))))
+        (<= jdee-auto-parse-max-buffer-size 0)
+        (< (buffer-size) jdee-auto-parse-max-buffer-size))))
 
 (eval-when-compile
   (defsubst jdee-auto-parse-delay ()
@@ -172,43 +172,43 @@ replaced by that range.  See also `semantic-change-hooks'."
     (setq jdee-parse-buffer-needs-reparse-p t)
     (when (jdee-parse-should-auto-parse-buffer-p)
       (if (timerp jdee-auto-parse-buffer-timer)
-	  (let ((rem (jdee-auto-parse-delay)))
-	    (cond
-	     ((< rem 0)
-	      ;; Timer has expired, re-schedule a new auto-parse.
-	      (cancel-timer jdee-auto-parse-buffer-timer)
-	      (setq jdee-auto-parse-buffer-timer nil))
-	     ((< rem 2) ;; less that 2 secs. before auto-parse
-	      ;; The auto-parse task is about to be triggered when
-	      ;; this change occurs, so it is delayed to let finish
-	      ;; typing before re-parsing.
-	      (timer-inc-time jdee-auto-parse-buffer-timer
-			      10) ;; wait 10 secs. more.
-	      (message "Auto parse delayed...")))))
+          (let ((rem (jdee-auto-parse-delay)))
+            (cond
+             ((< rem 0)
+              ;; Timer has expired, re-schedule a new auto-parse.
+              (cancel-timer jdee-auto-parse-buffer-timer)
+              (setq jdee-auto-parse-buffer-timer nil))
+             ((< rem 2) ;; less that 2 secs. before auto-parse
+              ;; The auto-parse task is about to be triggered when
+              ;; this change occurs, so it is delayed to let finish
+              ;; typing before re-parsing.
+              (timer-inc-time jdee-auto-parse-buffer-timer
+                              10) ;; wait 10 secs. more.
+              (message "Auto parse delayed...")))))
       ;; Schedule a new auto-parse task.
       (or (timerp jdee-auto-parse-buffer-timer)
-	  (setq jdee-auto-parse-buffer-timer
-		(run-with-timer
-		 jdee-auto-parse-buffer-interval
-		 nil
-		 #'jdee-parse-after-buffer-changed))))))
+          (setq jdee-auto-parse-buffer-timer
+                (run-with-timer
+                 jdee-auto-parse-buffer-interval
+                 nil
+                 #'jdee-parse-after-buffer-changed))))))
 
 (defun jdee-parse-buffer-contains-multiple-classes-p ()
   "Return non-nil if buffer contains multiple class definitions."
   (let* ((top-level-classes
-	  (semantic-brute-find-tag-by-class
-	   'type
-	   (semantic-fetch-tags)))
-	 (top-level-class-count (length top-level-classes)))
+          (semantic-brute-find-tag-by-class
+           'type
+           (semantic-fetch-tags)))
+         (top-level-class-count (length top-level-classes)))
     (or
      (>  top-level-class-count 1)
      (and
       (= top-level-class-count 1)
       (let* ((inner-class-parts (semantic-tag-type-members (car top-level-classes)))
-	     (inner-classes
-	      (semantic-brute-find-tag-by-class
-	       'type inner-class-parts)))
-	(>= (length inner-classes) 1))))))
+             (inner-classes
+              (semantic-brute-find-tag-by-class
+               'type inner-class-parts)))
+        (>= (length inner-classes) 1))))))
 
 
 (defvar jdee-parse-buffer-contains-multiple-classes-p nil
@@ -223,15 +223,15 @@ when the cache is cleared.
 See also `semantic-after-toplevel-cache-change-hook'."
   (if (jdee-parse-should-auto-parse-buffer-p)
       (setq jdee-parse-buffer-needs-reparse-p nil
-	    jdee-auto-parse-buffer-timer
-	    (and (timerp jdee-auto-parse-buffer-timer)
-		 (cancel-timer jdee-auto-parse-buffer-timer)
-		 nil)))
+            jdee-auto-parse-buffer-timer
+            (and (timerp jdee-auto-parse-buffer-timer)
+                 (cancel-timer jdee-auto-parse-buffer-timer)
+                 nil)))
   (if (car tokens)
       (setq jdee-parse-buffer-contains-multiple-classes-p
-	    (jdee-parse-buffer-contains-multiple-classes-p)
-	    jdee-parse-the-method-map
-	    (jdee-parse-method-map "Method map"))))
+            (jdee-parse-buffer-contains-multiple-classes-p)
+            jdee-parse-the-method-map
+            (jdee-parse-method-map "Method map"))))
 
 (defun jdee-parse-update-after-partial-parse (tokens)
   "Hook run after Semantic updated the token cache.
@@ -256,47 +256,47 @@ moved also."
   (if (eq class-regexp 'first)
       (setq class-regexp ".*")
     (if (or (null class-regexp) (= 0 (length class-regexp)))
-	(let* ((class-name (car (jdee-parse-get-innermost-class-at-point))))
-	  (if (null class-name) (error "point is not in a class definition"))
-	  (setq class-regexp (regexp-quote class-name)))))
+        (let* ((class-name (car (jdee-parse-get-innermost-class-at-point))))
+          (if (null class-name) (error "point is not in a class definition"))
+          (setq class-regexp (regexp-quote class-name)))))
 
   (let* ((tokens (semantic-fetch-tags))
-	 (classes (semantic-brute-find-tag-by-class 'type tokens))
-	 class-parts pos)
+         (classes (semantic-brute-find-tag-by-class 'type tokens))
+         class-parts pos)
 
     (setq pos
-	  (save-excursion
-	    (save-match-data)
-	    (block outter
-	      (dolist (class classes)
-		;; Commented out this form because the variable is never
-		;; used, causes a compile error, and I don't know it's purpose.
-		;; (setq token-class-regexp (semantic-tag-name class))
-		(when (or (null class-regexp)
-			  (string-match class-regexp
-					(semantic-tag-name class)))
-		  (let ((class-parts (semantic-tag-type-members class)))
+          (save-excursion
+            (save-match-data)
+            (block outter
+              (dolist (class classes)
+                ;; Commented out this form because the variable is never
+                ;; used, causes a compile error, and I don't know it's purpose.
+                ;; (setq token-class-regexp (semantic-tag-name class))
+                (when (or (null class-regexp)
+                          (string-match class-regexp
+                                        (semantic-tag-name class)))
+                  (let ((class-parts (semantic-tag-type-members class)))
 
-		    (setq pos (semantic-tag-start class))
+                    (setq pos (semantic-tag-start class))
 
-		    (if (not (numberp pos))
-			(error (concat "invalid token start, probably because "
-				       "not semantic bovinated top level")))
+                    (if (not (numberp pos))
+                        (error (concat "invalid token start, probably because "
+                                       "not semantic bovinated top level")))
 
-		    (goto-char pos)
+                    (goto-char pos)
 
-		    (if (not (search-forward "{" nil t))
-			(error "invalid class, can't find next `{'"))
+                    (if (not (search-forward "{" nil t))
+                        (error "invalid class, can't find next `{'"))
 
-		    (return-from outter (point))))))))
+                    (return-from outter (point))))))))
     (if (and (not no-move-point) pos) (goto-char pos))
     pos))
 
 
 (defun jdee-parse-get-nth-member (&optional class-name modifiers
-					   member-name-regexp
-					   elt goto-start-p
-					   compare-method)
+                                           member-name-regexp
+                                           elt goto-start-p
+                                           compare-method)
   "Return the point at the Nth class member (field) with given criteria.  The
 first match that is a subset of the modifiers give is choosen.
 
@@ -314,68 +314,68 @@ MODIFIERS creteria as an exact match or subset.  This defaults to `subset'."
   (if (null member-name-regexp) (setq member-name-regexp ".*"))
 
   (let* ((tokens (semantic-fetch-tags))
-	 (classes (semantic-brute-find-tag-by-class 'type tokens))
-	 cmp-fn vars var-parts var-name var-modifiers i)
+         (classes (semantic-brute-find-tag-by-class 'type tokens))
+         cmp-fn vars var-parts var-name var-modifiers i)
 
     (setq cmp-fn
-	  (cond ((or (null compare-method)
-		     (eq 'subset compare-method))
-		 #'(lambda (modifiers var-modifiers)
-		     (cl-subsetp modifiers var-modifiers :test 'equal)
-		     ))
-		((eq 'equal compare-method)
-		 #'(lambda (modifiers var-modifiers)
-		       (let ((m (copy-tree modifiers))
-			     (v (copy-tree var-modifiers)))
-			 (setq m (sort m 'string<)
-			       v (sort v 'string<))
-			 (equal m v)
-			 )))
-		(t (error "compare-method `%S' not supported"
-			  compare-method))))
+          (cond ((or (null compare-method)
+                     (eq 'subset compare-method))
+                 #'(lambda (modifiers var-modifiers)
+                     (cl-subsetp modifiers var-modifiers :test 'equal)
+                     ))
+                ((eq 'equal compare-method)
+                 #'(lambda (modifiers var-modifiers)
+                       (let ((m (copy-tree modifiers))
+                             (v (copy-tree var-modifiers)))
+                         (setq m (sort m 'string<)
+                               v (sort v 'string<))
+                         (equal m v)
+                         )))
+                (t (error "compare-method `%S' not supported"
+                          compare-method))))
 
     (save-excursion
       (save-match-data
-	(block outter
-	  (dolist (class classes)
-	    ;; commented out this line because the variable is never bound
-	    ;; nor used and I don't understand it's purpose. Paul Kinnucan.
-	    ;; (setq token-class-name (semantic-tag-name class))
-	    (when (or (null class-name)
-		      (string-equal class-name (semantic-tag-name class)))
+        (block outter
+          (dolist (class classes)
+            ;; commented out this line because the variable is never bound
+            ;; nor used and I don't understand it's purpose. Paul Kinnucan.
+            ;; (setq token-class-name (semantic-tag-name class))
+            (when (or (null class-name)
+                      (string-equal class-name (semantic-tag-name class)))
 
-	      (setq var-parts (semantic-tag-type-members class)
-		    vars (semantic-brute-find-tag-by-class
-			  'variable var-parts)
-		    i 0)
+              (setq var-parts (semantic-tag-type-members class)
+                    vars (semantic-brute-find-tag-by-class
+                          'variable var-parts)
+                    i 0)
 
-	      (setq vars
-		    (mapcar
-		     #'(lambda (variable)
-			 (setq var-modifiers
-			       (if modifiers
-				   (semantic-tag-modifiers variable)))
-			 (if (or (and (null var-modifiers) (null modifiers))
-				 (funcall cmp-fn modifiers var-modifiers))
-			     variable)) vars))
+              (setq vars
+                    (mapcar
+                     #'(lambda (variable)
+                         (setq var-modifiers
+                               (if modifiers
+                                   (semantic-tag-modifiers variable)))
+                         (if (or (and (null var-modifiers) (null modifiers))
+                                 (funcall cmp-fn modifiers var-modifiers))
+                             variable)) vars))
 
-	      (setq vars (remove nil vars))
+              (setq vars (remove nil vars))
 
-	      (setq elt (cond ((not elt) 0)
-			      ((< elt 0) (+ (length vars) elt))
-			      (t elt)))
+              (setq elt (cond ((not elt) 0)
+                              ((< elt 0) (+ (length vars) elt))
+                              (t elt)))
 
-	      (dolist (variable vars)
+              (dolist (variable vars)
 
-		(setq var-name (semantic-tag-name variable))
+                (setq var-name (semantic-tag-name variable))
 
-		(when (and (= elt i)
-			   (string-match member-name-regexp var-name))
-		  (goto-char (if goto-start-p (semantic-tag-start variable)
-			       (semantic-tag-end variable)))
-		  (return-from outter (point)) )
+                (when (and (= elt i)
+                           (string-match member-name-regexp var-name))
+                  (goto-char (if goto-start-p (semantic-tag-start variable)
+                               (semantic-tag-end variable)))
+                  (return-from outter (point)) )
 
-		(setq i (1+ i))))))))))
+                (setq i (1+ i))))))))))
 
 
 
@@ -385,12 +385,12 @@ The optional parameter `tag' can be a semantic tag, which is
 then used as the current class instead of the result of `semantic-current-tag'."
   (let ((curtag (or tag (semantic-current-tag))))
     (remove nil
-	    (mapcar
-	     (lambda (member)
-	       (if (semantic-tag-of-class-p member 'variable)
-		   member
-		 nil))
-	     (semantic-tag-type-members curtag)))))
+            (mapcar
+             (lambda (member)
+               (if (semantic-tag-of-class-p member 'variable)
+                   member
+                 nil))
+             (semantic-tag-type-members curtag)))))
 
 (defun jdee-parse-get-member-functions (&optional tag)
   "Get all member functions of the current class as a semantic tag list.
@@ -398,9 +398,9 @@ The optional parameter `tag' can be a semantic tag, which is
 then used as the current class instead of the result of `semantic-current-tag'."
   (let ((curtag (or tag (semantic-current-tag))))
     (remove nil
-	    (mapcar
-	     (lambda (member) (if (semantic-tag-of-class-p member 'function) member nil))
-	     (semantic-tag-type-members curtag)))))
+            (mapcar
+             (lambda (member) (if (semantic-tag-of-class-p member 'function) member nil))
+             (semantic-tag-type-members curtag)))))
 
 (defun jdee-parse-get-serializable-members (&optional tag)
   "Get all serializable member variables of the current class as a semantic tag list.
@@ -408,35 +408,35 @@ The optional parameter `tag' can be a semantic tag, which is
 then used as the current class instead of the result of `semantic-current-tag'."
   (let ((curtag (or tag (semantic-current-tag))))
     (remove nil
-	    (mapcar
-	     (lambda (member)
-	       (let ((is-variable (semantic-tag-of-class-p member 'variable))
-		     (modifiers (semantic-tag-modifiers member)))
-		 (if (and is-variable (not (or (member "static" modifiers)
-					       (member "transient" modifiers))))
-		     member
-		      nil)))
-	     (semantic-tag-type-members curtag)))))
+            (mapcar
+             (lambda (member)
+               (let ((is-variable (semantic-tag-of-class-p member 'variable))
+                     (modifiers (semantic-tag-modifiers member)))
+                 (if (and is-variable (not (or (member "static" modifiers)
+                                               (member "transient" modifiers))))
+                     member
+                      nil)))
+             (semantic-tag-type-members curtag)))))
 
 (defun jdee-parse-member-is-scalar (tag)
   "Check if tag is of a scalar type"
   (not (or (string-match "\\[.*\\]" (semantic-tag-name tag))
-	   (string-match "\\[.*\\]" (semantic-tag-type tag)))))
+           (string-match "\\[.*\\]" (semantic-tag-type tag)))))
 
 (defun jdee-parse-member-is-primitive (tag)
   "Check if tag is of primitive type"
   (and (or (semantic-tag-of-type-p tag "byte")
-	   (semantic-tag-of-type-p tag "char")
-	   (semantic-tag-of-type-p tag "short")
-	   (semantic-tag-of-type-p tag "boolean")
-	   (semantic-tag-of-type-p tag "int")
-	   (semantic-tag-of-type-p tag "long"))
+           (semantic-tag-of-type-p tag "char")
+           (semantic-tag-of-type-p tag "short")
+           (semantic-tag-of-type-p tag "boolean")
+           (semantic-tag-of-type-p tag "int")
+           (semantic-tag-of-type-p tag "long"))
        (jdee-parse-member-is-scalar tag)))
 
 (defun jdee-parse-member-is-float (tag)
   "Check if tag is of a floating point type"
   (and (or (semantic-tag-of-type-p tag "float")
-	   (semantic-tag-of-type-p tag "double")))
+           (semantic-tag-of-type-p tag "double")))
   (jdee-parse-member-is-scalar tag))
 
 (defun jdee-parse-compare-member-types (a b)
@@ -444,21 +444,21 @@ then used as the current class instead of the result of `semantic-current-tag'."
 lower, so that they are returned at the head of the list. This ensures they will be
 processed first and the more costly complex types later."
   (or (and (jdee-parse-member-is-primitive a)
-	   (not (jdee-parse-member-is-primitive b)))
+           (not (jdee-parse-member-is-primitive b)))
       (and (jdee-parse-member-is-float a)
-	   (not (or (jdee-parse-member-is-primitive b)
-		    (jdee-parse-member-is-float b))))
+           (not (or (jdee-parse-member-is-primitive b)
+                    (jdee-parse-member-is-float b))))
       (and (jdee-parse-member-is-scalar a)
-	   (not (or (jdee-parse-member-is-primitive b)
-		    (jdee-parse-member-is-float b)
-		    (jdee-parse-member-is-scalar b))))))
+           (not (or (jdee-parse-member-is-primitive b)
+                    (jdee-parse-member-is-float b)
+                    (jdee-parse-member-is-scalar b))))))
 
 (defun jdee-parse-get-package-name ()
   "Gets the name of the package in which the Java source file in the
 current buffer resides."
   (let ((packages (semantic-brute-find-tag-by-class 'package (current-buffer))))
     (if (and (listp packages) (eq (length packages) 1))
-	(semantic-tag-name (car packages)))))
+        (semantic-tag-name (car packages)))))
 
 (defun jdee-parse-get-package-from-name (class-name)
   "Gets the package portion of a qualified class name."
@@ -466,7 +466,7 @@ current buffer resides."
    class-name 0
    (let ((pos  (cl-position ?. class-name :from-end t)))
      (if pos
-	 pos
+         pos
        0))))
 
 ;;FIXME: remove in favor of jdee-parse-get-package-name
@@ -475,8 +475,8 @@ current buffer resides."
   (save-excursion
     (goto-char (point-min))
     (if (re-search-forward "^[ \t]*\\<\\(package\\) +\\([^ \t\n]*\\) *;" (point-max) t)
-	(concat (buffer-substring-no-properties (match-beginning 2) (match-end 2))
-		"."))))
+        (concat (buffer-substring-no-properties (match-beginning 2) (match-end 2))
+                "."))))
 
 (defun jdee-parse-get-unqualified-name (name)
   "Gets the last name in a qualified name."
@@ -486,18 +486,18 @@ current buffer resides."
 (defun jdee-parse-get-super-class-at-point ()
   (condition-case err
       (let ((superClass "Object")
-	    (class-re "extends[ \t]+\\([a-zA-z]+[a-zA-Z0-9._]*\\).*[ \n]*"))
-	(save-excursion
-	  (let ((open-brace-pos
-		 (scan-lists (point) -1 1)))
-	    (when open-brace-pos
-	      (goto-char open-brace-pos)
-	      (when (re-search-backward class-re (point-min) t)
-		(looking-at class-re)
-		(setq superClass (buffer-substring-no-properties
-				  (match-beginning 1)
-				  (match-end 1)))))))
-	superClass)
+            (class-re "extends[ \t]+\\([a-zA-z]+[a-zA-Z0-9._]*\\).*[ \n]*"))
+        (save-excursion
+          (let ((open-brace-pos
+                 (scan-lists (point) -1 1)))
+            (when open-brace-pos
+              (goto-char open-brace-pos)
+              (when (re-search-backward class-re (point-min) t)
+                (looking-at class-re)
+                (setq superClass (buffer-substring-no-properties
+                                  (match-beginning 1)
+                                  (match-end 1)))))))
+        superClass)
     (error)))
 
 (defconst jdee-parse-class-mod-re
@@ -519,37 +519,37 @@ Returns a list constisting of the result of
 all modifieres of the class.
 Returns nil, if no class could be found."
   (let ((class (jdee-parse-get-innermost-class-at-point))
-	(mod-or-ws-re (concat "\\(" jdee-parse-class-mod-re
-			      "\\|" jdee-parse-java-comment-or-ws-re
-			      "\\)\\="))
-	(case-fold-search)
-	(modifiers))
+        (mod-or-ws-re (concat "\\(" jdee-parse-class-mod-re
+                              "\\|" jdee-parse-java-comment-or-ws-re
+                              "\\)\\="))
+        (case-fold-search)
+        (modifiers))
     (if class
-	(save-excursion
-	  (goto-char (cdr class))
-	  (while (re-search-backward mod-or-ws-re (point-min) t)
-	    (progn
-	      (if (looking-at jdee-parse-class-mod-re)
-		  (setq modifiers
-			(cons (match-string-no-properties 0) modifiers)))))
-	  (setq modifiers (cons class modifiers))))
+        (save-excursion
+          (goto-char (cdr class))
+          (while (re-search-backward mod-or-ws-re (point-min) t)
+            (progn
+              (if (looking-at jdee-parse-class-mod-re)
+                  (setq modifiers
+                        (cons (match-string-no-properties 0) modifiers)))))
+          (setq modifiers (cons class modifiers))))
     modifiers))
 
 (defconst jdee-parse-class-decl-re
   (concat "^"
-	  ;; comments, string literals, keywords, identifier,
-	  ;; assignment operator or open parenthese:
-	  "\\(?:" jdee-parse-java-comment-or-ws-re "\\|[a-zA-Z0-9_.=(]\\)*"
-	  ;; keyword before classname:
-	  "\\<\\(class\\|enum\\|interface\\|new\\)"
-	  "\\(?:" jdee-parse-java-comment-or-ws-re "\\)+"
-	  ;; package part of superclass of anonymous class:
-	  "\\(?:[a-zA-Z0-9_]+\\.\\)*"
-	  ;; classname:
-	  "\\([a-zA-Z0-9_]+\\)"
-	  ;; everything between classname and curly brace:
-	  "\\(?:" jdee-parse-java-comment-or-ws-re "\\|[a-zA-Z0-9_.,()<>]\\)*"
-	  "\\=")
+          ;; comments, string literals, keywords, identifier,
+          ;; assignment operator or open parenthese:
+          "\\(?:" jdee-parse-java-comment-or-ws-re "\\|[a-zA-Z0-9_.=(]\\)*"
+          ;; keyword before classname:
+          "\\<\\(class\\|enum\\|interface\\|new\\)"
+          "\\(?:" jdee-parse-java-comment-or-ws-re "\\)+"
+          ;; package part of superclass of anonymous class:
+          "\\(?:[a-zA-Z0-9_]+\\.\\)*"
+          ;; classname:
+          "\\([a-zA-Z0-9_]+\\)"
+          ;; everything between classname and curly brace:
+          "\\(?:" jdee-parse-java-comment-or-ws-re "\\|[a-zA-Z0-9_.,()<>]\\)*"
+          "\\=")
   "Regular expression matching class declarations before point.
 Point must be at opening curly brace of class.
 It matches interfaces, named and anonymous classes.")
@@ -568,43 +568,43 @@ Returns nil, if point is not in a class."
   (semantic-refresh-tags-safe)
   (let ((left-paren-pos (c-parse-state)))
     (if left-paren-pos
-	(save-excursion
-	  (catch 'class-found
-	    (let ((left-paren-index 0)
-		  (left-paren-count (length left-paren-pos)))
-	      (while (< left-paren-index left-paren-count)
-		(let ((paren-pos (nth left-paren-index left-paren-pos)))
-		  (unless (consp paren-pos)
-		    (goto-char paren-pos)
-		    (when (looking-at "{")
-		      (let* ((search-end-pos
-			      (if (< left-paren-index (1- left-paren-count))
-				  (let ((pos (nth (1+ left-paren-index) left-paren-pos)))
-				    (if (consp pos)
-					(cdr pos)
-				      pos))
-				(point-min)))
-			     (case-fold-search nil)
-			     (class-pos (re-search-backward jdee-parse-class-decl-re search-end-pos t)))
-			(if class-pos
-			    (throw
-			     'class-found
-			     (cons (match-string-no-properties 2)
-				   (match-beginning 1))))))))
-		(setq left-paren-index (1+ left-paren-index)))))))))
+        (save-excursion
+          (catch 'class-found
+            (let ((left-paren-index 0)
+                  (left-paren-count (length left-paren-pos)))
+              (while (< left-paren-index left-paren-count)
+                (let ((paren-pos (nth left-paren-index left-paren-pos)))
+                  (unless (consp paren-pos)
+                    (goto-char paren-pos)
+                    (when (looking-at "{")
+                      (let* ((search-end-pos
+                              (if (< left-paren-index (1- left-paren-count))
+                                  (let ((pos (nth (1+ left-paren-index) left-paren-pos)))
+                                    (if (consp pos)
+                                        (cdr pos)
+                                      pos))
+                                (point-min)))
+                             (case-fold-search nil)
+                             (class-pos (re-search-backward jdee-parse-class-decl-re search-end-pos t)))
+                        (if class-pos
+                            (throw
+                             'class-found
+                             (cons (match-string-no-properties 2)
+                                   (match-beginning 1))))))))
+                (setq left-paren-index (1+ left-paren-index)))))))))
 
 (defun jdee-parse-get-class-at-point ()
   (let ((class-info (jdee-parse-get-innermost-class-at-point))
-	class-name)
+        class-name)
     (while class-info
       (let ((name (car class-info))
-	    (pos (cdr class-info)))
-	(if (not class-name)
-	    (setq class-name name)
-	  (setq class-name (concat name "." class-name)))
-	(save-excursion
-	  (goto-char pos)
-	  (setq class-info (jdee-parse-get-innermost-class-at-point)))))
+            (pos (cdr class-info)))
+        (if (not class-name)
+            (setq class-name name)
+          (setq class-name (concat name "." class-name)))
+        (save-excursion
+          (goto-char pos)
+          (setq class-info (jdee-parse-get-innermost-class-at-point)))))
     class-name))
 
 (defun jdee-parse-get-classes-at-point ()
@@ -633,14 +633,14 @@ is in inner class B of A."
 Return the selection."
   (condition-case err
       (let ((names (jdee-backend-get-qualified-name class)))
-	(if names
-	    (if (> (length names) 1)
-		(efc-query-options
-		 names
-		 (or prompt "Select class.")
-		 "Class Name Dialog")
-	      (car names))
-	  (error "Cannot find class %s on the current classpath." class)))
+        (if names
+            (if (> (length names) 1)
+                (efc-query-options
+                 names
+                 (or prompt "Select class.")
+                 "Class Name Dialog")
+              (car names))
+          (error "Cannot find class %s on the current classpath." class)))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -651,7 +651,7 @@ QUALIFIER is the symbol's qualifier. For example, suppose the name at
 point is
 
      int i = error.msg.length()
-		   ^
+                   ^
 In this case, this function returns (cons \"error.msg\" \"length\").
 This function works only for qualified names that do not contain
 white space. It returns null if there is no qualified name at point."
@@ -659,18 +659,18 @@ white space. It returns null if there is no qualified name at point."
     (when symbol-at-point
        (thing-at-point-looking-at "[^ \n\t();,:+<]+") ;; add < to prevent like "Map<String"
       (let ((qualified-name
-	     (buffer-substring-no-properties
-	      (match-beginning 0)
-	      (match-end 0))))
-	(string-match "\\(.+[.]\\)*\\([^.]+\\)" qualified-name)
-	(let ((qualifier (if (match-beginning 1)
-			     (substring qualified-name
-					(match-beginning 1) (match-end 1))))
-	      (name (substring qualified-name
-			       (match-beginning 2) (match-end 2))))
-	  (if qualifier
-	      (setq qualifier (substring qualifier 0 (1- (length qualifier)))))
-	  (cons qualifier name))))))
+             (buffer-substring-no-properties
+              (match-beginning 0)
+              (match-end 0))))
+        (string-match "\\(.+[.]\\)*\\([^.]+\\)" qualified-name)
+        (let ((qualifier (if (match-beginning 1)
+                             (substring qualified-name
+                                        (match-beginning 1) (match-end 1))))
+              (name (substring qualified-name
+                               (match-beginning 2) (match-end 2))))
+          (if qualifier
+              (setq qualifier (substring qualifier 0 (1- (length qualifier)))))
+          (cons qualifier name))))))
 
 
 ;;;###autoload
@@ -684,21 +684,21 @@ If called interactively, add the name in the mini-buffer."
   (interactive (list (not current-prefix-arg)))
   (if (eq major-mode 'jdee-mode)
       (let ((package-name (jdee-parse-get-package-name))
-	    (class-name (file-name-sans-extension
-			 (file-name-nondirectory (buffer-file-name)))))
-	(if (and (not no-package-p) package-name)
-	    (setq class-name (concat package-name "." class-name)))
-	(when (called-interactively-p 'interactive)
-	  (kill-new class-name)
-	  (message (format "Copied `%s'" class-name)))
-	class-name)
+            (class-name (file-name-sans-extension
+                         (file-name-nondirectory (buffer-file-name)))))
+        (if (and (not no-package-p) package-name)
+            (setq class-name (concat package-name "." class-name)))
+        (when (called-interactively-p 'interactive)
+          (kill-new class-name)
+          (message (format "Copied `%s'" class-name)))
+        class-name)
     (error "Not a Java source buffer.")))
 
 
 (defun jdee-parse-get-buffer-unqualified-class ()
   "Get the class name from the buffer filename"
   (file-name-sans-extension (file-name-nondirectory
-			     (or (buffer-file-name) "Object.java"))))
+                             (or (buffer-file-name) "Object.java"))))
 
 ;;;TODO: is the same as jdee-parse-get-buffer-class?
 (defun jdee-parse-fqn ()
@@ -734,15 +734,15 @@ Return the fully qualified name."
   (rx
    (1+              ;; A Java symbol comprises one or more of the following:
     (char (?A . ?Z)   ;;   - upper case characters
-	  (?a . ?z)   ;;   - lower case characters
-	  (?0 . ?9)   ;;   - digits
-	  "[]"        ;;   - square brackets
-	  "?"         ;;   - question mark
-	  "<,> \t\n\r";;   - java1.5 generic support
-	  "_"         ;;   - underscore
-	  "."         ;;   - period
-	  (160 . 255) ;;   - accented characters
-	  )))
+          (?a . ?z)   ;;   - lower case characters
+          (?0 . ?9)   ;;   - digits
+          "[]"        ;;   - square brackets
+          "?"         ;;   - question mark
+          "<,> \t\n\r";;   - java1.5 generic support
+          "_"         ;;   - underscore
+          "."         ;;   - period
+          (160 . 255) ;;   - accented characters
+          )))
 "Regular expression that matches any Java symbol declare.")
 
 (defun jdee-parse-valid-declaration-at (point varname)
@@ -752,37 +752,37 @@ for the VARNAME variable."
     (goto-char point)
     (let ((case-fold-search nil)) ;; Why case-insensitive?
       (if (or
-	   (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
-			      (jdee-parse-double-backslashes varname)
-			      "[]?[ \t\n\r]*[),;=]"))
+           (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
+                              (jdee-parse-double-backslashes varname)
+                              "[]?[ \t\n\r]*[),;=]"))
 
-	   ;; Handle case where varname is part of a list declaration, e.g.,
-	   ;;
-	   ;;   String a, b, c;
-	   ;;
-	   (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
-			       "\\(" jdee-parse-java-symbol-re "[ \t\n\r]*,[ \t\n\r]*\\)*"
-			      (jdee-parse-double-backslashes varname)
-			      "[]?[ \t\n\r]*[,;]"))
-	   ;; Parse jdk1.5 for (Type val : collection) {
-	   (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
-			       varname "[ \t\n\r]*:")))  ;[ \t\n\r]*"
-			       ;"\\(" jdee-parse-java-symbol-re "[,{} \t\n\r]*\\)+" ")")))
-	  (let ((type (match-string 1))
-		(type-pos (match-beginning 1)))
-	    (goto-char type-pos)
-	    ;;  Check for following case.
-	    ;;     Object table
-	    ;;    //representing objects after all updates.
-	    ;;    table = new Truc();
-	    ;;    table.
-	    ;;  Avoid false hit on updates.
-	    (if (not (or
-		      (jdee-parse-comment-or-quoted-p)
-		      (string= type "instanceof")
-		      (string= type "return")))
-		type))
-	nil))))
+           ;; Handle case where varname is part of a list declaration, e.g.,
+           ;;
+           ;;   String a, b, c;
+           ;;
+           (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
+                               "\\(" jdee-parse-java-symbol-re "[ \t\n\r]*,[ \t\n\r]*\\)*"
+                              (jdee-parse-double-backslashes varname)
+                              "[]?[ \t\n\r]*[,;]"))
+           ;; Parse jdk1.5 for (Type val : collection) {
+           (looking-at (concat "\\(" jdee-parse-java-symbol-declare-re "\\)[ \t\n\r]+"
+                               varname "[ \t\n\r]*:")))  ;[ \t\n\r]*"
+                               ;"\\(" jdee-parse-java-symbol-re "[,{} \t\n\r]*\\)+" ")")))
+          (let ((type (match-string 1))
+                (type-pos (match-beginning 1)))
+            (goto-char type-pos)
+            ;;  Check for following case.
+            ;;     Object table
+            ;;    //representing objects after all updates.
+            ;;    table = new Truc();
+            ;;    table.
+            ;;  Avoid false hit on updates.
+            (if (not (or
+                      (jdee-parse-comment-or-quoted-p)
+                      (string= type "instanceof")
+                      (string= type "return")))
+                type))
+        nil))))
 
 (defun jdee-parse-declared-type-of (name)
   "Find in the current buffer the java type of the variable NAME.  The
@@ -801,11 +801,11 @@ the containing/outer class of the declared type."
       ;; now check for qualifying identifier. Note: reuses
       ;; jdee-parse-qualified-name-at-point for simplicity, not efficiency
       (if found
-	  (let (qualname)
-	    (goto-char foundpt)
-	    (setq qualname (jdee-parse-qualified-name-at-point))
-	    (setq qualifier (car qualname))
-	    (setq res (cdr qualname))))
+          (let (qualname)
+            (goto-char foundpt)
+            (setq qualname (jdee-parse-qualified-name-at-point))
+            (setq qualifier (car qualname))
+            (setq res (cdr qualname))))
 
       (cons res qualifier))))
 
@@ -822,93 +822,93 @@ could be found."
 
       ;; Search backward in the buffer.
       (while (and (not found)
-		  (search-backward name nil t))
-	(setq pos (point))
+                  (search-backward name nil t))
+        (setq pos (point))
     (setq lastpos (point))
 
-	;; Position point at the start of the type
-	;; symbol in the declaration, e.g.,
-	;;
-	;;  String s;
-	;;  ^
-	(backward-word 1)
+        ;; Position point at the start of the type
+        ;; symbol in the declaration, e.g.,
+        ;;
+        ;;  String s;
+        ;;  ^
+        (backward-word 1)
 
-	;; Handle case where declaration declares
-	;; a list of symbols, e.g.,
-	;;
-	;;  String a, b, c;
-	;;
-	;; In this case, back over any entries in
-	;; the list ahead of name.
-	(while (looking-at symbol-list-entry-re)
+        ;; Handle case where declaration declares
+        ;; a list of symbols, e.g.,
+        ;;
+        ;;  String a, b, c;
+        ;;
+        ;; In this case, back over any entries in
+        ;; the list ahead of name.
+        (while (looking-at symbol-list-entry-re)
       (setq lastpos (point))
-	  (backward-word 1))
+          (backward-word 1))
     ;;  List<String, List<String>> a;
     ;;                    ^
     ;; In this case, back over any entries between < and >
     (let ((try-count 0)
-	  (max-try-count 20))
+          (max-try-count 20))
       (while (and
-	      (< try-count max-try-count)
-	      (not
-	       (= (cl-count ?< (buffer-substring (point) lastpos))
-		  (cl-count ?> (buffer-substring (point) lastpos)))))
-	(setq try-count (1+ try-count))
-	(backward-word 1)))
+              (< try-count max-try-count)
+              (not
+               (= (cl-count ?< (buffer-substring (point) lastpos))
+                  (cl-count ?> (buffer-substring (point) lastpos)))))
+        (setq try-count (1+ try-count))
+        (backward-word 1)))
 
 
-	(setq resname (jdee-parse-valid-declaration-at (point) name))
-	(setq foundpt (point))
-	(goto-char pos)
-	(forward-char -1)
-	(if (and resname
-		 (not (jdee-parse-keywordp resname)))
-	    (setq found t)))
+        (setq resname (jdee-parse-valid-declaration-at (point) name))
+        (setq foundpt (point))
+        (goto-char pos)
+        (forward-char -1)
+        (if (and resname
+                 (not (jdee-parse-keywordp resname)))
+            (setq found t)))
 
       (unless found
 
-	;; Not found backward in buffer. Try looking forward.
-	(goto-char orgpt)
+        ;; Not found backward in buffer. Try looking forward.
+        (goto-char orgpt)
 
-	(while (and (not found)
-		    (search-forward name nil t))
-	  (setq pos (point))
+        (while (and (not found)
+                    (search-forward name nil t))
+          (setq pos (point))
       (setq lastpos (point))
-	  (backward-word 2)
+          (backward-word 2)
 
-	  (while (looking-at symbol-list-entry-re)
-	(setq lastpos (point))
-	    (backward-word 1))
+          (while (looking-at symbol-list-entry-re)
+        (setq lastpos (point))
+            (backward-word 1))
 
     ;;  List<String, List<String>> a;
     ;;                    ^
     ;; In this case, back over any entries between < and >
       (let ((try-count 0)
-	    (max-try-count 20))
-	(while (and
-		(< try-count max-try-count)
-		(not
-		 (= (cl-count ?< (buffer-substring (point) lastpos))
-		    (cl-count ?> (buffer-substring (point) lastpos)))))
-	  (setq try-count (1+ try-count))
-	  (backward-word 1)))
+            (max-try-count 20))
+        (while (and
+                (< try-count max-try-count)
+                (not
+                 (= (cl-count ?< (buffer-substring (point) lastpos))
+                    (cl-count ?> (buffer-substring (point) lastpos)))))
+          (setq try-count (1+ try-count))
+          (backward-word 1)))
 
-	  (setq resname (jdee-parse-valid-declaration-at (point) name))
-	  (setq foundpt (point))
-	  (goto-char pos)
-	  (forward-char 1)
-	  (if (and resname
-		   (not (jdee-parse-keywordp resname)))
-	      (setq found t))))
+          (setq resname (jdee-parse-valid-declaration-at (point) name))
+          (setq foundpt (point))
+          (goto-char pos)
+          (forward-char 1)
+          (if (and resname
+                   (not (jdee-parse-keywordp resname)))
+              (setq found t))))
 
       (if found foundpt nil))))
 
 
 (defun jdee-display-parse-error (error)
   (let* ((parser-buffer-name "*Java Parser*")
-	 (buf (get-buffer parser-buffer-name)))
+         (buf (get-buffer parser-buffer-name)))
     (if (not buf)
-	(setq buf (get-buffer-create parser-buffer-name)))
+        (setq buf (get-buffer-create parser-buffer-name)))
     (set-buffer buf)
     (erase-buffer)
     (insert error)
@@ -933,50 +933,50 @@ fast."
   (let ((parse-error
          (jdee-backend-parse-file (buffer-file-name))))
     (if parse-error
-	(jdee-display-parse-error parse-error)
+        (jdee-display-parse-error parse-error)
       (message "Parsed %s successfully" (buffer-name)))))
 
 (defun jdee-parse-comment-or-quoted-p ()
   "Returns t if point is in a comment or a quoted string,
 otherwise nil."
   (let* ((state (save-excursion
-		  (parse-partial-sexp (point-min) (point)))))
+                  (parse-partial-sexp (point-min) (point)))))
     (if (or (nth 3 state)
-	    (nth 4 state))
-	t)))
+            (nth 4 state))
+        t)))
 
 (defun jdee-parse--search-class (class pos)
   ;; Define an internal function that recursively searches a class
   ;; and its subclasses for a method containing point.
   (let* ((class-name       (semantic-tag-name class))
-	 (class-parts      (semantic-tag-type-members class))
-	 (class-subclasses (semantic-brute-find-tag-by-class 'type class-parts))
-	 (class-methods    (semantic-brute-find-tag-by-class 'function class-parts)))
+         (class-parts      (semantic-tag-type-members class))
+         (class-subclasses (semantic-brute-find-tag-by-class 'type class-parts))
+         (class-methods    (semantic-brute-find-tag-by-class 'function class-parts)))
 
     ;; Is point in a method of a subclass of this class?
     (loop for subclass in class-subclasses do
-	  (jdee-parse--search-class subclass pos))
+          (jdee-parse--search-class subclass pos))
 
     ;; Is point in any of the methods of this class?
     (loop for method in class-methods do
-	  (let* ((method-name  (semantic-tag-name method))
-		 (method-start (semantic-tag-start method))
-		 (method-end   (semantic-tag-end method)))
-	    (when (and (>= pos method-start)
-		       (<= pos method-end))
-	      (throw 'found (cons (cons class-name method-name)
-				  (cons method-start method-end))))))))
+          (let* ((method-name  (semantic-tag-name method))
+                 (method-start (semantic-tag-start method))
+                 (method-end   (semantic-tag-end method)))
+            (when (and (>= pos method-start)
+                       (<= pos method-end))
+              (throw 'found (cons (cons class-name method-name)
+                                  (cons method-start method-end))))))))
 
 (defun jdee-parse-get-method-at-point (&optional position)
   "Gets the method at POSITION, if specified, otherwise at point.
 Returns (CLASS_NAME . METHOD_NAME) if the specified position is
 in a method; otherwise, nil."
   (let* ((pos (if position position (point)))
-	 (tokens (semantic-fetch-tags))
-	 (classes (semantic-brute-find-tag-by-class 'type tokens)))
+         (tokens (semantic-fetch-tags))
+         (classes (semantic-brute-find-tag-by-class 'type tokens)))
     (catch 'found
       (loop for class in classes
-	    do (jdee-parse--search-class class pos)))))
+            do (jdee-parse--search-class class pos)))))
 
 (defclass jdee-parse-method-map (jdee-avl-tree)
   ()
@@ -990,24 +990,24 @@ in a method; otherwise, nil."
 
 (defun jdee-parse--add-methods (method-map class)
   (let* ((class-name       (semantic-tag-name class))
-	 (class-parts      (semantic-tag-type-members class))
-	 (class-subclasses (semantic-brute-find-tag-by-class 'type class-parts))
-	 (class-methods    (semantic-brute-find-tag-by-class 'function class-parts)))
+         (class-parts      (semantic-tag-type-members class))
+         (class-subclasses (semantic-brute-find-tag-by-class 'type class-parts))
+         (class-methods    (semantic-brute-find-tag-by-class 'function class-parts)))
 
     ;; Add methods of subclasses
     (loop for subclass in class-subclasses do
-	  (jdee-parse--add-methods method-map subclass))
+          (jdee-parse--add-methods method-map subclass))
 
     ;; Add methods of this class?
     (loop for method in class-methods do
-	  (let* ((method-name  (semantic-tag-name method))
-		 (method-start (semantic-tag-start method))
-		 (method-end   (semantic-tag-end method)))
-	    (jdee-avl-tree-add
-	     method-map
-	     (cons
-	      (cons class-name method-name)
-	      (cons method-start method-end)))))))
+          (let* ((method-name  (semantic-tag-name method))
+                 (method-start (semantic-tag-start method))
+                 (method-end   (semantic-tag-end method)))
+            (jdee-avl-tree-add
+             method-map
+             (cons
+              (cons class-name method-name)
+              (cons method-start method-end)))))))
 
 (defmethod initialize-instance ((this jdee-parse-method-map) &rest fields)
   "Constructor for method map."
@@ -1018,9 +1018,9 @@ in a method; otherwise, nil."
   (call-next-method)
 
   (let* ((tokens (semantic-fetch-tags))
-	 (classes (semantic-brute-find-tag-by-class 'type tokens)))
+         (classes (semantic-brute-find-tag-by-class 'type tokens)))
     (loop for class in classes do
-	  (jdee-parse--add-methods this class))))
+          (jdee-parse--add-methods this class))))
 
 (defmethod jdee-parse-method-map-get-method-at ((this jdee-parse-method-map) &optional pos)
   "Get the method at POS, if specified, otherwise, at point."
@@ -1035,16 +1035,16 @@ in a method; otherwise, nil."
 (defun jdee-current-buffer-exact-name-match-p (tag)
   (and (tag-exact-match-p tag)
        (equal (buffer-file-name (window-buffer (selected-window)))
-	      (file-of-tag))))
+              (file-of-tag))))
 
 (defun jdee-etags-recognize-tags-table () ; see etags-recognize-tags-table
   (let ((recognized (etags-recognize-tags-table)))
     (if recognized
-	;; prefer exact match in current buffer to other files
-	(setq find-tag-tag-order '(jdee-current-buffer-exact-name-match-p
-				   tag-exact-file-name-match-p
-				   tag-exact-match-p
-				   ))
+        ;; prefer exact match in current buffer to other files
+        (setq find-tag-tag-order '(jdee-current-buffer-exact-name-match-p
+                                   tag-exact-file-name-match-p
+                                   tag-exact-match-p
+                                   ))
       recognized)))
 
 (defun jdee-parse-java-variable-at-point ()
@@ -1076,30 +1076,30 @@ at point. This function would return the list (\"obj.f1\" \"ge\")."
       ;;                      ^              ^
       (setq curcar (char-before))
       (if curcar
-	  (progn
-	    (while (null found)
-	      (cond
-	       ((or (and (>= curcar ?a) (<= curcar ?z)) ; a-z
-		    (and (>= curcar ?A) (<= curcar ?Z)) ; A-z
-		    (and (>= curcar ?0) (<= curcar ?9))
-		    (>= curcar 127)
-		    (member curcar '(?$ ?_ ?\\))) ;; _ \
-		(forward-char -1))
-	       ((eq ?. curcar)
-		(setq dot-offset 1)
-		(if (eq ?\) (char-before (- (point) 1)))
-		    (progn
-		      (forward-char -2)
-		      (setq first-paren (point))
-		      (setq second-paren (jdee-parse-match-paren-position))
-		      (setq offset (+ (- first-paren second-paren) 1))
-		      (forward-char 2)
-		      (setq found (point)))
-		  (setq found (point))))
-	       (t
-		(setq found (point))))
-	      (setq curcar (char-before)))
-	    (setq intermediate-point found)
+          (progn
+            (while (null found)
+              (cond
+               ((or (and (>= curcar ?a) (<= curcar ?z)) ; a-z
+                    (and (>= curcar ?A) (<= curcar ?Z)) ; A-z
+                    (and (>= curcar ?0) (<= curcar ?9))
+                    (>= curcar 127)
+                    (member curcar '(?$ ?_ ?\\))) ;; _ \
+                (forward-char -1))
+               ((eq ?. curcar)
+                (setq dot-offset 1)
+                (if (eq ?\) (char-before (- (point) 1)))
+                    (progn
+                      (forward-char -2)
+                      (setq first-paren (point))
+                      (setq second-paren (jdee-parse-match-paren-position))
+                      (setq offset (+ (- first-paren second-paren) 1))
+                      (forward-char 2)
+                      (setq found (point)))
+                  (setq found (point))))
+               (t
+                (setq found (point))))
+              (setq curcar (char-before)))
+            (setq intermediate-point found)
 
         ;; Back up past any white space.  This lets completion work when
         ;; continuing onto a new-line.
@@ -1107,19 +1107,19 @@ at point. This function would return the list (\"obj.f1\" \"ge\")."
         (skip-syntax-backward " >")
 
 
-	   ;; Now move point to the beginning of the expression, e.g.,
-	    ;; from
-	    ;;
-	    ;;  obj.f1.ge
-	    ;;        ^
-	    ;; to
-	    ;;
-	    ;;  obj.f1.ge
-	    ;; ^
-	    ;; Note that if we did not find a dot, (e.g., new Widget), we are
-	    ;; already at the beginning of the text part of the expression.
-	    (progn
-	      (setq curcar (char-before))
+           ;; Now move point to the beginning of the expression, e.g.,
+            ;; from
+            ;;
+            ;;  obj.f1.ge
+            ;;        ^
+            ;; to
+            ;;
+            ;;  obj.f1.ge
+            ;; ^
+            ;; Note that if we did not find a dot, (e.g., new Widget), we are
+            ;; already at the beginning of the text part of the expression.
+            (progn
+              (setq curcar (char-before))
           (when (> dot-offset 0)
             (while (or (and (>= curcar ?a) (<= curcar ?z))
                        (and (>= curcar ?A) (<= curcar ?Z))
@@ -1145,44 +1145,44 @@ at point. This function would return the list (\"obj.f1\" \"ge\")."
               (forward-char -1)
               (setq curcar (char-before))))
 
-	      (setq beg-point (point))
-	      (set-marker jdee-parse-current-beginning intermediate-point)
-	      (set-marker jdee-parse-current-end original-point)
-	      (setq middle-point (- intermediate-point dot-offset offset))
-	      (setq first-part
-		    (buffer-substring-no-properties beg-point middle-point))
-	      (setq first-part (jdee-parse-isolate-to-parse first-part))
+              (setq beg-point (point))
+              (set-marker jdee-parse-current-beginning intermediate-point)
+              (set-marker jdee-parse-current-end original-point)
+              (setq middle-point (- intermediate-point dot-offset offset))
+              (setq first-part
+                    (buffer-substring-no-properties beg-point middle-point))
+              (setq first-part (jdee-parse-isolate-to-parse first-part))
 
-	      ;;replacing newline by empty strings new lines seems to break the
-	      ;;beanshell
-	      (while (string-match "\n" first-part)
-		(setq first-part (replace-match "" nil nil first-part)))
+              ;;replacing newline by empty strings new lines seems to break the
+              ;;beanshell
+              (while (string-match "\n" first-part)
+                (setq first-part (replace-match "" nil nil first-part)))
 
-	      ;;replacing extra spaces for "". This done to reduce the space
-	      ;;that the completion title takes
-	      (while (string-match " " first-part)
-		(setq first-part (replace-match "" nil nil first-part)))
+              ;;replacing extra spaces for "". This done to reduce the space
+              ;;that the completion title takes
+              (while (string-match " " first-part)
+                (setq first-part (replace-match "" nil nil first-part)))
 
-	      (setq second-part
-		    (buffer-substring-no-properties
-		     intermediate-point original-point-before-ws))
+              (setq second-part
+                    (buffer-substring-no-properties
+                     intermediate-point original-point-before-ws))
 
           (while (string-match "\\s-\\|\\s>" second-part)
             (setq second-part (replace-match "" nil nil second-part)))
 
-	      ;;Checking for casting
-	      ;; ((Object) obj).ge
-	      ;; FIXME can't work ok for generic type, eg: ((List<String>) obj).ge
-	      (if (and (not cast-type)
-		       (string= first-part "")
-		       (eq (char-before (+ 1 middle-point)) ?\()
-		       (eq (char-before (+ 2 middle-point)) ?\())
-		  (save-excursion
-		    (goto-char (+ middle-point 1))
-		    (setq first-paren (point))
-		    (setq second-paren (jdee-parse-match-paren-position))
-		    (setq cast-type (buffer-substring-no-properties
-				     (+ 1 first-paren) second-paren))))
+              ;;Checking for casting
+              ;; ((Object) obj).ge
+              ;; FIXME can't work ok for generic type, eg: ((List<String>) obj).ge
+              (if (and (not cast-type)
+                       (string= first-part "")
+                       (eq (char-before (+ 1 middle-point)) ?\()
+                       (eq (char-before (+ 2 middle-point)) ?\())
+                  (save-excursion
+                    (goto-char (+ middle-point 1))
+                    (setq first-paren (point))
+                    (setq second-paren (jdee-parse-match-paren-position))
+                    (setq cast-type (buffer-substring-no-properties
+                                     (+ 1 first-paren) second-paren))))
 
           ;; If the parsed region is just white-space, move the start of the
           ;; region to the end of the region to preserve the whitespace
@@ -1191,54 +1191,54 @@ at point. This function would return the list (\"obj.f1\" \"ge\")."
                                                               jdee-parse-current-end))
             (setq jdee-parse-current-beginning jdee-parse-current-end))
 
-	      (if cast-type
+              (if cast-type
               (progn
                 (setq jdee-parse-casting t)
                 (list cast-type second-part))
             (progn
               (setq jdee-parse-casting nil)
               (list first-part second-part))))
-	    )))))
+            )))))
 
 (defun jdee-parse-isolate-to-parse (s)
   "Returns the right expression that needs completion in S."
   (let* ((index (length s)) stop (paren 0) curcar final-string
-	 (inside-quotes nil))
+         (inside-quotes nil))
     (while (and (> index 0)
-		(not stop))
+                (not stop))
       (setq index (1- index))
       (setq curcar (aref s index))
       (cond
        ((eq ?\" curcar);;Checking if we are inside double quotes
-	(if (not (eq ?\\ (aref s (max 0 (1- index))))) ;;if the quote is not escape
-	    (setq inside-quotes (not inside-quotes))))
+        (if (not (eq ?\\ (aref s (max 0 (1- index))))) ;;if the quote is not escape
+            (setq inside-quotes (not inside-quotes))))
        ((eq ?\) curcar)
-	(if (not inside-quotes)
-	    (setq paren (1+ paren))))
+        (if (not inside-quotes)
+            (setq paren (1+ paren))))
        ((eq ?\( curcar)
-	(if (not inside-quotes)
-	    (setq paren (1- paren)))))
+        (if (not inside-quotes)
+            (setq paren (1- paren)))))
       (if (or (< paren 0)
-	      (and (eq curcar ?\,) (<= paren 0)))
-	  (setq stop t)))
+              (and (eq curcar ?\,) (<= paren 0)))
+          (setq stop t)))
     (if stop
-	(setq index (1+ index)))
+        (setq index (1+ index)))
     (setq final-string (substring s index))
     (if (and (not (string= final-string ""))
-	     (string= "(" (substring final-string 0 1)))
-	(let* ((closing-paren (string-match ")" final-string))
-	       (closing (string-match ")." final-string (+ 1 closing-paren))))
-	  (setq final-string
-		(concat (substring final-string 2 closing-paren)
-			"."
-			(substring final-string (+ closing 2))))))
+             (string= "(" (substring final-string 0 1)))
+        (let* ((closing-paren (string-match ")" final-string))
+               (closing (string-match ")." final-string (+ 1 closing-paren))))
+          (setq final-string
+                (concat (substring final-string 2 closing-paren)
+                        "."
+                        (substring final-string (+ closing 2))))))
     final-string))
 (defun jdee-parse-match-paren-position ()
   "Returns the position of the parenthesis match"
   (let ((current (point))
-	match)
+        match)
     (cond ((looking-at "\\s\(") (forward-list 1) (backward-char 1))
-	  ((looking-at "\\s\)") (forward-char 1) (backward-list 1)))
+          ((looking-at "\\s\)") (forward-char 1) (backward-list 1)))
     (setq match (point))
     (goto-char current)
     match))
@@ -1284,182 +1284,182 @@ For example: 000F or 123f."
 Java type name, e.g., int."
   (if expr
       (let ((class-at-point (jdee-parse-get-class-at-point))
-	    (super-at-point (jdee-parse-get-super-class-at-point))
-	    qualified-name chop-pos temp answer)
-	(setq answer
-	      (cond
-	       ((jdee--parse-integer-p expr) "int")
-	       ((jdee--parse-long-p expr) "long")
-	       ((jdee--parse-double-p expr) "double")
-	       ((jdee--parse-float-p expr) "float")
-	       ((jdee--parse-boolean-p expr) "boolean")
-	       ((jdee--parse-char-p expr) "char")
-	       ((jdee--parse-string-p expr) "java.lang.String")
-	       ;; If it's "this", we return the class name of the class we code in
-	       ((and class-at-point (string= "this" expr))
-		(jdee-parse-get-qualified-name class-at-point t))
-	       ;; If it's "super", we return the super class
-	       ;;name of the class we code in
-	       ((and super-at-point (string= "super" expr))
-		(jdee-parse-get-qualified-name super-at-point t))
-	       ;;if it's a class name, done
-	       ((setq qualified-name (jdee-parse-get-qualified-name expr t))
-		qualified-name)
+            (super-at-point (jdee-parse-get-super-class-at-point))
+            qualified-name chop-pos temp answer)
+        (setq answer
+              (cond
+               ((jdee--parse-integer-p expr) "int")
+               ((jdee--parse-long-p expr) "long")
+               ((jdee--parse-double-p expr) "double")
+               ((jdee--parse-float-p expr) "float")
+               ((jdee--parse-boolean-p expr) "boolean")
+               ((jdee--parse-char-p expr) "char")
+               ((jdee--parse-string-p expr) "java.lang.String")
+               ;; If it's "this", we return the class name of the class we code in
+               ((and class-at-point (string= "this" expr))
+                (jdee-parse-get-qualified-name class-at-point t))
+               ;; If it's "super", we return the super class
+               ;;name of the class we code in
+               ((and super-at-point (string= "super" expr))
+                (jdee-parse-get-qualified-name super-at-point t))
+               ;;if it's a class name, done
+               ((setq qualified-name (jdee-parse-get-qualified-name expr t))
+                qualified-name)
 
-	       ;;check if it's an inner class
-	       ((and expr
-		     class-at-point
-		     (string= "this.this" expr)
-		     (setq qualified-name (jdee-parse-get-inner-class
-					   class-at-point)))
-		qualified-name)
+               ;;check if it's an inner class
+               ((and expr
+                     class-at-point
+                     (string= "this.this" expr)
+                     (setq qualified-name (jdee-parse-get-inner-class
+                                           class-at-point)))
+                qualified-name)
 
-	       (t
-		(let (to-complete
-		      (last-char
-		       (aref expr (- (length expr) 1 ))))
-		  ;; If it ends with a parenthesis
-		  (cond
-		   ((eq last-char ?\))
-		    (let* ((result
-			    (jdee-parse-isolate-before-matching-of-last-car
-			     expr))
-			   (temp (if (not (string= "this.this" result))
-				     (jdee-parse-split-by-dots result)))
-			   to-complete)
-		      (if temp
-			  (jdee-parse-find-completion-for-pair temp)
-			;;we need exact completion here
-			(jdee-parse-find-completion-for-pair
-			 (list "this" result) nil jdee-complete-private))
+               (t
+                (let (to-complete
+                      (last-char
+                       (aref expr (- (length expr) 1 ))))
+                  ;; If it ends with a parenthesis
+                  (cond
+                   ((eq last-char ?\))
+                    (let* ((result
+                            (jdee-parse-isolate-before-matching-of-last-car
+                             expr))
+                           (temp (if (not (string= "this.this" result))
+                                     (jdee-parse-split-by-dots result)))
+                           to-complete)
+                      (if temp
+                          (jdee-parse-find-completion-for-pair temp)
+                        ;;we need exact completion here
+                        (jdee-parse-find-completion-for-pair
+                         (list "this" result) nil jdee-complete-private))
 
-		      ;;if the previous did not work try only result
-		      (if (not jdee-complete-current-list)
-			  (jdee-parse-find-completion-for-pair (list result "")))
+                      ;;if the previous did not work try only result
+                      (if (not jdee-complete-current-list)
+                          (jdee-parse-find-completion-for-pair (list result "")))
 
-		      ;;if the previous did not work try again
-		      (setq qualified-name
-			    (jdee-parse-get-qualified-name result t))
-		      (if qualified-name
-			  qualified-name
-			(if jdee-complete-current-list
-			    (progn
-			      (setq to-complete
-				    (car (car jdee-complete-current-list)))
-			      (setq chop-pos (+ 3 (string-match " : " to-complete)))
-			      (let* ((space-pos (string-match " " to-complete chop-pos))
-				     (uqname (if space-pos (substring to-complete chop-pos space-pos)
-					       (substring to-complete chop-pos))))
-				uqname))))))
+                      ;;if the previous did not work try again
+                      (setq qualified-name
+                            (jdee-parse-get-qualified-name result t))
+                      (if qualified-name
+                          qualified-name
+                        (if jdee-complete-current-list
+                            (progn
+                              (setq to-complete
+                                    (car (car jdee-complete-current-list)))
+                              (setq chop-pos (+ 3 (string-match " : " to-complete)))
+                              (let* ((space-pos (string-match " " to-complete chop-pos))
+                                     (uqname (if space-pos (substring to-complete chop-pos space-pos)
+                                               (substring to-complete chop-pos))))
+                                uqname))))))
 
-		   ;;if it's an array
-		   ((eq last-char ?\])
-		    (let ((temp (jdee-parse-eval-type-of
-				 (jdee-parse-isolate-before-matching-of-last-car
-				  expr))))
-		      (jdee-parse-get-component-type-of-array-class temp)))
+                   ;;if it's an array
+                   ((eq last-char ?\])
+                    (let ((temp (jdee-parse-eval-type-of
+                                 (jdee-parse-isolate-before-matching-of-last-car
+                                  expr))))
+                      (jdee-parse-get-component-type-of-array-class temp)))
 
-		   ;;we look for atoms if expr is splittable by dots
-		   ((setq temp (if (not (string= "this.this" expr))
-				   (jdee-parse-split-by-dots expr)))
-		    ;;we need exact completion here
-		    (jdee-parse-find-completion-for-pair temp t)
-		    (if jdee-complete-current-list
-			(progn
-			  (setq to-complete (car (car
-						  jdee-complete-current-list)))
-			  (setq chop-pos (+ 3 (string-match " : " to-complete)))
-			  (let* ((space-pos (string-match " " to-complete chop-pos))
-				 (uqname (if space-pos (substring to-complete chop-pos space-pos)
-					   (substring to-complete chop-pos))))
-			    (jdee-parse-get-qualified-name uqname)))
+                   ;;we look for atoms if expr is splittable by dots
+                   ((setq temp (if (not (string= "this.this" expr))
+                                   (jdee-parse-split-by-dots expr)))
+                    ;;we need exact completion here
+                    (jdee-parse-find-completion-for-pair temp t)
+                    (if jdee-complete-current-list
+                        (progn
+                          (setq to-complete (car (car
+                                                  jdee-complete-current-list)))
+                          (setq chop-pos (+ 3 (string-match " : " to-complete)))
+                          (let* ((space-pos (string-match " " to-complete chop-pos))
+                                 (uqname (if space-pos (substring to-complete chop-pos space-pos)
+                                           (substring to-complete chop-pos))))
+                            (jdee-parse-get-qualified-name uqname)))
 
-		      nil))
-		   (t
-		    ;; See if it's declared somewhere in this buffer.
-		    (let (parsed-type result result-qualifier)
-		      (setq parsed-type (jdee-parse-declared-type-of expr))
-		      (setq result (car parsed-type))
-		      (setq result-qualifier (cdr parsed-type))
+                      nil))
+                   (t
+                    ;; See if it's declared somewhere in this buffer.
+                    (let (parsed-type result result-qualifier)
+                      (setq parsed-type (jdee-parse-declared-type-of expr))
+                      (setq result (car parsed-type))
+                      (setq result-qualifier (cdr parsed-type))
 
-		      (if result
-			  (let ((count 0) type)
-			    (while (string-match ".*\\[\\]" result)
-			      (setq result (substring result 0
-						      (- (length result) 2)))
-			      (setq count (1+ count)))
+                      (if result
+                          (let ((count 0) type)
+                            (while (string-match ".*\\[\\]" result)
+                              (setq result (substring result 0
+                                                      (- (length result) 2)))
+                              (setq count (1+ count)))
 
-			    (let (work)
-			      (setq type
-				    (cond
+                            (let (work)
+                              (setq type
+                                    (cond
                                      ;; handle primitive types, e.g., int
-				     ((member result jdee-parse-primitive-types)
-				      result)
+                                     ((member result jdee-parse-primitive-types)
+                                      result)
                                      ;; quickly make sure fully qualified name
-				     ;;doesn't exist
-				     ((and result-qualifier
-					   (jdee-parse-class-exists
-					    (setq work (concat result-qualifier
-							       "."
-							       result))))
-				      work)
-				     ;; then check for inner classes
-				     ((setq work
-					    (jdee-parse-get-inner-class-name
-					     result result-qualifier))
-				      work)
+                                     ;;doesn't exist
+                                     ((and result-qualifier
+                                           (jdee-parse-class-exists
+                                            (setq work (concat result-qualifier
+                                                               "."
+                                                               result))))
+                                      work)
+                                     ;; then check for inner classes
+                                     ((setq work
+                                            (jdee-parse-get-inner-class-name
+                                             result result-qualifier))
+                                      work)
                                      ;; otherwise use unqualified class name
-				     (t
-				      (jdee-parse-get-qualified-name result
+                                     (t
+                                      (jdee-parse-get-qualified-name result
                                                                      t)))))
 
-			    (if type
-				(progn
-				  (while (> count 0)
-				    (setq type (concat type "[]"))
-				    (setq count (1- count)))
-				  (jdee-parse-transform-array-classes-names
-				   type))
-			      (if (y-or-n-p
-				   (format (concat "Could not find type of %s"
-						   " Attempt to import %s? ")
-					   expr result))
-				  (progn
-				    ;; import
-				    (jdee-import-find-and-import result)
-				    ;; recursive call of eval-type-of
-				    (jdee-parse-eval-type-of expr))
-				(error "Could not find type of %s" result))))
-			(if (and jdee-parse-casting
-				 (null jdee-parse-attempted-to-import)
-				 (y-or-n-p
-				  (format (concat "Could not find type of %s"
-						  " Attempt to import %s? ")
-					  expr expr)))
-			    (progn
-			      (setq jdee-parse-attempted-to-import t)
-			      (setq jdee-parse-casting nil)
-			      (jdee-import-find-and-import expr)
-			      (jdee-parse-eval-type-of expr))
-			  (progn
-			    (setq jdee-parse-attempted-to-import nil)
-			    nil))))))))))
-	answer)))
+                            (if type
+                                (progn
+                                  (while (> count 0)
+                                    (setq type (concat type "[]"))
+                                    (setq count (1- count)))
+                                  (jdee-parse-transform-array-classes-names
+                                   type))
+                              (if (y-or-n-p
+                                   (format (concat "Could not find type of %s"
+                                                   " Attempt to import %s? ")
+                                           expr result))
+                                  (progn
+                                    ;; import
+                                    (jdee-import-find-and-import result)
+                                    ;; recursive call of eval-type-of
+                                    (jdee-parse-eval-type-of expr))
+                                (error "Could not find type of %s" result))))
+                        (if (and jdee-parse-casting
+                                 (null jdee-parse-attempted-to-import)
+                                 (y-or-n-p
+                                  (format (concat "Could not find type of %s"
+                                                  " Attempt to import %s? ")
+                                          expr expr)))
+                            (progn
+                              (setq jdee-parse-attempted-to-import t)
+                              (setq jdee-parse-casting nil)
+                              (jdee-import-find-and-import expr)
+                              (jdee-parse-eval-type-of expr))
+                          (progn
+                            (setq jdee-parse-attempted-to-import nil)
+                            nil))))))))))
+        answer)))
 
 (defun jdee-parse-convert-args-to-types (args)
   "Converts something like this (10, 10) to (int, int)"
   (let* ((answer "(")
-	 (first-time t)
-	 (temp (substring args 1 (- (length args) 1)));;Striping the parens
-	 (lst (split-string temp ", ?"))
-	 tmp)
+         (first-time t)
+         (temp (substring args 1 (- (length args) 1)));;Striping the parens
+         (lst (split-string temp ", ?"))
+         tmp)
     (while lst
       (setq tmp (car lst))
       (if (not first-time)
-	  (setq answer (concat answer ", "))
-	(setq first-time nil))
+          (setq answer (concat answer ", "))
+        (setq first-time nil))
       (setq answer (concat answer
-			   (jdee-parse-eval-type-of tmp)))
+                           (jdee-parse-eval-type-of tmp)))
       (setq lst (cdr lst)))
     (setq answer (concat answer ")"))
     answer))
@@ -1470,33 +1470,33 @@ Java type name, e.g., int."
       (setq name (substring name 0 (- (length name) 2 )))
       (setq result (concat "[" result)))
     (if result
-	(progn
-	  (cond
-	   ((string= name "byte")
-	    (setq result (concat result "B")))
-	   ((string= name "char")
-	    (setq result (concat result "C")))
-	   ((string= name "double")
-	    (setq result (concat result "D")))
-	   ((string= name "float")
-	    (setq result (concat result "F")))
-	   ((string= name "int")
-	    (setq result (concat result "I")))
-	   ((string= name "long")
-	    (setq result (concat result "J")))
-	   ((string= name "short")
-	    (setq result (concat result "S")))
-	   ((string= name "boolean")
-	    (setq result (concat result "Z")))
-	   (t
-	    (setq result (concat result "L" name ";"))))
-	  result)
+        (progn
+          (cond
+           ((string= name "byte")
+            (setq result (concat result "B")))
+           ((string= name "char")
+            (setq result (concat result "C")))
+           ((string= name "double")
+            (setq result (concat result "D")))
+           ((string= name "float")
+            (setq result (concat result "F")))
+           ((string= name "int")
+            (setq result (concat result "I")))
+           ((string= name "long")
+            (setq result (concat result "J")))
+           ((string= name "short")
+            (setq result (concat result "S")))
+           ((string= name "boolean")
+            (setq result (concat result "Z")))
+           (t
+            (setq result (concat result "L" name ";"))))
+          result)
       name)))
 
 (defun jdee-parse-get-component-type-of-array-class (name)
   (if (string= "[" (substring name 0 1))
       (let ((result (jdee-backend-get-component-type-name name)))
-	(substring result 0 (- (length result) 1)))
+        (substring result 0 (- (length result) 1)))
     name))
 
 ;; Modified `jdee-parse-import-list' to use semantic parser table
@@ -1512,16 +1512,16 @@ For example:
   : (jdee-split-import-token \"test\")
   > (\"test.\" . \"*\")"
   (let* ((import      (semantic-tag-name token))
-	 (match-point (string-match "\\." import))
-	 split-point)
+         (match-point (string-match "\\." import))
+         split-point)
     (while match-point
       (setq split-point (1+ match-point)
-	    match-point (string-match "\\." import split-point)))
+            match-point (string-match "\\." import split-point)))
     (if split-point
-	(list (substring import 0 split-point)
-	      (substring import split-point))
+        (list (substring import 0 split-point)
+              (substring import split-point))
       (list (concat import ".")
-	    "*"))))
+            "*"))))
 
 (defun jdee-parse-import-list ()
   "Return the list of Java packages declared in the current buffer.
@@ -1529,20 +1529,20 @@ It uses the semantic parser table to find the 'package' and 'import'
 statements. It implicitly adds the java.lang.* package. See also
 `jdee-split-import-token'."
   (let* ((tokens   (semantic-fetch-tags))
-	 (packages (semantic-brute-find-tag-by-class 'package tokens))
-	 (imports  (semantic-brute-find-tag-by-class 'include tokens))
-	 lst)
+         (packages (semantic-brute-find-tag-by-class 'package tokens))
+         (imports  (semantic-brute-find-tag-by-class 'include tokens))
+         lst)
     (setq lst (append
-	       (mapcar (function
-			(lambda (token)
-			  (list
-			   (concat (semantic-tag-name token) ".")
-			   "*")))
-		       packages)
-	      (mapcar 'jdee-split-import-token
-		       imports)))
+               (mapcar (function
+                        (lambda (token)
+                          (list
+                           (concat (semantic-tag-name token) ".")
+                           "*")))
+                       packages)
+              (mapcar 'jdee-split-import-token
+                       imports)))
     (or (member "java.lang.*" lst)
-	(setq lst (append lst '(("java.lang." "*")))))
+        (setq lst (append lst '(("java.lang." "*")))))
     lst))
 
 ;; Contributed by Charles Hart <cfhart@Z-TEL.com>
@@ -1559,22 +1559,22 @@ try importing the class"
   (if (jdee-parse-class-exists name)
       name
     (let ((importlist (jdee-parse-import-list))
-	  shortname fullname tmp result)
+          shortname fullname tmp result)
       (while (and importlist (null result))
-	(setq tmp (car importlist))
-	(setq shortname (car (cdr tmp)))
-	(setq fullname (concat (car tmp) name))
-	(cond
-	 ((and (string= "*" shortname) (jdee-parse-class-exists fullname))
-	  (setq result fullname))
-	 ((string= name shortname)
-	  (setq result fullname))
-	 (t
-	  (setq importlist (cdr importlist)))))
+        (setq tmp (car importlist))
+        (setq shortname (car (cdr tmp)))
+        (setq fullname (concat (car tmp) name))
+        (cond
+         ((and (string= "*" shortname) (jdee-parse-class-exists fullname))
+          (setq result fullname))
+         ((string= name shortname)
+          (setq result fullname))
+         (t
+          (setq importlist (cdr importlist)))))
       (if (and (null result) import)
-	  (progn
-	    (jdee-import-find-and-import name t)
-	    (setq result (jdee-parse-get-qualified-name name))))
+          (progn
+            (jdee-import-find-and-import name t)
+            (setq result (jdee-parse-get-qualified-name name))))
       result)))
 
 ;; Contributed by Charles Hart <cfhart@Z-TEL.com>
@@ -1583,15 +1583,15 @@ try importing the class"
   classpath, nil otherwise."
   (if (stringp name)
       (progn
-	;; Replace double quotes by empty strings.
-	;; Double quotes seems to break the beanshell.
-	(while (string-match "\"" name)
-	  (setq name (replace-match "" nil nil name)))
+        ;; Replace double quotes by empty strings.
+        ;; Double quotes seems to break the beanshell.
+        (while (string-match "\"" name)
+          (setq name (replace-match "" nil nil name)))
 
-	;; Replace back slashes by empty strings.\
-	;; Back slashes causes Beeanshell problems
-	(while (string-match "\\\\" name)
-	  (setq name (replace-match "" nil nil name)))
+        ;; Replace back slashes by empty strings.\
+        ;; Back slashes causes Beeanshell problems
+        (while (string-match "\\\\" name)
+          (setq name (replace-match "" nil nil name)))
 
         (jdee-backend-class-exists-p name))))
 
@@ -1601,9 +1601,9 @@ and qualifer. The name and the qualifier are then use as arguments
 to the function `jdee-parse-get-inner-class-name'"
   (let (name qualifier (pos (string-match "\\." expr)))
     (if pos
-	(progn
-	  (setq name (substring expr (+ 1 pos)))
-	  (setq qualifier (substring expr 0 pos))))
+        (progn
+          (setq name (substring expr (+ 1 pos)))
+          (setq qualifier (substring expr 0 pos))))
     (jdee-parse-get-inner-class-name name qualifier)))
 
 ;; Tries to divine inner class via the following algorithm:
@@ -1625,99 +1625,99 @@ searched.  Returns nil if not found; a fully qualified inner class name
 otherwise."
   (let (class-name this-full-class-name result)
     (setq this-full-class-name (jdee-parse-get-qualified-name
-				(jdee-parse-get-class-at-point)))
+                                (jdee-parse-get-class-at-point)))
     (cond
      (qualifier
       (let ((work (concat qualifier "$" name)))
-	(setq work (subst-char-in-string ?. ?\$ work))
+        (setq work (subst-char-in-string ?. ?\$ work))
 
-	;; check against this$D$C$B$A
-	(setq class-name (concat this-full-class-name "$" work))
-	(if (not (jdee-parse-class-exists class-name))
-	    (let (dot-count index first-part remaining-part)
-	      (setq class-name nil)
+        ;; check against this$D$C$B$A
+        (setq class-name (concat this-full-class-name "$" work))
+        (if (not (jdee-parse-class-exists class-name))
+            (let (dot-count index first-part remaining-part)
+              (setq class-name nil)
 
-	      ;; check against D$C$B$A (default and imported)
-	      (print "Zero dots" (get-buffer "*scratch*"))
-	      (setq class-name (jdee-parse-get-qualified-name work))
+              ;; check against D$C$B$A (default and imported)
+              (print "Zero dots" (get-buffer "*scratch*"))
+              (setq class-name (jdee-parse-get-qualified-name work))
 
-	      ;; check remaining semi-qualified variants
-	      (setq dot-count 1)
-	      (while (and (null class-name)
-			  (setq index (string-match "\\$" work)))
+              ;; check remaining semi-qualified variants
+              (setq dot-count 1)
+              (while (and (null class-name)
+                          (setq index (string-match "\\$" work)))
 
-		(setq first-part (substring work 0 index))
-		(setq remaining-part (if (< index (length work))
-					 (substring work (+ 1 index))
-				       nil))
-		(cond
-		 ;; check against C$B$A on class D
-		 ((= 1 dot-count)
-		  (setq class-name (jdee-parse-get-qualified-name
-				    first-part))
-		  (if (not (null class-name))
-		      (progn
-			(setq class-name (concat class-name
-						 "$"
-						 remaining-part))
-			(if (null (jdee-parse-class-exists class-name))
-			    (setq class-name nil)))))
+                (setq first-part (substring work 0 index))
+                (setq remaining-part (if (< index (length work))
+                                         (substring work (+ 1 index))
+                                       nil))
+                (cond
+                 ;; check against C$B$A on class D
+                 ((= 1 dot-count)
+                  (setq class-name (jdee-parse-get-qualified-name
+                                    first-part))
+                  (if (not (null class-name))
+                      (progn
+                        (setq class-name (concat class-name
+                                                 "$"
+                                                 remaining-part))
+                        (if (null (jdee-parse-class-exists class-name))
+                            (setq class-name nil)))))
 
-		 ;; just check if it exists (ignoring imports)
-		 (t
-		  (setq class-name (concat first-part "." remaining-part))
-		  (if (null (jdee-parse-class-exists class-name))
-		      ;; lastly check if it exists in this package
-		      (progn
-			(setq class-name (concat (jdee-parse-get-package-name)
-						 "."
-						 work))
-			(if (not (jdee-parse-class-exists class-name))
-			    (setq class-name nil))))))
+                 ;; just check if it exists (ignoring imports)
+                 (t
+                  (setq class-name (concat first-part "." remaining-part))
+                  (if (null (jdee-parse-class-exists class-name))
+                      ;; lastly check if it exists in this package
+                      (progn
+                        (setq class-name (concat (jdee-parse-get-package-name)
+                                                 "."
+                                                 work))
+                        (if (not (jdee-parse-class-exists class-name))
+                            (setq class-name nil))))))
 
-		(setq work (concat first-part "." remaining-part))
-		(setq dot-count (1+ dot-count)))
+                (setq work (concat first-part "." remaining-part))
+                (setq dot-count (1+ dot-count)))
 
-	      class-name))))
+              class-name))))
 
      ;=; otherwise, no qualifier...check against this$D
      ((jdee-parse-class-exists (setq class-name
-				    (concat this-full-class-name "$" name)))
+                                    (concat this-full-class-name "$" name)))
       class-name))))
 
 ;; Can this function be reimplemented to use regular expressions?
 (defun jdee-parse-isolate-before-matching-of-last-car (s)
   "Returns the right expression that needs completion in S."
   (let* (final-string (index (length s)) stop (paren 0) (bracket 0) curcar
-		      (inside-quotes nil))
+                      (inside-quotes nil))
     (while (and (> index 0)
-		(not stop))
+                (not stop))
       (setq index (- index 1))
       (setq curcar (aref s index))
       (cond
        ((eq ?\" curcar);;Checking if we are inside double quotes
-	(if (not (eq ?\\ (aref s (- index 1))));;if the quote is not escape
-	    (setq inside-quotes (not inside-quotes))))
+        (if (not (eq ?\\ (aref s (- index 1))));;if the quote is not escape
+            (setq inside-quotes (not inside-quotes))))
        ((eq ?\) curcar)
-	(if (not inside-quotes)
-	    (setq paren (1+ paren))))
+        (if (not inside-quotes)
+            (setq paren (1+ paren))))
        ((eq ?\( curcar)
-	(if (not inside-quotes)
-	    (setq paren (1- paren))))
+        (if (not inside-quotes)
+            (setq paren (1- paren))))
        ((eq ?\] curcar)
-	(if (not inside-quotes)
-	    (setq bracket (1+ bracket))))
+        (if (not inside-quotes)
+            (setq bracket (1+ bracket))))
        ((eq ?\[ curcar)
-	(if (not inside-quotes)
-	    (setq bracket (1- bracket)))))
+        (if (not inside-quotes)
+            (setq bracket (1- bracket)))))
       (if (and (= paren 0)
-	       (= bracket 0))
-	  (setq stop t)))
+               (= bracket 0))
+          (setq stop t)))
     (setq final-string (substring s 0 index))
     (if (and (string= "" final-string)
-	     (string= "((" (substring s 0 2)))
-	(let ((closing-paren (string-match ")" s)))
-	  (setq final-string (substring s 2 closing-paren))))
+             (string= "((" (substring s 0 2)))
+        (let ((closing-paren (string-match ")" s)))
+          (setq final-string (substring s 2 closing-paren))))
     final-string))
 
 (defun jdee-parse-split-by-dots (s)
@@ -1729,7 +1729,7 @@ otherwise."
     nil))
 
 (defun jdee-parse-find-completion-for-pair (pair &optional exact-completion
-						access-level)
+                                                access-level)
   (jdee-complete-find-completion-for-pair pair exact-completion access-level))
 
 (defun jdee-parse-keywordp (variable)
@@ -1750,43 +1750,43 @@ codeing standard).
 
 The first two elements of the list are `nil' if CLASSNAME isn't fully qualifed."
   (cl-flet* ((is-first-cap
-	      (str)
-	      (unless (= 0 (length str))
-		(let ((char (substring str 0 1)))
-		  (string= char (upcase char)))))
-	     (is-all-cap
-	      (str)
-	      (string= str (upcase str)))
-	     (parse-at-point
-	      (classname)
-	      (let ((nopkgclass classname)
-		    end-pos fq pkg)
-		(when (> (length classname) 0)
-		  (setq end-pos (cl-position ?. classname :from-end t))
-		  (if end-pos
-		      (setq fq classname
-			    pkg (substring fq 0 end-pos)
-			    classname (substring fq (1+ end-pos))))
-		  (when (and (> (length nopkgclass) 0)
-			     (is-first-cap classname))
-		    ;; either a class can be all caps with a package behind it
-		    ;; (i.e. com.google.gwt.core.client.GWT) or it can be class
-		    ;; with a constant in front of it (i.e. Color.WHITE), currently
-		    ;; support the latter instead of kludging this now
-		    ;; --PL 2010-06-30
-		    (if (and (> (length classname) 1)
-			     (is-all-cap classname))
-			;; looks like <class>.<sym> (i.e. Color.WHITE)
-			nil
-		      (list fq pkg classname)))))))
+              (str)
+              (unless (= 0 (length str))
+                (let ((char (substring str 0 1)))
+                  (string= char (upcase char)))))
+             (is-all-cap
+              (str)
+              (string= str (upcase str)))
+             (parse-at-point
+              (classname)
+              (let ((nopkgclass classname)
+                    end-pos fq pkg)
+                (when (> (length classname) 0)
+                  (setq end-pos (cl-position ?. classname :from-end t))
+                  (if end-pos
+                      (setq fq classname
+                            pkg (substring fq 0 end-pos)
+                            classname (substring fq (1+ end-pos))))
+                  (when (and (> (length nopkgclass) 0)
+                             (is-first-cap classname))
+                    ;; either a class can be all caps with a package behind it
+                    ;; (i.e. com.google.gwt.core.client.GWT) or it can be class
+                    ;; with a constant in front of it (i.e. Color.WHITE), currently
+                    ;; support the latter instead of kludging this now
+                    ;; --PL 2010-06-30
+                    (if (and (> (length classname) 1)
+                             (is-all-cap classname))
+                        ;; looks like <class>.<sym> (i.e. Color.WHITE)
+                        nil
+                      (list fq pkg classname)))))))
     (if (eq classname 'point)
-	;; TODO: a fully qualified class name looks like a file name
-	;; (i.e. [a-zA-Z.])  but this need to be refined to use the Sun Java
-	;; standards of class name parsing
-	(or (let ((thing-at-point-file-name-chars "-~/[:alnum:]_.${}#%:"))
-	      (parse-at-point (thing-at-point 'filename)))
-	    (parse-at-point (thing-at-point 'word))
-	    (parse-at-point (thing-at-point 'symbol)))
+        ;; TODO: a fully qualified class name looks like a file name
+        ;; (i.e. [a-zA-Z.])  but this need to be refined to use the Sun Java
+        ;; standards of class name parsing
+        (or (let ((thing-at-point-file-name-chars "-~/[:alnum:]_.${}#%:"))
+              (parse-at-point (thing-at-point 'filename)))
+            (parse-at-point (thing-at-point 'word))
+            (parse-at-point (thing-at-point 'symbol)))
       (parse-at-point classname))))
 
 (provide 'jdee-parse)

--- a/jdee-plugins.el
+++ b/jdee-plugins.el
@@ -38,18 +38,18 @@
 
 (defclass jdee-plugin ()
   ((bsh-cp    :initarg :bsh-cp
-	      :type list
+              :type list
               :initform nil
-	      :documentation "Beanshell classpath for this plugin.")
+              :documentation "Beanshell classpath for this plugin.")
    (menu-spec :initarg :menu-spec
-	      :type list
+              :type list
               :initform nil
-	      :documentation "Specifies menu for this plugin.")
+              :documentation "Specifies menu for this plugin.")
    (plugins   :type list
-	      :allocation :class
-	      :initform nil
-	      :documentation
-	     "Installed plugins."))
+              :allocation :class
+              :initform nil
+              :documentation
+             "Installed plugins."))
 "Class of plugins.")
 
 
@@ -78,17 +78,17 @@ plugins directory named PLUGIN and that this subdirectory contains
 a subdirectory name LISP that contains a file named jdee-plugin.el.
 This function loads jdee-PLUGIN.el."
   (let* ((plugin-dir (expand-file-name plugin jdee-plugins-directory))
-	 (plugin-lisp-dir (expand-file-name "lisp" plugin-dir))
-	 (plugin-lisp-package-name (concat "jdee-" plugin))
-	 (plugin-lisp-file-name (concat plugin-lisp-package-name ".el"))
-	 (plugin-lisp-file
-	  (expand-file-name
-	   plugin-lisp-file-name
-	   plugin-lisp-dir)))
+         (plugin-lisp-dir (expand-file-name "lisp" plugin-dir))
+         (plugin-lisp-package-name (concat "jdee-" plugin))
+         (plugin-lisp-file-name (concat plugin-lisp-package-name ".el"))
+         (plugin-lisp-file
+          (expand-file-name
+           plugin-lisp-file-name
+           plugin-lisp-dir)))
     (if (file-exists-p plugin-lisp-file)
-	(progn
-	  (add-to-list 'load-path plugin-lisp-dir)
-	  (require (intern plugin-lisp-package-name)))
+        (progn
+          (add-to-list 'load-path plugin-lisp-dir)
+          (require (intern plugin-lisp-package-name)))
       (error "JDEE plugin Lisp file %s missing" plugin-lisp-file-name))))
 
 
@@ -115,9 +115,9 @@ This function loads jdee-PLUGIN.el."
 (defun jdee-pi-get-bsh-classpath ()
   "Get the plugin directories and jar files to include in the Beanshell classpath."
   (let ((plugins (oref-default 'jdee-plugin plugins))
-	classpath)
+        classpath)
     (loop for plugin in plugins do
-	  (setq classpath (append classpath (oref plugin bsh-cp))))
+          (setq classpath (append classpath (oref plugin bsh-cp))))
     classpath))
 
 
@@ -132,7 +132,7 @@ jar program is on the system path."
           "Cannot find the jar program on the system path.")
 
   (let ((zip-files
-	 (directory-files jdee-plugins-directory nil ".*[.]\\(zip\\|jar\\)")))
+         (directory-files jdee-plugins-directory nil ".*[.]\\(zip\\|jar\\)")))
 
     (when zip-files
       (let ((buf (get-buffer-create "*plugins*")))
@@ -144,7 +144,7 @@ jar program is on the system path."
           (loop for zip-file in zip-files do
                 (let ((result
                        (shell-command-to-string
-			(concat "jar xvf " zip-file))))
+                        (concat "jar xvf " zip-file))))
                   (insert "\n\n")
                   (insert (format "Installing %s ..."
                                   (file-name-sans-extension zip-file)))
@@ -158,11 +158,11 @@ jar program is on the system path."
       (append
        (list "Plug-Ins")
        (delq
-	nil
-	(cl-mapcan
-	 (lambda (plugin)
-	   (oref plugin menu-spec))
-	 (oref-default 'jdee-plugin plugins))))))
+        nil
+        (cl-mapcan
+         (lambda (plugin)
+           (oref plugin menu-spec))
+         (oref-default 'jdee-plugin plugins))))))
 
 (provide 'jdee-plugins)
 

--- a/jdee-project-file.el
+++ b/jdee-project-file.el
@@ -54,7 +54,7 @@ temporarily when stepping through code."
   "Toggles project switching on or off."
   (interactive)
   (setq jdee-project-context-switching-enabled-p
-	(not jdee-project-context-switching-enabled-p)))
+        (not jdee-project-context-switching-enabled-p)))
 
 (defcustom jdee-project-name "default"
 "Specifies name of project to which the current buffer belongs."
@@ -95,12 +95,12 @@ being loaded.")
 DIR.  Returns nil if it cannot find a project file in DIR or an
 ascendant directory."
   (let* ((directory-sep-char ?/) ;; Override NT/XEmacs setting
-	 (file (cl-find (or file-name jdee-project-file-name)
-			(directory-files dir) :test 'string=)))
+         (file (cl-find (or file-name jdee-project-file-name)
+                        (directory-files dir) :test 'string=)))
     (if file
-	(expand-file-name file dir)
+        (expand-file-name file dir)
       (if (not (jdee-root-dir-p dir))
-	  (jdee-find-project-file (expand-file-name ".." dir) file-name)))))
+          (jdee-find-project-file (expand-file-name ".." dir) file-name)))))
 
 (defvar jdee-buffer-project-file ""
   "Path of project file associated with the current Java source buffer.")
@@ -110,16 +110,16 @@ ascendant directory."
   "Return all the project files in the current directory tree,
 starting with the topmost."
   (let* ((directory-sep-char ?/) ;; Override NT/XEmacs setting
-	 (file (jdee-find-project-file dir))
-	 current-dir files)
+         (file (jdee-find-project-file dir))
+         current-dir files)
     (while file
       (setq files (append (list file) files))
       (setq current-dir (file-name-directory file))
       (setq
        file
        (if (not (jdee-root-dir-p current-dir))
-	   (jdee-find-project-file
-	    (expand-file-name ".." current-dir)))))
+           (jdee-find-project-file
+            (expand-file-name ".." current-dir)))))
     files))
 
 (defvar jdee-loading-project nil
@@ -139,21 +139,21 @@ Emacs startup values."
   (interactive)
   (setq jdee-loading-project t)
   (let ((prj-files
-	 (jdee-find-project-files
-	  ;; Need to normalize path to work around bug in the
-	  ;; cygwin version of XEmacs.
-	  (expand-file-name "." default-directory))))
+         (jdee-find-project-files
+          ;; Need to normalize path to work around bug in the
+          ;; cygwin version of XEmacs.
+          (expand-file-name "." default-directory))))
     (if prj-files
-	(progn
-	  (jdee-set-variables-init-value)
-	  (loop for file in prj-files do
-	    (setq jdee-loading-project-file file)
-	    (jdee-log-msg "jdee-load-project-file: Loading %s" file)
-	    ;; reset project file version
-	    (setq jdee-loaded-project-file-version nil)
-	    (load-file file)
-	    (setq jdee-loading-project-file nil))
-	  (run-hooks 'jdee-project-hooks))
+        (progn
+          (jdee-set-variables-init-value)
+          (loop for file in prj-files do
+            (setq jdee-loading-project-file file)
+            (jdee-log-msg "jdee-load-project-file: Loading %s" file)
+            ;; reset project file version
+            (setq jdee-loaded-project-file-version nil)
+            (load-file file)
+            (setq jdee-loading-project-file nil))
+          (run-hooks 'jdee-project-hooks))
       (jdee-set-variables-init-value t)))
   (setq jdee-loading-project nil))
 
@@ -165,7 +165,7 @@ Emacs startup values."
    (lambda (java-buffer)
      (with-current-buffer java-buffer
        (message "Loading project file for %s ..."
-		(buffer-file-name java-buffer))
+                (buffer-file-name java-buffer))
        (jdee-load-project-file)))
    (jdee-get-java-source-buffers)))
 
@@ -175,7 +175,7 @@ Emacs startup values."
   (interactive)
   (let ((prj-file (jdee-find-project-file default-directory)))
     (if prj-file
-	(find-file prj-file)
+        (find-file prj-file)
       (message "Project file not found."))))
 
 
@@ -186,26 +186,26 @@ Leave point at the location of the call, or after the last expression."
     (goto-char (point-min))
     (catch 'found
       (while t
-	(let ((sexp (condition-case nil
-			(read (current-buffer))
-		      (end-of-file (throw 'found nil)))))
-	  (when (and (listp sexp)
-		     (eq (car sexp) symbol))
-	    (delete-region (save-excursion
-			     (backward-sexp)
-			     (point))
-			   (point))
-	    (throw 'found nil)))))
+        (let ((sexp (condition-case nil
+                        (read (current-buffer))
+                      (end-of-file (throw 'found nil)))))
+          (when (and (listp sexp)
+                     (eq (car sexp) symbol))
+            (delete-region (save-excursion
+                             (backward-sexp)
+                             (point))
+                           (point))
+            (throw 'found nil)))))
     (unless (bolp)
       (princ "\n"))))
 
 (defun jdee-symbol-p (symbol)
   "Return non-nil if SYMBOL is a JDEE variable."
   (and (or
-	(get symbol 'custom-type)
-	(get symbol 'jdee-project))
+        (get symbol 'custom-type)
+        (get symbol 'jdee-project))
        (or (string-match "^bsh-" (symbol-name symbol))
-	   (string-match "^jdee-" (symbol-name symbol)))))
+           (string-match "^jdee-" (symbol-name symbol)))))
 
 (defvar jdee-symbol-list nil
   "*A list of JDEE variables to process by `jdee-save-project'.")
@@ -222,7 +222,7 @@ packages loaded after startup of the JDEE."
     (mapatoms
      (lambda (symbol)
        (if (jdee-symbol-p symbol)
-	   (setq jdee-symbol-list (cons symbol jdee-symbol-list))))))
+           (setq jdee-symbol-list (cons symbol jdee-symbol-list))))))
   jdee-symbol-list)
 
 (defun jdee-set-project-name (name)
@@ -234,10 +234,10 @@ packages loaded after startup of the JDEE."
 existing value."
   (let ((proj-alist (get symbol 'jdee-project)))
     (if (null proj-alist)
-	(put symbol 'jdee-project (list (cons project (list value))))
+        (put symbol 'jdee-project (list (cons project (list value))))
       (if (assoc project proj-alist)
-	  (setcdr (assoc project proj-alist) (list value))
-	(put symbol 'jdee-project (pushnew (cons project (list value)) proj-alist))))))
+          (setcdr (assoc project proj-alist) (list value))
+        (put symbol 'jdee-project (pushnew (cons project (list value)) proj-alist))))))
 
 (defun jdee-get-project (symbol project)
   "Gets the value for SYMBOL that is associated with PROJECT, or nil if none.
@@ -251,8 +251,8 @@ To test if SYMBOL has any value for PROJECT, use
 
 (defun jdee-save-open-buffer (project)
   "Create a new buffer or open an existing buffer for PROJECT."
-  (let ((auto-insert nil)	; turn off auto-insert when
-	buffer standard-output)	; creating a new file
+  (let ((auto-insert nil)        ; turn off auto-insert when
+        buffer standard-output)        ; creating a new file
     (setq buffer (find-file-noselect project))
     (setq standard-output buffer)
     (with-current-buffer buffer
@@ -273,8 +273,8 @@ To test if SYMBOL has any value for PROJECT, use
 (defun jdee-save-close-buffer (project)
   "Save and close the buffer associated with PROJECT."
   (let* ((buffer
-	  (find-buffer-visiting project))
-	 (standard-output buffer))
+          (find-buffer-visiting project))
+         (standard-output buffer))
     (if buffer
         (progn
           (princ ")\n")
@@ -289,19 +289,19 @@ To test if SYMBOL has any value for PROJECT, use
   (mapc
    (lambda (project)
      (if (and (not (string= (car project) "default"))
-	      (member (car project) projects))
-	 (let ((buffer
-		(find-buffer-visiting (car project)))
-	       standard-output)
-	   (if (null buffer)
-	       (setq standard-output (setq buffer (jdee-save-open-buffer (car project))))
-	     (setq standard-output buffer))
-	   (jdee-log-msg "jdee-save-variable: Saving %S in %s" symbol (car project))
-	   (princ "\n '(")
-	   (princ symbol)
-	   (princ " ")
-	   (prin1 (custom-quote (car (cdr project))))
-	   (princ ")"))))
+              (member (car project) projects))
+         (let ((buffer
+                (find-buffer-visiting (car project)))
+               standard-output)
+           (if (null buffer)
+               (setq standard-output (setq buffer (jdee-save-open-buffer (car project))))
+             (setq standard-output buffer))
+           (jdee-log-msg "jdee-save-variable: Saving %S in %s" symbol (car project))
+           (princ "\n '(")
+           (princ symbol)
+           (princ " ")
+           (prin1 (custom-quote (car (cdr project))))
+           (princ ")"))))
    (get symbol 'jdee-project)))
 
 (defun jdee-save-needs-saving-p (symbol projects)
@@ -310,62 +310,62 @@ are settings to be saved, this function also resolves which project
 should receive the customized values."
   (unless (= (length projects) 0)
     (let ((value (symbol-value symbol))
-	  val-to-save
-	  current-proj proj-iter)
+          val-to-save
+          current-proj proj-iter)
       (setq current-proj (car projects))
       (cond
       ;; CASE: current value changed from saved value in current
        ;; project
        ((and (jdee-project-present-p symbol current-proj)
-	     (not (null (get symbol 'customized-value))) ;; not decustomized.
-	     (not (equal value (jdee-get-project symbol current-proj))))
-	(jdee-log-msg "jdee-save-needs-saving-p: changed value for %S in project `%s'"
-		     symbol current-proj)
-	(jdee-put-project symbol current-proj value)
-	t)
+             (not (null (get symbol 'customized-value))) ;; not decustomized.
+             (not (equal value (jdee-get-project symbol current-proj))))
+        (jdee-log-msg "jdee-save-needs-saving-p: changed value for %S in project `%s'"
+                     symbol current-proj)
+        (jdee-put-project symbol current-proj value)
+        t)
        ;; CASE: no value for symbol in current project - check all
        ;; parent projects (plus default) to see if value has changed
        ((and (not (jdee-project-present-p symbol current-proj))
-	     (progn
-	       (setq val-to-save value)
-	       (setq proj-iter (cdr projects))
-	       (while (and proj-iter
-			   (not (jdee-project-present-p symbol (car proj-iter))))
-		 (setq proj-iter (cdr proj-iter)))
-	       (if proj-iter
-		   (not (equal value
-			       (jdee-get-project symbol (car proj-iter))))
-		 (setq val-to-save (eval (car (get symbol 'customized-value))))
-		 (and (not (null (get symbol 'customized-value))) ;; has been customized.
-		      (or                               ;; either
-		       (null (get symbol 'saved-value)) ;; not saved in .emacs file, or
-		       (not (equal val-to-save          ;; different from value in .emacs file
-				   (eval (car (get symbol 'saved-value))))))))))
-	(jdee-log-msg "jdee-save-needs-saving-p: override value %S from parent `%s' in project `%s'"
-		     symbol (car proj-iter) current-proj)
-	(jdee-put-project symbol current-proj val-to-save)
-	t)
+             (progn
+               (setq val-to-save value)
+               (setq proj-iter (cdr projects))
+               (while (and proj-iter
+                           (not (jdee-project-present-p symbol (car proj-iter))))
+                 (setq proj-iter (cdr proj-iter)))
+               (if proj-iter
+                   (not (equal value
+                               (jdee-get-project symbol (car proj-iter))))
+                 (setq val-to-save (eval (car (get symbol 'customized-value))))
+                 (and (not (null (get symbol 'customized-value))) ;; has been customized.
+                      (or                               ;; either
+                       (null (get symbol 'saved-value)) ;; not saved in .emacs file, or
+                       (not (equal val-to-save          ;; different from value in .emacs file
+                                   (eval (car (get symbol 'saved-value))))))))))
+        (jdee-log-msg "jdee-save-needs-saving-p: override value %S from parent `%s' in project `%s'"
+                     symbol (car proj-iter) current-proj)
+        (jdee-put-project symbol current-proj val-to-save)
+        t)
        ;; CASE: current value same as value in the deepest project that
        ;; holds that value - re-save it
        ((progn
-	  (setq proj-iter projects)
-	  (while (and proj-iter
-		      (not (jdee-project-present-p symbol (car proj-iter))))
-	    (setq proj-iter (cdr proj-iter)))
-	  (if proj-iter
-	      (equal value (jdee-get-project symbol (car proj-iter)))))
-	(jdee-log-msg "jdee-save-needs-saving-p: original value for %S in project `%s'"
-		     symbol (car proj-iter))
-	t)))))
+          (setq proj-iter projects)
+          (while (and proj-iter
+                      (not (jdee-project-present-p symbol (car proj-iter))))
+            (setq proj-iter (cdr proj-iter)))
+          (if proj-iter
+              (equal value (jdee-get-project symbol (car proj-iter)))))
+        (jdee-log-msg "jdee-save-needs-saving-p: original value for %S in project `%s'"
+                     symbol (car proj-iter))
+        t)))))
 
 (defun jdee-save-project-internal (projects)
   (let ((projects-reversed (nreverse projects)))
     (jdee-log-msg "jdee-save-project-internal: projects: %S" projects-reversed)
     (mapc 'jdee-save-open-buffer projects-reversed)
     (mapc (lambda (symbol)
-	    (if (jdee-save-needs-saving-p symbol projects-reversed)
-		(jdee-save-variable symbol projects-reversed)))
-	  (jdee-symbol-list))
+            (if (jdee-save-needs-saving-p symbol projects-reversed)
+                (jdee-save-variable symbol projects-reversed)))
+          (jdee-symbol-list))
     (mapc 'jdee-save-close-buffer projects-reversed)))
 
 ;;;###autoload
@@ -379,13 +379,13 @@ file from the same directory tree, the saved settings will be restored
 for that file."
   (interactive)
   (let* ((directory-sep-char ?/) ;; Override NT/XEmacs setting
-	(project-file-paths (jdee-find-project-files default-directory)))
+        (project-file-paths (jdee-find-project-files default-directory)))
     (if (not project-file-paths)
-	(setq project-file-paths
-	      (list (expand-file-name jdee-project-file-name
-				      (read-file-name "Save in directory: "
-						      default-directory
-						      default-directory)))))
+        (setq project-file-paths
+              (list (expand-file-name jdee-project-file-name
+                                      (read-file-name "Save in directory: "
+                                                      default-directory
+                                                      default-directory)))))
     (jdee-save-project-internal project-file-paths)))
 
 ;;;###autoload
@@ -400,20 +400,20 @@ the directory specified, thus allowing the user to create and maintain
 hierarchical projects."
   (interactive "DCreate new project in directory: ")
   (let* ((directory-sep-char ?/) ;; Override NT/XEmacs setting
-	 (prj-file (expand-file-name jdee-project-file-name new-dir))
-	 (projects (jdee-find-project-files new-dir)))
+         (prj-file (expand-file-name jdee-project-file-name new-dir))
+         (projects (jdee-find-project-files new-dir)))
     (if (not (member prj-file projects))
-	;; create empty project file if none found
-	(let* ((auto-insert nil)	; disable auto-insert
-	       (standard-output (find-file-noselect prj-file))
-	       (message-log-max nil))	; disable message log
-	  (princ "(jdee-project-file-version ")
-	  (prin1 jdee-project-file-version)
-	  (princ ")\n(jdee-set-variables)\n")
-	  (with-current-buffer standard-output
-	    (save-buffer))
-	  (kill-buffer standard-output)
-	  (setq projects (nconc projects (list prj-file)))))
+        ;; create empty project file if none found
+        (let* ((auto-insert nil)        ; disable auto-insert
+               (standard-output (find-file-noselect prj-file))
+               (message-log-max nil))        ; disable message log
+          (princ "(jdee-project-file-version ")
+          (prin1 jdee-project-file-version)
+          (princ ")\n(jdee-set-variables)\n")
+          (with-current-buffer standard-output
+            (save-buffer))
+          (kill-buffer standard-output)
+          (setq projects (nconc projects (list prj-file)))))
     (jdee-save-project-internal projects)))
 
 
@@ -433,39 +433,39 @@ This function is used in JDEE project files."
   (while args
     (let ((entry (car args)))
       (if (listp entry)
-	  (let* ((symbol (nth 0 entry))
-		 (value (nth 1 entry))
-		 (customized (nth 2 entry))
-		 (set (or (and (local-variable-if-set-p symbol nil) 'set)
-			  (get symbol 'custom-set)
-			  'set-default)))
+          (let* ((symbol (nth 0 entry))
+                 (value (nth 1 entry))
+                 (customized (nth 2 entry))
+                 (set (or (and (local-variable-if-set-p symbol nil) 'set)
+                          (get symbol 'custom-set)
+                          'set-default)))
 
-	    (add-to-list 'jdee-dirty-variables symbol)
+            (add-to-list 'jdee-dirty-variables symbol)
 
-	    (if (or customized
-		    jdee-loaded-project-file-version)
-		(put symbol 'customized-value (list value)))
-	    (if jdee-loading-project-file
-		(progn
-		  (jdee-log-msg "jdee-set-variables: Loading %S from project %s" symbol
-			       jdee-loading-project-file)
-		  (jdee-put-project symbol
-				   jdee-loading-project-file
-				   (eval value)))
-	      (jdee-log-msg "jdee-set-variables: Loading %S from unknown project" symbol))
-	    (when (default-boundp symbol)
-	      ;; Something already set this, overwrite it
-	      (funcall set symbol (eval value)))
-	    (setq args (cdr args)))))))
+            (if (or customized
+                    jdee-loaded-project-file-version)
+                (put symbol 'customized-value (list value)))
+            (if jdee-loading-project-file
+                (progn
+                  (jdee-log-msg "jdee-set-variables: Loading %S from project %s" symbol
+                               jdee-loading-project-file)
+                  (jdee-put-project symbol
+                                   jdee-loading-project-file
+                                   (eval value)))
+              (jdee-log-msg "jdee-set-variables: Loading %S from unknown project" symbol))
+            (when (default-boundp symbol)
+              ;; Something already set this, overwrite it
+              (funcall set symbol (eval value)))
+            (setq args (cdr args)))))))
 
 (defsubst jdee-set-variable-init-value(symbol)
   "Set a variable  to the value it has at Emacs startup."
  (let ((val-to-set (eval (car (or (get symbol 'saved-value)
-				   (get symbol 'standard-value)))))
-	(set (or (get symbol 'custom-set) 'set-default)))
+                                   (get symbol 'standard-value)))))
+        (set (or (get symbol 'custom-set) 'set-default)))
     (if (or (get symbol 'customized-value)
-	    (get symbol 'jdee-project))
-	(funcall set symbol val-to-set))
+            (get symbol 'jdee-project))
+        (funcall set symbol val-to-set))
     (put symbol 'customized-value nil)
     (put symbol 'jdee-project nil)
     (jdee-put-project symbol "default" val-to-set)))
@@ -515,20 +515,20 @@ for a newly activated Java buffer when the new buffer's project
 differs from the old buffer's."
   (condition-case err
       (let ((project-file-path (jdee-find-project-file default-directory)))
-	(if (not project-file-path) (setq project-file-path ""))
-	(if (and
-	     jdee-project-context-switching-enabled-p
-	     (not (jdee-debugger-running-p))
-	     (not (string=
-		   (file-truename jdee-current-project)
-		   (file-truename project-file-path))))
-	    (progn
-	      (setq jdee-current-project project-file-path)
-	      (jdee-load-project-file)
-	      (jdee-project-update-backend))))
+        (if (not project-file-path) (setq project-file-path ""))
+        (if (and
+             jdee-project-context-switching-enabled-p
+             (not (jdee-debugger-running-p))
+             (not (string=
+                   (file-truename jdee-current-project)
+                   (file-truename project-file-path))))
+            (progn
+              (setq jdee-current-project project-file-path)
+              (jdee-load-project-file)
+              (jdee-project-update-backend))))
     (error (message
-	    "Project file reload error: %s"
-	    (error-message-string err)))))
+            "Project file reload error: %s"
+            (error-message-string err)))))
 
 (defun jdee-update-autoloaded-symbols ()
   "Regenerate `jdee-symbol-list' and reload

--- a/jdee-project.el
+++ b/jdee-project.el
@@ -39,7 +39,7 @@
 
 (defvar jdee-project-menu-definition
   (list "JDEEPrj"
-	["New"   jdee-project-create-project t])
+        ["New"   jdee-project-create-project t])
   "Defines the JDEE project menu.")
 
 (defvar jdee-project-keymap (make-sparse-keymap)
@@ -193,14 +193,14 @@ PATH-TYPE is either `global classpath' for `jdee-global-classpath' or
   (interactive
    (list (completing-read "Path: " '("global classpath" "source path") nil t)))
   (let ((user-home (expand-file-name "~/"))
-	path-name path desc)
+        path-name path desc)
     (if (equal "source path" path-type)
-	(setq path-name "Source Path"
+        (setq path-name "Source Path"
               path jdee-sourcepath)
       (setq path-name "Global Classpath"
             path jdee-global-classpath))
     (with-current-buffer
-	(or buf (get-buffer-create (format "*JDEE %s*" path-name)))
+        (or buf (get-buffer-create (format "*JDEE %s*" path-name)))
       (setq truncate-lines t)
       (erase-buffer)
       (insert (format "%s:
@@ -209,11 +209,11 @@ f:      file
 blank:  path doesn't exist
 --------------------------\n" path-name))
       (dolist (file path)
-	(setq desc (cond ((file-directory-p file) "d")
-			 ((file-exists-p file) "f")
-			 (t " ")))
-	(setq file (replace-regexp-in-string "~/" user-home file nil t))
-	(insert (format "[%s]  %s\n" desc file)))
+        (setq desc (cond ((file-directory-p file) "d")
+                         ((file-exists-p file) "f")
+                         (t " ")))
+        (setq file (replace-regexp-in-string "~/" user-home file nil t))
+        (insert (format "[%s]  %s\n" desc file)))
       (goto-char (point-min))
       (unless buf (pop-to-buffer (current-buffer))))))
 

--- a/jdee-refactor.el
+++ b/jdee-refactor.el
@@ -41,20 +41,20 @@ string replace, changes the buffer name, and changes the file name."
   (if (not (eql 'jdee-mode major-mode))
       (error "Not a Java source buffer."))
   (let* ((buf-name (buffer-name))
-	 (old-class-name
-	  (with-temp-buffer
-	    (insert buf-name)
-	    (goto-char (point-min))
-	    (if (re-search-forward "\\.java$" nil t)
-		(replace-match ""))
-	    (buffer-substring-no-properties (point-min) (point-max))))
-	 (old-class-regexp (regexp-quote old-class-name)))
+         (old-class-name
+          (with-temp-buffer
+            (insert buf-name)
+            (goto-char (point-min))
+            (if (re-search-forward "\\.java$" nil t)
+                (replace-match ""))
+            (buffer-substring-no-properties (point-min) (point-max))))
+         (old-class-regexp (regexp-quote old-class-name)))
     (save-some-buffers)
     (dired-rename-file (buffer-file-name) (concat new-class-name ".java") t)
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward old-class-regexp nil t)
-	(replace-match new-class-name)))))
+        (replace-match new-class-name)))))
 
 ;;;###autoload
 (defun jdee-replace-fully-qualified-class-at-point (class)

--- a/jdee-run.el
+++ b/jdee-run.el
@@ -108,24 +108,24 @@ Choose Local from the menu to override the
 no classpath."
   :group 'jdee-run-options
   :type '(choice
-	  (const :menu-tag "Global" "global")
-	  (repeat :menu-tag "Local" (file :tag "Path"))
-	  (const :menu-tag "None" "none")))
+          (const :menu-tag "Global" "global")
+          (repeat :menu-tag "Local" (file :tag "Path"))
+          (const :menu-tag "None" "none")))
 
 (defcustom jdee-run-option-verbose (list nil nil nil)
   "*Print messages about the running process.
 The messages are printed in the run buffer."
   :group 'jdee-run-options
   :type '(list :indent 2
-	       (checkbox :format "\n  %[%v%] %h \n"
-			 :doc "Print classes loaded.
+               (checkbox :format "\n  %[%v%] %h \n"
+                         :doc "Print classes loaded.
 Prints a message in the run buffer each time a class is loaded.")
-	       (checkbox :format "%[%v%] %h \n"
-			 :doc "Print memory freed.
+               (checkbox :format "%[%v%] %h \n"
+                         :doc "Print memory freed.
 Prints a message in the run buffer each time the garbage collector
 frees memory.")
-	       (checkbox :format "%[%v%] %h \n"
-			 :doc "Print JNI info.
+               (checkbox :format "%[%v%] %h \n"
+                         :doc "Print JNI info.
 Prints JNI-related messages including information about which native
 methods have been linked and warnings about excessive creation of
 local references.")))
@@ -138,86 +138,86 @@ Property Name field; enter its value, for example, green, in the
 Property Value field. You can specify as many properties as you like."
   :group 'jdee-run-options
   :type '(repeat (cons :tag "Property"
-		  (string :tag "Name")
-		  (string :tag "Value"))))
+                  (string :tag "Name")
+                  (string :tag "Value"))))
 
 (defcustom jdee-run-option-heap-size (list
-				     (cons 1 "megabytes")
-				     (cons 16 "megabytes"))
+                                     (cons 1 "megabytes")
+                                     (cons 16 "megabytes"))
 "*Specify the initial and maximum size of the interpreter heap."
 :group 'jdee-run-options
 :type '(list
-	(cons (integer :tag "Start")
-	     (radio-button-choice (const "bytes")
-				  (const "kilobytes")
-				  (const "megabytes")
-				  (const "gigabytes")))
-	(cons (integer :tag "Max")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))))
+        (cons (integer :tag "Start")
+             (radio-button-choice (const "bytes")
+                                  (const "kilobytes")
+                                  (const "megabytes")
+                                  (const "gigabytes")))
+        (cons (integer :tag "Max")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))))
 
 (defcustom jdee-run-option-stack-size (list
-				      (cons 128 "kilobytes")
-				      (cons 400 "kilobytes"))
+                                      (cons 128 "kilobytes")
+                                      (cons 400 "kilobytes"))
   "*Specify size of the C and Java stacks."
   :group 'jdee-run-options
   :type '(list
-	  (cons (integer :tag "C Stack")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))
-	  (cons (integer :tag "Java Stack")
-	       (radio-button-choice (const "bytes")
-				    (const "kilobytes")
-				    (const "megabytes")
-				    (const "gigabytes")))))
+          (cons (integer :tag "C Stack")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))
+          (cons (integer :tag "Java Stack")
+               (radio-button-choice (const "bytes")
+                                    (const "kilobytes")
+                                    (const "megabytes")
+                                    (const "gigabytes")))))
 
 (defcustom jdee-run-option-garbage-collection (list t t)
   "*Specify garbage collection options."
   :group 'jdee-run-options
   :type '(list :indent 2
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Collect garbage asynchronously.")
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Collect unused classes.")))
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Collect garbage asynchronously.")
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Collect unused classes.")))
 
 (defcustom jdee-run-option-java-profile (cons nil "./java.prof")
   "*Enable Java profiling."
   :group 'jdee-run-options
   :type '(cons boolean
-	       (file :tag "File"
-		     :help-echo
+               (file :tag "File"
+                     :help-echo
 "Specify where to put profile results here.")))
 
 (defcustom jdee-run-option-heap-profile (cons nil
-						   (list "./java.hprof"
-							 5
-							 20
-							 "Allocation objects"))
+                                                   (list "./java.hprof"
+                                                         5
+                                                         20
+                                                         "Allocation objects"))
 "*Output heap profiling data."
   :group 'jdee-run-options
   :type '(cons boolean
-	       (list
-		(string :tag "Output File Path")
-		(integer :tag "Stack Trace Depth")
-		(integer :tag "Allocation Sites")
-		(radio-button-choice :format "%t \n%v"
-				     :tag "Sort output based on:"
-		 (const "Allocation objects")
-		 (const "Live objects")))))
+               (list
+                (string :tag "Output File Path")
+                (integer :tag "Stack Trace Depth")
+                (integer :tag "Allocation Sites")
+                (radio-button-choice :format "%t \n%v"
+                                     :tag "Sort output based on:"
+                 (const "Allocation objects")
+                 (const "Live objects")))))
 
 ;; (makunbound 'jdee-run-option-verify)
 (defcustom jdee-run-option-verify (list nil t)
   "*Verify classes."
   :group 'jdee-run-options
   :type '(list :indent 2
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Executed code in all classes.")
-	       (checkbox :format "%[%v%] %t \n"
-			 :tag "Classes loaded by a classloader.")))
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Executed code in all classes.")
+               (checkbox :format "%[%v%] %t \n"
+                         :tag "Classes loaded by a classloader.")))
 
 ;; (makunbound 'jdee-run-option-boot-classpath)
 (defcustom jdee-run-option-boot-classpath nil
@@ -253,17 +253,17 @@ project file for the current project and replaces the period (.) with
 the path of the directory containing the project file."
   :group 'jdee-run-options
   :type '(choice
-	  :tag "Classpath Options"
-	  (const :tag "standard" nil)
-	  (cons :tag "custom" :inline nil
-		(choice
-		 :tag "Custom Mode"
-		 (const "append")
-		 (const "prepend")
-		 (const "replace"))
-		(repeat
-		 :tag "Classpath"
-		 (file :tag "Path")))))
+          :tag "Classpath Options"
+          (const :tag "standard" nil)
+          (cons :tag "custom" :inline nil
+                (choice
+                 :tag "Custom Mode"
+                 (const "append")
+                 (const "prepend")
+                 (const "replace"))
+                (repeat
+                 :tag "Classpath"
+                 (file :tag "Path")))))
 
 
 ;; (makunbound 'jdee-run-option-debug)
@@ -301,35 +301,35 @@ The \"Suspend\" option specifies whether the vm should suspend
 this process on startup."
   :group 'jdee-run-options
   :type  '(choice
-	   :tag "Debug Connection Options"
-	   (const :tag "No connect" nil)
-	   (list
-	    :tag "Connect"
-	    :inline nil
-	    (choice
-	     :tag "Mode"
-	     (const "Server")
-	     (const "Client"))
-	    (choice
-	     :tag "Data Transport"
-	     (const "Shared Memory")
-	     (const "Socket"))
-	    (choice
-	     :tag "Shared Memory Name"
-	     (const :menu-tag "Default" "javadebug")
-	     (string :menu-tag "Custom" :tag "Name"))
-	    (choice
-	     :tag "Socket Host"
-	     (const :menu-tag "Local" nil)
-	     (string :menu-tag "Remote" :tag "Name"))
-	    (choice
-	     :tag "Socket Port"
-	     (const :menu-tag "Default" "4444")
-	     (string :menu-tag "Custom" :tag "Address"))
-	    (choice
-	     :tag "Suspend?"
-	     (const :tag "No" nil)
-	     (const :tag "Yes" t)))))
+           :tag "Debug Connection Options"
+           (const :tag "No connect" nil)
+           (list
+            :tag "Connect"
+            :inline nil
+            (choice
+             :tag "Mode"
+             (const "Server")
+             (const "Client"))
+            (choice
+             :tag "Data Transport"
+             (const "Shared Memory")
+             (const "Socket"))
+            (choice
+             :tag "Shared Memory Name"
+             (const :menu-tag "Default" "javadebug")
+             (string :menu-tag "Custom" :tag "Name"))
+            (choice
+             :tag "Socket Host"
+             (const :menu-tag "Local" nil)
+             (string :menu-tag "Remote" :tag "Name"))
+            (choice
+             :tag "Socket Port"
+             (const :menu-tag "Default" "4444")
+             (string :menu-tag "Custom" :tag "Address"))
+            (choice
+             :tag "Suspend?"
+             (const :tag "No" nil)
+             (const :tag "Yes" t)))))
 
 (defcustom jdee-run-option-interpret-mode nil
   "Causes the vm to interpret all byte codes. By default VMs
@@ -361,8 +361,8 @@ are ignored."
   "Specify whether to use the Hotspot client or server vm."
   :group 'jdee-run-options
   :type  '(choice :tag "vm type"
-		  (const :tag "client"    client)
-		  (const :tag "server"    server)))
+                  (const :tag "client"    client)
+                  (const :tag "server"    server)))
 
 
 ;;(makunbound 'jdee-run-option-enable-assertions)
@@ -387,16 +387,16 @@ of the JDK that precedes version 1.4, which
 introduced assertions into Java."
   :group 'jdee-run-options
   :type '(choice :tag "Enable assertions"
-	      (const "Nowhere")
-	      (const "Everywhere")
-	      (cons :tag "Somewhere" :inline "Everywhere"
-		    (boolean :tag "In current directory")
-		    (repeat :tag "In the following locations"
-			    (cons :tag "Location"
-				  (choice :tag "Type"
-					  (const "package")
-					  (const "class"))
-				  (string :tag "Name"))))))
+              (const "Nowhere")
+              (const "Everywhere")
+              (cons :tag "Somewhere" :inline "Everywhere"
+                    (boolean :tag "In current directory")
+                    (repeat :tag "In the following locations"
+                            (cons :tag "Location"
+                                  (choice :tag "Type"
+                                          (const "package")
+                                          (const "class"))
+                                  (string :tag "Name"))))))
 
 ;;(makunbound 'jdee-run-option-disable-assertions)
 (defcustom jdee-run-option-disable-assertions "Nowhere"
@@ -418,16 +418,16 @@ of the JDK that precedes version 1.4, which
 introduced assertions into Java."
   :group 'jdee-run-options
   :type '(choice :tag "Disable assertions"
-	      (const "Nowhere")
-	      (const "Everywhere")
-	      (cons :tag "Somewhere" :inline "Everywhere"
-		    (boolean :tag "In current directory")
-		    (repeat :tag "In the following locations"
-			    (cons :tag "Location"
-				  (choice :tag "Type"
-					  (const "package")
-					  (const "class"))
-				  (string :tag "Name"))))))
+              (const "Nowhere")
+              (const "Everywhere")
+              (cons :tag "Somewhere" :inline "Everywhere"
+                    (boolean :tag "In current directory")
+                    (repeat :tag "In the following locations"
+                            (cons :tag "Location"
+                                  (choice :tag "Type"
+                                          (const "package")
+                                          (const "class"))
+                                  (string :tag "Name"))))))
 
 (defcustom jdee-run-option-enable-system-assertions nil
   "Enable assertions in system classes."
@@ -503,11 +503,11 @@ to the executable specified by `jdee-run-executable'."
   "Saves the value of the w32-start-process-show-window variable
 before evaluating body and restores the value afterwards."
   `(let ((win32-start-process-show-window t)
-	 (w32-start-process-show-window t)
-	 (w32-quote-process-args ?\")
-	 (win32-quote-process-args ?\") ;; XEmacs
-	 (windowed-process-io t)
-	 (process-connection-type nil))
+         (w32-start-process-show-window t)
+         (w32-quote-process-args ?\")
+         (win32-quote-process-args ?\") ;; XEmacs
+         (windowed-process-io t)
+         (process-connection-type nil))
      ,@body))
 
 (defun jdee-run-parse-args (s)
@@ -515,13 +515,13 @@ before evaluating body and restores the value afterwards."
 Any substring that is enclosed in single or double quotes or does not include
 whitespace is considered a parameter."
    (let ((n (string-match "[^\"' ][^ ]*\\|\"[^\"]*\"\\|'[^']*'" s))
-	(tok)
-	(tokens '()))
+        (tok)
+        (tokens '()))
      (while n
        (setq n (match-end 0))
        (setq tok (match-string 0 s))
        (if (string-match "[\"']\\([^\"']*\\)[\"']" tok)
-	   (setq tok (match-string 1 tok)))
+           (setq tok (match-string 1 tok)))
        (setq tokens (append tokens (list tok)))
        (setq n (string-match "[^\"' ][^ ]*\\|\"[^\"]*\"\\|'[^']*'" s n)))
      tokens))
@@ -529,11 +529,11 @@ whitespace is considered a parameter."
 (defun jdee-run-make-arg-string (args)
 "Converts a list of command-line arguments to a string of arguments."
   (let ((str "")
-	(n (length args))
-	(i 0))
+        (n (length args))
+        (i 0))
     (while (< i n)
       (if (not (string= str ""))
-	  (setq str (concat str " ")))
+          (setq str (concat str " ")))
       (setq str (concat str (nth i args)))
       (setq i (+ i 1)))
     str))
@@ -587,50 +587,50 @@ panel to specifying the applet document."
 
 (defclass jdee-run-vm ()
   ((version          :initarg :version
-		     :type string
-		     :initform ""
-		     :documentation
-		     "Java virtual machine version number.")
+                     :type string
+                     :initform ""
+                     :documentation
+                     "Java virtual machine version number.")
    (path             :initarg :path
-		     :type string
-		     :documentation
-		     "Path of the compiler executable.")
+                     :type string
+                     :documentation
+                     "Path of the compiler executable.")
    (buffer           :initarg :buffer
-		     :type buffer
-		     :documentation
-		     "Compilation buffer")
+                     :type buffer
+                     :documentation
+                     "Compilation buffer")
    (main-class        :initarg :main-class
-		     :type string
-		     :documentation
-		     "Name of main class."))
+                     :type string
+                     :documentation
+                     "Name of main class."))
     "Class of Java virtual machines.")
 
 (defmethod jdee-run-classpath-arg ((this jdee-run-vm))
   "Returns the classpath argument for this vm."
   (let ((classpath
-	 (if jdee-run-option-classpath
-	     (if (and (stringp jdee-run-option-classpath)
-		      (string= jdee-run-option-classpath "global"))
-		 jdee-global-classpath
-	       (unless (and (stringp jdee-run-option-classpath)
-			    (string= jdee-run-option-classpath "none"))
-		 jdee-run-option-classpath))))
-	(symbol
-	 (if (and jdee-run-option-classpath
-		  (stringp jdee-run-option-classpath)
-		  (string= jdee-run-option-classpath "global"))
-	     'jdee-global-classpath
-	   'jdee-run-option-classpath)))
+         (if jdee-run-option-classpath
+             (if (and (stringp jdee-run-option-classpath)
+                      (string= jdee-run-option-classpath "global"))
+                 jdee-global-classpath
+               (unless (and (stringp jdee-run-option-classpath)
+                            (string= jdee-run-option-classpath "none"))
+                 jdee-run-option-classpath))))
+        (symbol
+         (if (and jdee-run-option-classpath
+                  (stringp jdee-run-option-classpath)
+                  (string= jdee-run-option-classpath "global"))
+             'jdee-global-classpath
+           'jdee-run-option-classpath)))
     (if classpath
-	(list
-	 "-classpath"
-	 (jdee-build-classpath
-	  classpath symbol)))))
+        (list
+         "-classpath"
+         (jdee-build-classpath
+          classpath symbol)))))
 
 (defmethod jdee-run-classic-mode-arg ((this jdee-run-vm))
   "Get classic-mode option>"
     (if jdee-run-classic-mode-vm
-	(list "-classic")))
+        (list "-classic")))
 
 
 (defmethod jdee-run-property-args ((this jdee-run-vm))
@@ -643,74 +643,74 @@ panel to specifying the applet document."
 (defmethod jdee-run-heap-size-args ((this jdee-run-vm))
    "Get heap size arguments."
     (let* ((memory-unit-abbrevs
-	    (list (cons "bytes" "")
-	       (cons "kilobytes" "k")
-	       (cons "megabytes" "m")
-	       (cons "gigabytes" "g")))
-	   (start-cons (nth 0 jdee-run-option-heap-size))
-	   (start-size (format "%d%s" (car start-cons)
-			       (cdr (assoc (cdr start-cons)
-				      memory-unit-abbrevs))))
-	   (max-cons (nth 1 jdee-run-option-heap-size))
-	   (max-size (format "%d%s" (car max-cons)
-			     (cdr (assoc (cdr max-cons)
-				    memory-unit-abbrevs)))))
+            (list (cons "bytes" "")
+               (cons "kilobytes" "k")
+               (cons "megabytes" "m")
+               (cons "gigabytes" "g")))
+           (start-cons (nth 0 jdee-run-option-heap-size))
+           (start-size (format "%d%s" (car start-cons)
+                               (cdr (assoc (cdr start-cons)
+                                      memory-unit-abbrevs))))
+           (max-cons (nth 1 jdee-run-option-heap-size))
+           (max-size (format "%d%s" (car max-cons)
+                             (cdr (assoc (cdr max-cons)
+                                    memory-unit-abbrevs)))))
       (append
        (if (not (string= start-size "1m"))
-	   (list (concat "-Xms" start-size)))
+           (list (concat "-Xms" start-size)))
        (if (not (string= max-size "16m"))
-	  (list (concat "-Xmx" max-size))))))
+          (list (concat "-Xmx" max-size))))))
 
 (defmethod jdee-run-stack-size-args ((this jdee-run-vm))
   "Get stack size arguments."
     (let* ((memory-unit-abbrevs
-	    (list (cons "bytes" "")
-	       (cons "kilobytes" "k")
-	       (cons "megabytes" "m")
-	       (cons "gigabytes" "g")))
-	   (c-cons (nth 0 jdee-run-option-stack-size))
-	   (c-size (format "%d%s" (car c-cons)
-			   (cdr (assoc (cdr c-cons)
-				       memory-unit-abbrevs))))
-	   (java-cons (nth 1 jdee-run-option-stack-size))
-	   (java-size (format "%d%s" (car java-cons)
-			     (cdr (assoc (cdr java-cons)
-				    memory-unit-abbrevs)))))
+            (list (cons "bytes" "")
+               (cons "kilobytes" "k")
+               (cons "megabytes" "m")
+               (cons "gigabytes" "g")))
+           (c-cons (nth 0 jdee-run-option-stack-size))
+           (c-size (format "%d%s" (car c-cons)
+                           (cdr (assoc (cdr c-cons)
+                                       memory-unit-abbrevs))))
+           (java-cons (nth 1 jdee-run-option-stack-size))
+           (java-size (format "%d%s" (car java-cons)
+                             (cdr (assoc (cdr java-cons)
+                                    memory-unit-abbrevs)))))
       (append
        (if (not (string= c-size "128k"))
-	   (list (concat "-Xss" c-size)))
+           (list (concat "-Xss" c-size)))
        (if (not (string= java-size "400k"))
-	   (list (concat "-Xoss" java-size))))))
+           (list (concat "-Xoss" java-size))))))
 
 
 (defmethod jdee-run-java-profile-arg ((this jdee-run-vm))
    "Get Java profile option."
     (let ((profilep (car jdee-run-option-java-profile))
-	  (file (cdr jdee-run-option-java-profile)))
+          (file (cdr jdee-run-option-java-profile)))
       (if profilep
-	  (if (string= file "./java.prof")
-	      '("-Xprof")
-	    (list (concat "-Xprof:" file))))))
+          (if (string= file "./java.prof")
+              '("-Xprof")
+            (list (concat "-Xprof:" file))))))
 
 (defmethod jdee-run-heap-profile-arg ((this jdee-run-vm))
   "Get heap profile argument."
     (let* ((profilep (car jdee-run-option-heap-profile))
-	   (prof-options (cdr jdee-run-option-heap-profile))
-	   (file (nth 0 prof-options))
-	   (depth (nth 1 prof-options))
-	   (top (nth 2 prof-options))
-	   (sort
-	    (downcase (substring (nth 3 prof-options) 0 1))))
+           (prof-options (cdr jdee-run-option-heap-profile))
+           (file (nth 0 prof-options))
+           (depth (nth 1 prof-options))
+           (top (nth 2 prof-options))
+           (sort
+            (downcase (substring (nth 3 prof-options) 0 1))))
       (if profilep
-	  (if (and (string= file "./java.hprof")
-		   (equal depth 5)
-		   (equal top 20)
-		   (string= sort "a"))
-	      '("-Xhprof")
-	    (list
-	     (format
-	      "-Xhprof:file=%s,depth=%d,top=%d,sort=%s"
-	      file depth top sort))))))
+          (if (and (string= file "./java.hprof")
+                   (equal depth 5)
+                   (equal top 20)
+                   (string= sort "a"))
+              '("-Xhprof")
+            (list
+             (format
+              "-Xhprof:file=%s,depth=%d,top=%d,sort=%s"
+              file depth top sort))))))
 
 
 (defmethod jdee-run-vm-args ((this jdee-run-vm))
@@ -720,50 +720,50 @@ panel to specifying the applet document."
 
 (defmethod jdee-run-vm-launch ((this jdee-run-vm))
   (let ((run-buf-name (concat "*" (oref this :main-class) "*"))
-	(source-directory default-directory)
-	(working-directory (if (string= jdee-run-working-directory "")
-			       default-directory
-			     (jdee-normalize-path 'jdee-run-working-directory))))
+        (source-directory default-directory)
+        (working-directory (if (string= jdee-run-working-directory "")
+                               default-directory
+                             (jdee-normalize-path 'jdee-run-working-directory))))
     (if (not (comint-check-proc run-buf-name))
-	(let* ((run-buffer (get-buffer-create run-buf-name))
-	       (win32-p (eq system-type 'windows-nt))
-	       (prog (oref this :path))
-	       (prog-args (append
-			   (jdee-run-get-vm-args this)
-			   (if jdee-run-read-vm-args
-			       (jdee-run-parse-args
-				(read-from-minibuffer
-				 "Vm args: "
-				 (car jdee-run-interactive-vm-arg-history)
-				 nil nil
-				 'jdee-run-interactive-vm-arg-history)))
-			   (list (oref this :main-class))
-			   jdee-run-option-application-args
-			   (if jdee-run-read-app-args
-			       (jdee-run-parse-args
-				(read-from-minibuffer
-				 "Application args: "
-				 (car jdee-run-interactive-app-arg-history)
-				 nil nil
-				 'jdee-run-interactive-app-arg-history)))
-			   ))
-	       (command-string (concat prog " "
-				       (jdee-run-make-arg-string
-					prog-args)
-				       "\n\n")))
-	  (with-current-buffer run-buffer
-	    (erase-buffer)
-	    (cd working-directory)
-	    (insert (concat "cd " working-directory "\n"))
-	    (insert command-string)
-	    (jdee-run-mode))
-	  (save-w32-show-window
-	    (comint-exec run-buffer (oref this :main-class) prog nil prog-args))
-	  (pop-to-buffer run-buffer)
-	  (save-excursion
-	    (goto-char (point-min))
-	  (jdee-run-etrace-update-current-marker))
-	  (cd source-directory))
+        (let* ((run-buffer (get-buffer-create run-buf-name))
+               (win32-p (eq system-type 'windows-nt))
+               (prog (oref this :path))
+               (prog-args (append
+                           (jdee-run-get-vm-args this)
+                           (if jdee-run-read-vm-args
+                               (jdee-run-parse-args
+                                (read-from-minibuffer
+                                 "Vm args: "
+                                 (car jdee-run-interactive-vm-arg-history)
+                                 nil nil
+                                 'jdee-run-interactive-vm-arg-history)))
+                           (list (oref this :main-class))
+                           jdee-run-option-application-args
+                           (if jdee-run-read-app-args
+                               (jdee-run-parse-args
+                                (read-from-minibuffer
+                                 "Application args: "
+                                 (car jdee-run-interactive-app-arg-history)
+                                 nil nil
+                                 'jdee-run-interactive-app-arg-history)))
+                           ))
+               (command-string (concat prog " "
+                                       (jdee-run-make-arg-string
+                                        prog-args)
+                                       "\n\n")))
+          (with-current-buffer run-buffer
+            (erase-buffer)
+            (cd working-directory)
+            (insert (concat "cd " working-directory "\n"))
+            (insert command-string)
+            (jdee-run-mode))
+          (save-w32-show-window
+            (comint-exec run-buffer (oref this :main-class) prog nil prog-args))
+          (pop-to-buffer run-buffer)
+          (save-excursion
+            (goto-char (point-min))
+          (jdee-run-etrace-update-current-marker))
+          (cd source-directory))
       (message "An instance of %s is running." (oref this :main-class))
       (pop-to-buffer run-buf-name))))
 
@@ -782,11 +782,11 @@ panel to specifying the applet document."
 (defmethod jdee-run-verbose-arg ((this jdee-run-vm-1-1))
   "Set the verbose options."
     (let ((print-classes-loaded
-	   (nth 0 jdee-run-option-verbose))
-	  (print-memory-freed
-	   (nth 1 jdee-run-option-verbose))
-	  (print-jni-info
-	   (nth 2 jdee-run-option-verbose)))
+           (nth 0 jdee-run-option-verbose))
+          (print-memory-freed
+           (nth 1 jdee-run-option-verbose))
+          (print-jni-info
+           (nth 2 jdee-run-option-verbose)))
       (append
        (if print-classes-loaded (list "-verbose"))
        (if print-memory-freed (list "-verbosegc"))
@@ -795,26 +795,26 @@ panel to specifying the applet document."
 (defmethod jdee-run-gc-args ((this jdee-run-vm-1-1))
   "Get garbage collection arguments."
     (let ((no-gc-asynch (not
-			 (nth 0 jdee-run-option-garbage-collection)))
-	  (no-gc-classes (not
-			  (nth 1 jdee-run-option-garbage-collection))))
+                         (nth 0 jdee-run-option-garbage-collection)))
+          (no-gc-classes (not
+                          (nth 1 jdee-run-option-garbage-collection))))
       (append
        (if no-gc-asynch
-	  '("-noasyncgc"))
+          '("-noasyncgc"))
        (if no-gc-classes
-	   '("-noclassgc")))))
+           '("-noclassgc")))))
 
 (defmethod jdee-run-verify-args ((this jdee-run-vm-1-1))
   "Get verify arguments."
     (let ((verify-all (nth 0 jdee-run-option-verify))
-	  (verify-remote (nth 1 jdee-run-option-verify)))
+          (verify-remote (nth 1 jdee-run-option-verify)))
       (append
        (if verify-all
-	  '("-verify"))
+          '("-verify"))
        (if (and
-	   (not verify-all)
-	   (not verify-remote))
-	   '("-noverify")))))
+           (not verify-all)
+           (not verify-remote))
+           '("-noverify")))))
 
 (defmethod jdee-run-debug-args ((this jdee-run-vm-1-1))
   "Get arguments required to allow process to connect
@@ -858,21 +858,21 @@ to a debugger."
 (defmethod jdee-run-boot-classpath-arg ((this jdee-run-vm-1-2))
   "Returns the boot classpath argument for this vm."
   (if jdee-run-option-boot-classpath
-	(list
-	 (concat
-	  "-Xbootclasspath:"
-	  (jdee-build-classpath
-	   (cdr jdee-run-option-boot-classpath)
-	   'jdee-run-option-boot-classpath)))))
+        (list
+         (concat
+          "-Xbootclasspath:"
+          (jdee-build-classpath
+           (cdr jdee-run-option-boot-classpath)
+           'jdee-run-option-boot-classpath)))))
 
 (defmethod jdee-run-verbose-arg ((this jdee-run-vm-1-2))
   "Set the verbose options."
     (let ((print-classes-loaded
-	   (nth 0 jdee-run-option-verbose))
-	  (print-memory-freed
-	   (nth 1 jdee-run-option-verbose))
-	  (print-jni-info
-	   (nth 2 jdee-run-option-verbose)))
+           (nth 0 jdee-run-option-verbose))
+          (print-memory-freed
+           (nth 1 jdee-run-option-verbose))
+          (print-jni-info
+           (nth 2 jdee-run-option-verbose)))
       (append
        (if print-classes-loaded (list "-verbose:class"))
        (if print-memory-freed (list "-verbose:gc"))
@@ -881,14 +881,14 @@ to a debugger."
 (defmethod jdee-run-gc-args ((this jdee-run-vm-1-2))
   "Get garbage collection arguments."
     (let ((no-gc-asynch (not
-			 (nth 0 jdee-run-option-garbage-collection)))
-	  (no-gc-classes (not
-			  (nth 1 jdee-run-option-garbage-collection))))
+                         (nth 0 jdee-run-option-garbage-collection)))
+          (no-gc-classes (not
+                          (nth 1 jdee-run-option-garbage-collection))))
       (append
        (if no-gc-asynch
-	  '("-Xnoasyncgc"))
+          '("-Xnoasyncgc"))
        (if no-gc-classes
-	   '("-Xnoclassgc")))))
+           '("-Xnoclassgc")))))
 
 (defmethod jdee-run-debug-args ((this jdee-run-vm-1-2))
   "Get arguments required to allow process to connect
@@ -943,20 +943,20 @@ to a debugger."
   (if jdee-run-option-boot-classpath
       (list
        (concat
-	"-Xbootclasspath"
-	(let ((mode (car jdee-run-option-boot-classpath)))
-	  (cond
-	   ((string= mode "append")
-	    "/a:")
-	   ((string= mode "prepend")
-	    "/p:")
-	   ((string= mode "replace")
-	    ":")
-	   (t
-	    (error "Illegal custom classpath mode: %s"  mode))))
-	(jdee-build-classpath
-	 (cdr jdee-run-option-boot-classpath)
-	 'jdee-run-option-boot-classpath)))))
+        "-Xbootclasspath"
+        (let ((mode (car jdee-run-option-boot-classpath)))
+          (cond
+           ((string= mode "append")
+            "/a:")
+           ((string= mode "prepend")
+            "/p:")
+           ((string= mode "replace")
+            ":")
+           (t
+            (error "Illegal custom classpath mode: %s"  mode))))
+        (jdee-build-classpath
+         (cdr jdee-run-option-boot-classpath)
+         'jdee-run-option-boot-classpath)))))
 
 
 (defmethod jdee-run-debug-args ((this jdee-run-vm-1-3))
@@ -964,29 +964,29 @@ to a debugger."
 to a debugger."
   (if jdee-run-option-debug
       (let ((mode (nth 0 jdee-run-option-debug))
-	    (transport (nth 1 jdee-run-option-debug))
-	    (shared-mem-name (nth 2 jdee-run-option-debug))
-	    (socket-host (nth 3 jdee-run-option-debug))
-	    (socket-port (nth 4 jdee-run-option-debug))
-	    (suspend (nth 5 jdee-run-option-debug))
-	    (ms-windows (eq system-type 'windows-nt)))
-	(list "-Xdebug"
-	      (format
-	       "-Xrunjdwp:transport=%s,address=%s,server=%s,suspend=%s"
-	       (if (string= transport "Shared Memory")
-		   (if ms-windows
-		       "dt_shmem"
-		     (error "Shared memory transport is valid only on Windows."))
-		 "dt_socket")
-	       (if  (string= transport "Shared Memory")
-		   shared-mem-name
-		 (if (string= mode "Client")
-		     (if socket-host
-			 (concat socket-host ":" socket-port)
-		       socket-port)
-		   socket-port))
-	       (if (string= mode "Server") "y" "n")
-	       (if suspend "y" "n"))))))
+            (transport (nth 1 jdee-run-option-debug))
+            (shared-mem-name (nth 2 jdee-run-option-debug))
+            (socket-host (nth 3 jdee-run-option-debug))
+            (socket-port (nth 4 jdee-run-option-debug))
+            (suspend (nth 5 jdee-run-option-debug))
+            (ms-windows (eq system-type 'windows-nt)))
+        (list "-Xdebug"
+              (format
+               "-Xrunjdwp:transport=%s,address=%s,server=%s,suspend=%s"
+               (if (string= transport "Shared Memory")
+                   (if ms-windows
+                       "dt_shmem"
+                     (error "Shared memory transport is valid only on Windows."))
+                 "dt_socket")
+               (if  (string= transport "Shared Memory")
+                   shared-mem-name
+                 (if (string= mode "Client")
+                     (if socket-host
+                         (concat socket-host ":" socket-port)
+                       socket-port)
+                   socket-port))
+               (if (string= mode "Server") "y" "n")
+               (if suspend "y" "n"))))))
 
 (defmethod jdee-run-get-vm-args ((this jdee-run-vm-1-3))
   (append
@@ -1038,22 +1038,22 @@ to a debugger."
       (cond
        ((string= jdee-run-option-enable-assertions "Nowhere"))
        ((string= jdee-run-option-enable-assertions "Everywhere")
-	(setq args '("-ea")))
+        (setq args '("-ea")))
        (t
-	(error "Illegal enable assertions option: \"%s\"."
-	       jdee-run-option-enable-assertions))))
+        (error "Illegal enable assertions option: \"%s\"."
+               jdee-run-option-enable-assertions))))
      ((listp jdee-run-option-enable-assertions)
       (if (car jdee-run-option-enable-assertions)
-	  (setq args '("-ea:...")))
+          (setq args '("-ea:...")))
       (loop for location in (cdr jdee-run-option-enable-assertions) do
-	    (let ((type (car location))
-		  (name (cdr location)))
-	      (if (string= type "package")
-		  (setq name (concat name "...")))
-	      (setq args  (append args (list (concat "-ea:" name)))))))
+            (let ((type (car location))
+                  (name (cdr location)))
+              (if (string= type "package")
+                  (setq name (concat name "...")))
+              (setq args  (append args (list (concat "-ea:" name)))))))
      (t
       (error "Illegal enable assertions option: \"%s\"."
-		jdee-run-option-enable-assertions)))
+                jdee-run-option-enable-assertions)))
     args))
 
 
@@ -1065,22 +1065,22 @@ to a debugger."
       (cond
        ((string= jdee-run-option-disable-assertions "Nowhere"))
        ((string= jdee-run-option-disable-assertions "Everywhere")
-	(setq args '("-da")))
+        (setq args '("-da")))
        (t
-	(error "Illegal disable assertions option: \"%s\"."
-	       jdee-run-option-disable-assertions))))
+        (error "Illegal disable assertions option: \"%s\"."
+               jdee-run-option-disable-assertions))))
      ((listp jdee-run-option-disable-assertions)
       (if (car jdee-run-option-disable-assertions)
-	  (setq args '("-da:...")))
+          (setq args '("-da:...")))
       (loop for location in (cdr jdee-run-option-disable-assertions) do
-	    (let ((type (car location))
-		  (name (cdr location)))
-	      (if (string= type "package")
-		  (setq name (concat name "...")))
-	      (setq args  (append args (list (concat "-da:" name)))))))
+            (let ((type (car location))
+                  (name (cdr location)))
+              (if (string= type "package")
+                  (setq name (concat name "...")))
+              (setq args  (append args (list (concat "-da:" name)))))))
      (t
       (error "Illegal disable assertions option: \"%s\"."
-		jdee-run-option-disable-assertions)))
+                jdee-run-option-disable-assertions)))
     args))
 
 
@@ -1190,33 +1190,33 @@ to a debugger."
 (defun jdee-run-get-vm ()
   "Gets the vm for the current JDK."
   (let* ((jdk-version (jdee-java-version))
-	 (vm
-	  (cl-find-if
-	   (lambda (vm-x)
-	     (string-match
-	      (oref vm-x :version)
-	      (if jdk-version jdk-version "")))
-	   jdee-run-virtual-machines)))
+         (vm
+          (cl-find-if
+           (lambda (vm-x)
+             (string-match
+              (oref vm-x :version)
+              (if jdk-version jdk-version "")))
+           jdee-run-virtual-machines)))
     (if (not vm)
-	(setq vm (car jdee-run-virtual-machines)))
+        (setq vm (car jdee-run-virtual-machines)))
     (oset vm
-	  :path
-	  (let ((vm-path
-		 (substitute-in-file-name jdee-vm-path)))
-	    (if (string= vm-path "")
-		(jdee-get-jdk-prog (if (eq system-type 'windows-nt)
-				      'javaw 'java))
-	      (if (file-exists-p
-		   (if (and
-			(eq system-type 'windows-nt)
-			(not (string-match "[.]exe$" vm-path)))
-		       (concat vm-path ".exe")
-		     vm-path))
-		  vm-path
-		(if (executable-find vm-path)
-		    vm-path
-		  (error "Invalid vm path: %s"
-			 vm-path))))))
+          :path
+          (let ((vm-path
+                 (substitute-in-file-name jdee-vm-path)))
+            (if (string= vm-path "")
+                (jdee-get-jdk-prog (if (eq system-type 'windows-nt)
+                                      'javaw 'java))
+              (if (file-exists-p
+                   (if (and
+                        (eq system-type 'windows-nt)
+                        (not (string-match "[.]exe$" vm-path)))
+                       (concat vm-path ".exe")
+                     vm-path))
+                  vm-path
+                (if (executable-find vm-path)
+                    vm-path
+                  (error "Invalid vm path: %s"
+                         vm-path))))))
     vm))
 
 ;;;###autoload
@@ -1236,41 +1236,41 @@ interact with the program."
   (interactive "p")
   (if (equal major-mode 'jdee-mode)
       (if (string= jdee-run-executable "")
-	  (let ((vm (jdee-run-get-vm))
-		(read-app-args
-		 (or jdee-run-read-app-args
-		     (not (= prefix 1))))
-		(read-main-class
+          (let ((vm (jdee-run-get-vm))
+                (read-app-args
+                 (or jdee-run-read-app-args
+                     (not (= prefix 1))))
+                (read-main-class
                  (= prefix -1)))
-	    (oset
-	     vm
-	     :main-class
-	     (if read-main-class
-		 (read-from-minibuffer
-		  "Main class: "
-		  (concat (jdee-parse-get-package)
+            (oset
+             vm
+             :main-class
+             (if read-main-class
+                 (read-from-minibuffer
+                  "Main class: "
+                  (concat (jdee-parse-get-package)
                           (file-name-sans-extension
                            (file-name-nondirectory (buffer-file-name)))))
-	       (jdee-run-get-main-class)))
-	    (let ((jdee-run-read-app-args read-app-args))
-	      (jdee-run-vm-launch vm)))
-	(jdee-run-executable))
+               (jdee-run-get-main-class)))
+            (let ((jdee-run-read-app-args read-app-args))
+              (jdee-run-vm-launch vm)))
+        (jdee-run-executable))
     (error "The jdee-run command works only in a Java source buffer.")))
 
 (defun jdee-run-get-main-class ()
   "Gets the main class for the application to which the current
 source buffer belongs."
   (let ((main-class
-	 (if jdee-run-option-jar
-	     (jdee-normalize-path 'jdee-run-application-class)
+         (if jdee-run-option-jar
+             (jdee-normalize-path 'jdee-run-application-class)
            jdee-run-application-class)))
     (if (or
-	 (not main-class)
-	 (string= main-class ""))
-	(setq main-class
-	      (concat (jdee-parse-get-package)
-		      (file-name-sans-extension
-		       (file-name-nondirectory (buffer-file-name))))))
+         (not main-class)
+         (string= main-class ""))
+        (setq main-class
+              (concat (jdee-parse-get-package)
+                      (file-name-sans-extension
+                       (file-name-nondirectory (buffer-file-name))))))
     main-class))
 
 (defun jdee-run-main-class()
@@ -1296,48 +1296,48 @@ buffer belongs is running."
 
 (defun jdee-run-executable()
   (let* ((prog-path
-	  (jdee-normalize-path
-	   jdee-run-executable
-	   'jdee-run-executable))
-	 (prog-name (file-name-sans-extension
-		     (file-name-nondirectory
-		      prog-path)))
-	 (run-buf-name (concat "*" prog-name "*"))
-	 (source-directory default-directory)
-	 (working-directory (if (string= jdee-run-working-directory "")
-				default-directory
-			      (jdee-normalize-path 'jdee-run-working-directory))))
+          (jdee-normalize-path
+           jdee-run-executable
+           'jdee-run-executable))
+         (prog-name (file-name-sans-extension
+                     (file-name-nondirectory
+                      prog-path)))
+         (run-buf-name (concat "*" prog-name "*"))
+         (source-directory default-directory)
+         (working-directory (if (string= jdee-run-working-directory "")
+                                default-directory
+                              (jdee-normalize-path 'jdee-run-working-directory))))
     (if (not (comint-check-proc run-buf-name))
-	(let* ((w32-quote-process-args ?\")
-	       (win32-quote-process-args ?\") ;; XEmacs
-	       (run-buffer (get-buffer-create run-buf-name))
-	       (prog-args (append
-			   jdee-run-executable-args
-			   (if jdee-run-read-app-args
-			       (jdee-run-parse-args
-				(read-from-minibuffer
-				 "Application args: "
-				 nil
-				 nil nil
-				 '(jdee-run-interactive-app-arg-history . 1))))
-			   ))
-	       (command-string (concat jdee-run-executable " "
-				       (mapconcat (lambda (arg) arg)
-						  prog-args " ")
-				       "\n\n")))
-	  (with-current-buffer run-buffer
-	    (erase-buffer)
-	    (cd working-directory)
-	    (insert (concat "cd " working-directory "\n"))
-	    (insert command-string)
-	    (jdee-run-mode))
-	  (save-w32-show-window
-	   (comint-exec run-buffer prog-name prog-path nil prog-args))
-	  (pop-to-buffer run-buffer)
-	  (save-excursion
-	    (goto-char (point-min))
-	    (jdee-run-etrace-update-current-marker))
-	  (cd source-directory))
+        (let* ((w32-quote-process-args ?\")
+               (win32-quote-process-args ?\") ;; XEmacs
+               (run-buffer (get-buffer-create run-buf-name))
+               (prog-args (append
+                           jdee-run-executable-args
+                           (if jdee-run-read-app-args
+                               (jdee-run-parse-args
+                                (read-from-minibuffer
+                                 "Application args: "
+                                 nil
+                                 nil nil
+                                 '(jdee-run-interactive-app-arg-history . 1))))
+                           ))
+               (command-string (concat jdee-run-executable " "
+                                       (mapconcat (lambda (arg) arg)
+                                                  prog-args " ")
+                                       "\n\n")))
+          (with-current-buffer run-buffer
+            (erase-buffer)
+            (cd working-directory)
+            (insert (concat "cd " working-directory "\n"))
+            (insert command-string)
+            (jdee-run-mode))
+          (save-w32-show-window
+           (comint-exec run-buffer prog-name prog-path nil prog-args))
+          (pop-to-buffer run-buffer)
+          (save-excursion
+            (goto-char (point-min))
+            (jdee-run-etrace-update-current-marker))
+          (cd source-directory))
       (message "An instance of %s is running." prog-name)
       (pop-to-buffer run-buf-name))))
 
@@ -1358,20 +1358,20 @@ buffer belongs is running."
 (defun jdee-get-appletviewer-options ()
   (let (options)
     (if (not (string= jdee-appletviewer-option-encoding ""))
-	(setq options (list
-			"-encoding"
-			jdee-appletviewer-option-encoding)))
+        (setq options (list
+                        "-encoding"
+                        jdee-appletviewer-option-encoding)))
     (if jdee-appletviewer-option-vm-args
-	(let ((len (length jdee-appletviewer-option-vm-args))
-	      (n 0))
-	  (while (< n len)
-	    (setq options
-		  (nconc
-		   options
-		   (list
-		    (concat "-J"
-			    (nth n jdee-appletviewer-option-vm-args)))))
-	    (setq n (1+ n)))))
+        (let ((len (length jdee-appletviewer-option-vm-args))
+              (n 0))
+          (while (< n len)
+            (setq options
+                  (nconc
+                   options
+                   (list
+                    (concat "-J"
+                            (nth n jdee-appletviewer-option-vm-args)))))
+            (setq n (1+ n)))))
     options))
 
 (defun jdee-run-applet-exec (buffer name command startfile switches)
@@ -1380,7 +1380,7 @@ a command shell subprocess rather than as a subprocess of Emacs. This
 is necessary to avoid displaying a DOS window when starting a viewer
 under Windows."
   (with-current-buffer buffer
-    (let ((proc (get-buffer-process buffer)))	; Blast any old process.
+    (let ((proc (get-buffer-process buffer)))        ; Blast any old process.
       (if proc (delete-process proc)))
     ;; Crank up a new process
     (let ((proc (jdee-run-applet-exec-1 name buffer command switches)))
@@ -1398,54 +1398,54 @@ under Windows."
 
 (defun jdee-run-applet-exec-1 (name buffer command switches)
   (let ((w32-quote-process-args ?\")
-	(win32-quote-process-args ?\") ;; XEmacs
-	(process-environment
-	 (nconc
-	  ;; If using termcap, we specify `emacs' as the terminal type
-	  ;; because that lets us specify a width.
-	  ;; If using terminfo, we specify `dumb' because that is
-	  ;; a defined terminal type.  `emacs' is not a defined terminal type
-	  ;; and there is no way for us to define it here.
-	  ;; Some programs that use terminfo get very confused
-	  ;; if TERM is not a valid terminal type.
-	  (if (and (boundp 'system-uses-terminfo) system-uses-terminfo)
-	      (list "TERM=dumb"
-		    (format "COLUMNS=%d" (frame-width)))
-	    (list "TERM=emacs"
-		  (format "TERMCAP=emacs:co#%d:tc=unknown:" (frame-width))))
-	  (if (getenv "EMACS") nil (list "EMACS=t"))
-	  process-environment))
-	(default-directory
-	  (if (file-directory-p default-directory)
-	      default-directory
-	    "/")))
+        (win32-quote-process-args ?\") ;; XEmacs
+        (process-environment
+         (nconc
+          ;; If using termcap, we specify `emacs' as the terminal type
+          ;; because that lets us specify a width.
+          ;; If using terminfo, we specify `dumb' because that is
+          ;; a defined terminal type.  `emacs' is not a defined terminal type
+          ;; and there is no way for us to define it here.
+          ;; Some programs that use terminfo get very confused
+          ;; if TERM is not a valid terminal type.
+          (if (and (boundp 'system-uses-terminfo) system-uses-terminfo)
+              (list "TERM=dumb"
+                    (format "COLUMNS=%d" (frame-width)))
+            (list "TERM=emacs"
+                  (format "TERMCAP=emacs:co#%d:tc=unknown:" (frame-width))))
+          (if (getenv "EMACS") nil (list "EMACS=t"))
+          process-environment))
+        (default-directory
+          (if (file-directory-p default-directory)
+              default-directory
+            "/")))
     (apply 'start-process-shell-command name buffer command switches)))
 
 (defun jdee-run-applet-internal (doc)
   (let* ((doc-file-name (file-name-nondirectory doc))
-	 (doc-directory (file-name-directory doc))
-	 (doc-name (file-name-sans-extension doc-file-name))
-	 (run-buf-name (concat "*" doc-name "*")))
+         (doc-directory (file-name-directory doc))
+         (doc-name (file-name-sans-extension doc-file-name))
+         (run-buf-name (concat "*" doc-name "*")))
 
     (if (not (comint-check-proc run-buf-name))
-	(let* ((run-buffer (get-buffer-create run-buf-name))
-	       (win32-p (eq system-type 'windows-nt))
-	       (prog jdee-run-applet-viewer)
-	       (prog-args
-		(append (jdee-get-appletviewer-options)
-			(list doc-file-name)))
-	       (command-string (concat prog " "
-				       (jdee-run-make-arg-string
-					prog-args)
-				       "\n\n")))
-	  (with-current-buffer run-buffer
-	    (erase-buffer)
-	    (cd doc-directory)
-	    (insert (concat "cd " doc-directory "\n"))
-	    (insert command-string)
-	    (jdee-run-mode))
-	  (jdee-run-applet-exec run-buffer doc-name prog nil prog-args)
-	  (pop-to-buffer run-buffer))
+        (let* ((run-buffer (get-buffer-create run-buf-name))
+               (win32-p (eq system-type 'windows-nt))
+               (prog jdee-run-applet-viewer)
+               (prog-args
+                (append (jdee-get-appletviewer-options)
+                        (list doc-file-name)))
+               (command-string (concat prog " "
+                                       (jdee-run-make-arg-string
+                                        prog-args)
+                                       "\n\n")))
+          (with-current-buffer run-buffer
+            (erase-buffer)
+            (cd doc-directory)
+            (insert (concat "cd " doc-directory "\n"))
+            (insert command-string)
+            (jdee-run-mode))
+          (jdee-run-applet-exec run-buffer doc-name prog nil prog-args)
+          (pop-to-buffer run-buffer))
       (message "An instance of the applet in %s is running." doc-name)
       (pop-to-buffer run-buf-name))))
 
@@ -1456,7 +1456,7 @@ return (\"/a/b/c.html\") if it exists, else return (\"/a/b/c.htm\")
 if it exists, else return a list of all *.html files in /a/b/
 directory."
   (let ((basename (file-name-sans-extension (buffer-file-name)))
-	f)
+        f)
     (cond
      ((file-exists-p (setq f (concat basename ".html")))
       (list f))
@@ -1464,12 +1464,12 @@ directory."
       (list f))
      (t
       (cl-mapcan (lambda (file)
-		   (if (or
-			(string-match "[.]html$" file)
-			(string-match "[.]htm$" file))
-		       (list file)))
-		 (directory-files
-		  (file-name-directory (buffer-file-name)) t))))))
+                   (if (or
+                        (string-match "[.]html$" file)
+                        (string-match "[.]htm$" file))
+                       (list file)))
+                 (directory-files
+                  (file-name-directory (buffer-file-name)) t))))))
 
 
 
@@ -1497,20 +1497,20 @@ file."
      (list (read-file-name "Applet doc: " nil nil nil jdee-run-applet-last-doc))))
   (setq jdee-run-applet-last-doc doc)
   (let ((applet-doc (if (and jdee-run-applet-last-doc
-			     (not (string= jdee-run-applet-last-doc "")))
-			jdee-run-applet-last-doc
-		      (if (and jdee-run-applet-doc
-			       (not (string= jdee-run-applet-doc "")))
-			    jdee-run-applet-doc
-			  (car (jdee-run-find-html-files))))))
+                             (not (string= jdee-run-applet-last-doc "")))
+                        jdee-run-applet-last-doc
+                      (if (and jdee-run-applet-doc
+                               (not (string= jdee-run-applet-doc "")))
+                            jdee-run-applet-doc
+                          (car (jdee-run-find-html-files))))))
     (if applet-doc
-	(if (string-match "appletviewer" jdee-run-applet-viewer)
-	    (jdee-run-applet-internal applet-doc)
-	  (if (or
-	       (string= jdee-run-applet-viewer "")
-	       (string-match "browse-url" jdee-run-applet-viewer))
-	      (browse-url applet-doc)
-	    (jdee-run-applet-internal (concat default-directory applet-doc))))
+        (if (string-match "appletviewer" jdee-run-applet-viewer)
+            (jdee-run-applet-internal applet-doc)
+          (if (or
+               (string= jdee-run-applet-viewer "")
+               (string-match "browse-url" jdee-run-applet-viewer))
+              (browse-url applet-doc)
+            (jdee-run-applet-internal (concat default-directory applet-doc))))
       (signal 'error "Could not find html document to display applet."))))
 
 
@@ -1550,13 +1550,13 @@ A cons of two markers, location of the error and the location in the code.")
   "Update the `cdr' and the `car' of `jdee-run-etrace-current-marker' from its `car'.
 Here goes all the error message parsing."
   (let ((here (car jdee-run-etrace-current-marker))
-	(there (cdr jdee-run-etrace-current-marker))
-	(n (or next 0))
-	(re (concat " \\([a-zA-Z0-9_.]+\\.\\)?" ; package
-		     "\\([a-zA-Z0-9_$]+\\)" ; class
-		     "\\.<?[a-zA-Z0-9_]+>?" ; method
-		     "(\\([a-zA-Z0-9_]+\\)\\.java:" ; java file = public class
-		     "\\([0-9]+\\))"))); line number
+        (there (cdr jdee-run-etrace-current-marker))
+        (n (or next 0))
+        (re (concat " \\([a-zA-Z0-9_.]+\\.\\)?" ; package
+                     "\\([a-zA-Z0-9_$]+\\)" ; class
+                     "\\.<?[a-zA-Z0-9_]+>?" ; method
+                     "(\\([a-zA-Z0-9_]+\\)\\.java:" ; java file = public class
+                     "\\([0-9]+\\))"))); line number
     (with-current-buffer (marker-buffer here)
       (goto-char here)
       ;; In order to display the current match at the top of
@@ -1565,45 +1565,45 @@ Here goes all the error message parsing."
       ;; at the end of the line again, you will match the same error.
       ;; If n is 0 ensure that point is at the beggining
       (if (> n 0)
-	  (end-of-line)
-	(beginning-of-line))
+          (end-of-line)
+        (beginning-of-line))
 
       (if (>= n 0)
-	  (if (re-search-forward re nil t)
-	      (progn
-		;;setting the line at the beggining
-		;;so that it is the first line of the errors
-		(beginning-of-line)
-		(jdee-run-etrace-update-current-marker))
-	    (error "End of stack trace"))
-	(if (re-search-backward re nil t)
-	    (progn
-	      (jdee-run-etrace-update-current-marker))
-	  (error "Start of stack trace")))
+          (if (re-search-forward re nil t)
+              (progn
+                ;;setting the line at the beggining
+                ;;so that it is the first line of the errors
+                (beginning-of-line)
+                (jdee-run-etrace-update-current-marker))
+            (error "End of stack trace"))
+        (if (re-search-backward re nil t)
+            (progn
+              (jdee-run-etrace-update-current-marker))
+          (error "Start of stack trace")))
 ;;       (message "1: [%s]; 2: [%s]; 3: [%s]; 4: [%s]" (match-string 1)
 ;;                (match-string 2) (match-string 3) (match-string 4))
       (let* ((package (or (match-string 1) ""))
-	    (class (match-string 2))
-	    (file-name (match-string 3))
-	    (line (car (read-from-string (match-string 4))))
-	    (file (jdee-find-class-source-file (concat package file-name)))
-	    buf)
-	(condition-case err
-	    (progn
-	      (setq buf (if file (find-file-noselect file)))
-	      (set-buffer buf)
-	      (goto-char (point-min))
-	      (forward-line (1- line))
-	      (set-marker there (point) buf))
-	  (error err))))
+            (class (match-string 2))
+            (file-name (match-string 3))
+            (line (car (read-from-string (match-string 4))))
+            (file (jdee-find-class-source-file (concat package file-name)))
+            buf)
+        (condition-case err
+            (progn
+              (setq buf (if file (find-file-noselect file)))
+              (set-buffer buf)
+              (goto-char (point-min))
+              (forward-line (1- line))
+              (set-marker there (point) buf))
+          (error err))))
     jdee-run-etrace-current-marker))
 
 (defun jdee-run-etrace-goto (&optional next)
   "Display the current stack using `compilation-goto-locus'."
   (jdee-run-etrace-current-marker next)
   (compilation-goto-locus (car jdee-run-etrace-current-marker)
-			  (cdr jdee-run-etrace-current-marker)
-			  nil))
+                          (cdr jdee-run-etrace-current-marker)
+                          nil))
 
 (defun jdee-run-etrace-show-at-mouse (event)
   "Jump to the stack position at the mouse click.

--- a/jdee-stacktrace.el
+++ b/jdee-stacktrace.el
@@ -78,18 +78,18 @@ If a region is active, paste it into the stack trace buffer."
   (let ((buffer (or buffer (current-buffer))))
     (with-current-buffer buffer
       (let* ((active (region-active-p))
-	     (beg (if active (region-beginning)))
-	     (end (if active (region-end))))
-	(with-current-buffer (pop-to-buffer  "*JDEE Stack Trace*")
+             (beg (if active (region-beginning)))
+             (end (if active (region-end))))
+        (with-current-buffer (pop-to-buffer  "*JDEE Stack Trace*")
           (when clear (erase-buffer))
-	  (jdee-stacktrace-mode)
+          (jdee-stacktrace-mode)
           (make-local-variable 'jdee-sourcepath)
-	  (setq inhibit-read-only t)
-	  (when active
-	    (let ((start (point-max)))
-	      (goto-char start)
-	      (insert-buffer-substring buffer beg end)
-	      (goto-char start))))))))
+          (setq inhibit-read-only t)
+          (when active
+            (let ((start (point-max)))
+              (goto-char start)
+              (insert-buffer-substring buffer beg end)
+              (goto-char start))))))))
 
 (provide 'jdee-stacktrace)
 

--- a/jdee-stat.el
+++ b/jdee-stat.el
@@ -38,122 +38,122 @@ a total count could be passed to be displayed, as well as the number of
 processed files."
   (interactive)
   (cl-flet ((perc2x2 (a b)
-		     (format "%.1f" (* 100(/ (float a) (float b))))))
+                     (format "%.1f" (* 100(/ (float a) (float b))))))
     (let* ((fname (buffer-file-name))
-	   (result (if count count (jdee-stat-count-loc)))
-	   (total (nth 0 result))
-	   (comment (nth 1 result))
-	   (javadoc (nth 2 result))
-	   (blank (nth 3 result))
-	   (code (- total (+ comment javadoc blank)))
-	   (code-perc (perc2x2 code total))
-	   (doc-perc (perc2x2 comment total))
-	   (jdoc-perc (perc2x2 javadoc total))
-	   (blank-perc (perc2x2 blank total)))
+           (result (if count count (jdee-stat-count-loc)))
+           (total (nth 0 result))
+           (comment (nth 1 result))
+           (javadoc (nth 2 result))
+           (blank (nth 3 result))
+           (code (- total (+ comment javadoc blank)))
+           (code-perc (perc2x2 code total))
+           (doc-perc (perc2x2 comment total))
+           (jdoc-perc (perc2x2 javadoc total))
+           (blank-perc (perc2x2 blank total)))
       (with-output-to-temp-buffer "LOC Report"
-	(princ "Lines of Code Report\n\n")
-	(if (and count total-files)
-	    (princ (format "Total files:  %d\n" total-files))
-	  (progn
-	    (princ (format "File name: %s\n" fname))
-	    (princ (format "File date: %s\n" (format-time-string "%D" (nth 5 (file-attributes fname)))))))
-	(princ "------------------- \n")
-	(princ (format "Code lines:    %d (%s%%)\n" code code-perc))
-	(princ (format "Javadoc lines: %d (%s%%)\n" javadoc jdoc-perc))
-	(princ (format "Comment lines: %d (%s%%)\n" comment doc-perc))
-	(princ (format "Blank lines:   %d (%s%%)\n" blank blank-perc))
-	(princ (format "Total lines:   %d  \n" total))
-	(princ "")))))
+        (princ "Lines of Code Report\n\n")
+        (if (and count total-files)
+            (princ (format "Total files:  %d\n" total-files))
+          (progn
+            (princ (format "File name: %s\n" fname))
+            (princ (format "File date: %s\n" (format-time-string "%D" (nth 5 (file-attributes fname)))))))
+        (princ "------------------- \n")
+        (princ (format "Code lines:    %d (%s%%)\n" code code-perc))
+        (princ (format "Javadoc lines: %d (%s%%)\n" javadoc jdoc-perc))
+        (princ (format "Comment lines: %d (%s%%)\n" comment doc-perc))
+        (princ (format "Blank lines:   %d (%s%%)\n" blank blank-perc))
+        (princ (format "Total lines:   %d  \n" total))
+        (princ "")))))
 
 
 (defun jdee-stat-parse-token-out-of-quote (token line)
   (let (result)
      ;;;Does the line contain '//'?
     (if (string-match token line)
-	 ;;;if so, does it contain '"'
-	(if (not (string-match "\"" line ))
-	     ;;;no! Ok, it's a comment
-	    (setq result t)
-	   ;;;yes!? so, we've got to parse to see if '//' exists without enclosing quote
-	  (let (
-		;;;we split the line in '"' delimited parts
-		(to-parse (split-string line "\""))
-		(temp "")
-		(count-even 0))
-	    ;;;we consider the even numbered parts of split
-	    ;;;to see if the contain a'//'
-	    ;;;if so, this is a doc line
-	    (while temp
-	      (setq temp (nth count-even to-parse))
-	      (if temp
-		  (if (string-match token temp)
-		      (progn
-			(setq result t)
-			(setq temp nil))))
-	      (setq count-even (+ 2  count-even))))))
+         ;;;if so, does it contain '"'
+        (if (not (string-match "\"" line ))
+             ;;;no! Ok, it's a comment
+            (setq result t)
+           ;;;yes!? so, we've got to parse to see if '//' exists without enclosing quote
+          (let (
+                ;;;we split the line in '"' delimited parts
+                (to-parse (split-string line "\""))
+                (temp "")
+                (count-even 0))
+            ;;;we consider the even numbered parts of split
+            ;;;to see if the contain a'//'
+            ;;;if so, this is a doc line
+            (while temp
+              (setq temp (nth count-even to-parse))
+              (if temp
+                  (if (string-match token temp)
+                      (progn
+                        (setq result t)
+                        (setq temp nil))))
+              (setq count-even (+ 2  count-even))))))
     result))
 
 (defun jdee-stat-count-loc ()
   "Counts the code, comments, javadoc, and blank lines in the current buffer.
 Returns the counts in a list: (TOTAL-LINES COMMENT-LINES JAVADOC-LINES BLANK-LINES)."
   (let ((count 0)
-	(line "")
-	(javadoc-count 0)
-	(comment-count 0)
-	(blank-count 0)
-	in-javadoc
-	in-comment
-	(test-b t)
-	start
-	end)
+        (line "")
+        (javadoc-count 0)
+        (comment-count 0)
+        (blank-count 0)
+        in-javadoc
+        in-comment
+        (test-b t)
+        start
+        end)
     (save-excursion
       (goto-char (point-min))
       (while test-b
-	(beginning-of-line 1)
-	(setq start (point))
-	(end-of-line 1)
-	(setq end (point))
-	(setq line (buffer-substring start end))
-	(setq count (+ 1 count))
+        (beginning-of-line 1)
+        (setq start (point))
+        (end-of-line 1)
+        (setq end (point))
+        (setq line (buffer-substring start end))
+        (setq count (+ 1 count))
 
       ;;;To match a blank line, we search the pattern representing an empty line
       ;;;or a line that just contains spaces
-	(if (string-match "^ *$" line)
-	    (setq blank-count (+ 1 blank-count) ))
+        (if (string-match "^ *$" line)
+            (setq blank-count (+ 1 blank-count) ))
 
       ;;;To match a comment line, we search the pattern '//'
       ;;;but we must disgard the '//' patterns enclosed in a pair of quote '"'
-	(if (jdee-stat-parse-token-out-of-quote "//" line)
-	    (setq comment-count (+ 1 comment-count)))
+        (if (jdee-stat-parse-token-out-of-quote "//" line)
+            (setq comment-count (+ 1 comment-count)))
 
       ;;;To match a comment block start, we search the pattern '/*' and exclude those of type '/**'
       ;;;but we must disgard the '/*' patterns enclosed in a pair of quote '"'
-	(if (and
-	     (jdee-stat-parse-token-out-of-quote "/\\*" line)
-	     (not (jdee-stat-parse-token-out-of-quote "/\\*\\*" line)))
-	    (setq in-comment t))
+        (if (and
+             (jdee-stat-parse-token-out-of-quote "/\\*" line)
+             (not (jdee-stat-parse-token-out-of-quote "/\\*\\*" line)))
+            (setq in-comment t))
 
       ;;;To match a javadoc block start, we search the pattern '/**'
       ;;;but we must disgard the '/**' patterns enclosed in a pair of quote '"'
-	(if (jdee-stat-parse-token-out-of-quote "/\\*\\*" line)
-	    (setq in-javadoc t))
+        (if (jdee-stat-parse-token-out-of-quote "/\\*\\*" line)
+            (setq in-javadoc t))
 
       ;;;To match a block end, we search the pattern '*/'
       ;;;but we must disgard the '*/' patterns enclosed in a pair of quote '"'
-	(if (jdee-stat-parse-token-out-of-quote "\\*/" line)
-	    (progn
-	      (if in-javadoc
-		  (setq javadoc-count (+ 1 javadoc-count)))
-	      (if in-comment
-		  (setq comment-count (+ 1 comment-count)))
-	      (setq in-javadoc nil)
-	      (setq in-comment nil)))
-	(if in-javadoc
-	    (setq javadoc-count (+ 1 javadoc-count)))
-	(if in-comment
-	    (setq comment-count (+ 1 comment-count)))
-	(if (not (= (forward-line 1) 0))
-	    (setq test-b nil))))
+        (if (jdee-stat-parse-token-out-of-quote "\\*/" line)
+            (progn
+              (if in-javadoc
+                  (setq javadoc-count (+ 1 javadoc-count)))
+              (if in-comment
+                  (setq comment-count (+ 1 comment-count)))
+              (setq in-javadoc nil)
+              (setq in-comment nil)))
+        (if in-javadoc
+            (setq javadoc-count (+ 1 javadoc-count)))
+        (if in-comment
+            (setq comment-count (+ 1 comment-count)))
+        (if (not (= (forward-line 1) 0))
+            (setq test-b nil))))
     (list count comment-count javadoc-count blank-count)))
 
 ;;;###autoload
@@ -174,9 +174,9 @@ containing a java file contained in dir. It returns a list containing
 two elements, a list of the number of code lines, comment lines,
 javadoc lines and blank lines and the number fo files."
   (let* ((directories (jdee-stat-get-directories dir))
-	 (count (jdee-stat-loc-count-directory dir))
-	 (current-count (car count))
-	 (number-of-files (cadr count)))
+         (count (jdee-stat-loc-count-directory dir))
+         (current-count (car count))
+         (number-of-files (cadr count)))
     (while directories
       (setq count (jdee-stat-loc-count-directories (car directories)))
       (setq current-count (jdee-stat-add current-count (car count)))
@@ -188,12 +188,12 @@ javadoc lines and blank lines and the number fo files."
   "Returns a list of the subdirectories in dir."
   (let (result)
     (apply 'nconc
-	   (mapcar (function
-		    (lambda (file)
-		      (if (and (not (string= (substring file -1) "."))
-			       (file-directory-p file))
-			  (setq result (append result (list file))))))
-		   (directory-files dir t nil t)))
+           (mapcar (function
+                    (lambda (file)
+                      (if (and (not (string= (substring file -1) "."))
+                               (file-directory-p file))
+                          (setq result (append result (list file))))))
+                   (directory-files dir t nil t)))
     result))
 
 ;;;###autoload
@@ -214,8 +214,8 @@ contained in dir. It returns a list containing two elements,
 a list of the number of code lines, comment lines,
 javadoc lines and blank lines and the number fo files."
   (let* ((files (directory-files dir t (wildcard-to-regexp "*.java") t))
-	 (number-of-files (length files))
-	 (count (list 0 0 0 0)))
+         (number-of-files (length files))
+         (count (list 0 0 0 0)))
     (while files
       (switch-to-buffer (find-file-noselect (car files) nil t))
       (setq count (jdee-stat-add count (jdee-stat-count-loc)))
@@ -230,9 +230,9 @@ the third the number of javadoc lines, and fourth the number of
 blank lines. It adds the respective elements in each list and returns another
 list of four elements."
   (list (+ (nth 0 count) (nth 0 count2))
-	(+ (nth 1 count) (nth 1 count2))
-	(+ (nth 2 count) (nth 2 count2))
-	(+ (nth 3 count) (nth 3 count2))))
+        (+ (nth 1 count) (nth 1 count2))
+        (+ (nth 2 count) (nth 2 count2))
+        (+ (nth 3 count) (nth 3 count2))))
 
 ;; Register and initialize the customization variables defined
 ;; by this package.

--- a/jdee-util.el
+++ b/jdee-util.el
@@ -78,12 +78,12 @@ Signal an error if FEATURE can't be found."
       "Replace FROMCHAR with TOCHAR in STRING each time it occurs.
 Unless optional argument INPLACE is non-nil, return a new string."
       (let ((i (length string))
-	    (newstr (if inplace string (copy-sequence string))))
-	(while (> i 0)
-	  (setq i (1- i))
-	  (if (eq (aref newstr i) fromchar)
-	      (aset newstr i tochar)))
-	newstr)))
+            (newstr (if inplace string (copy-sequence string))))
+        (while (> i 0)
+          (setq i (1- i))
+          (if (eq (aref newstr i) fromchar)
+              (aset newstr i tochar)))
+        newstr)))
 
 (defun jdee-replace-in-string  (string regexp newtext &optional literal)
   "Replace REGEXP with NEWTEXT in STRING. see: `replace-match'"
@@ -95,14 +95,14 @@ Unless optional argument INPLACE is non-nil, return a new string."
 (defun jdee-get-line-at-point (&optional pos)
   "Get the number of the line at point."
   (let* ((point (or pos (point)))
-	 (ln (if (= point 1)
-		 1
-	       (count-lines (point-min) point))))
+         (ln (if (= point 1)
+                 1
+               (count-lines (point-min) point))))
     (save-excursion
       (goto-char point)
       (if (eq (char-before) ?\n)
-	  (1+ ln)
-	ln))))
+          (1+ ln)
+        ln))))
 
 (defun jdee-root ()
   "Return the path of the root directory of this JDEE
@@ -129,7 +129,7 @@ that contains the JDEE lisp directory."
   "Get the location used by the host system to store temporary files."
   (or (if (boundp 'temporary-file-directory) temporary-file-directory)
       (if (fboundp 'temp-directory) (temp-directory)
-	(error "No temp-directory function found"))))
+        (error "No temp-directory function found"))))
 
 ;; FIXME: this checks that temp-directory is unbound, then calls it anyway!?
 ;; (if (member system-type '(cygwin32 cygwin))
@@ -142,9 +142,9 @@ that contains the JDEE lisp directory."
    nil
    (mapcar
     #'(lambda (buffer)
-	(with-current-buffer buffer
-	  (if (eq major-mode 'jdee-mode)
-	      buffer)))
+        (with-current-buffer buffer
+          (if (eq major-mode 'jdee-mode)
+              buffer)))
     (buffer-list))))
 
 (defun jdee-get-project-source-buffers (&optional project-file)
@@ -153,14 +153,14 @@ whose project file is PROJECT-FILE. If PROJECT-FILE is not specified,
 this function returns the buffers belonging to the project in the
 currently selected source buffer."
   (let ((proj-file
-	 (or project-file
-	     (if (boundp 'jdee-current-project)
-		 jdee-current-project))))
+         (or project-file
+             (if (boundp 'jdee-current-project)
+                 jdee-current-project))))
     (delq
      nil
      (mapcar
       (lambda (buffer)
-	(with-current-buffer buffer
+        (with-current-buffer buffer
           (if (equal jdee-buffer-project-file proj-file)
               buffer)))
       (jdee-get-java-source-buffers)))))
@@ -168,14 +168,14 @@ currently selected source buffer."
 (defun jdee-get-visible-source-buffers ()
   "Return a list of visible Java source buffers."
   (delq nil (mapcar #'(lambda (buffer)
-			(if (get-buffer-window buffer 'visible)
-			    buffer))
-		    (jdee-get-java-source-buffers))))
+                        (if (get-buffer-window buffer 'visible)
+                            buffer))
+                    (jdee-get-java-source-buffers))))
 
 (defun jdee-get-selected-source-buffer ()
   (with-current-buffer (window-buffer (selected-window))
     (if (eq major-mode 'jdee-mode)
-	(current-buffer))))
+        (current-buffer))))
 
 (defvar jdee-exception-goto-regexp
   "[ \t]+\\(?:at \\)?\\([a-zA-Z0-9.]+\\)\\(?:\\$?[a-zA-Z0-9]*\\)\\.\\([^(]+\\)([^:]+:\\([0-9]+\\))$"
@@ -187,21 +187,21 @@ stack trace.")
   "Go to the Java source file and line indicated by an exception stack trace."
   (interactive)
   (let ((regexp jdee-exception-goto-regexp)
-	file line end)
+        file line end)
     (save-match-data
       (save-excursion
-	(end-of-line)
-	(setq end (point))
-	(beginning-of-line)
-	(if (not (re-search-forward regexp end t))
-	    (error (concat "Current line doesn't look "
-			   "like an exception stack trace line")))
-	(let ((full-class (match-string 1))
-	      (method (match-string 2)))
-	  (setq line (string-to-number (match-string 3)))
-	  (setq file (jdee-find-class-source-file full-class))
-	  (if (null file)
-	      (error "Java source for class `%s' not found" full-class)))))
+        (end-of-line)
+        (setq end (point))
+        (beginning-of-line)
+        (if (not (re-search-forward regexp end t))
+            (error (concat "Current line doesn't look "
+                           "like an exception stack trace line")))
+        (let ((full-class (match-string 1))
+              (method (match-string 2)))
+          (setq line (string-to-number (match-string 3)))
+          (setq file (jdee-find-class-source-file full-class))
+          (if (null file)
+              (error "Java source for class `%s' not found" full-class)))))
     (find-file-other-window file)
     (goto-char (point-min))
     (forward-line (1- line))))
@@ -226,47 +226,47 @@ Requires ELPA package `htmlize'.
 See `jdee-htmlize-code-destinations'."
   (interactive
    (append (if mark-active
-	       (list (region-beginning) (region-end))
-	     (list (point-min) (point-max)))
-	   (list (not current-prefix-arg))))
+               (list (region-beginning) (region-end))
+             (list (point-min) (point-max)))
+           (list (not current-prefix-arg))))
   (unless (require 'htmlize nil t)
     (error "Requires ELPA package `htmlize'"))
   (save-restriction
     (narrow-to-region start end)
     (let ((code-buf (current-buffer))
-	  (line-width (ceiling (log (count-lines (point-min) (point-max)) 10)))
-	  (ln 0))
+          (line-width (ceiling (log (count-lines (point-min) (point-max)) 10)))
+          (ln 0))
       (with-temp-buffer
-	(insert-buffer-substring code-buf)
-	(untabify (point-min) (point-max))
-	(goto-char (point-min))
-	(if (not no-line-numbers-p)
-	    (while (not (eobp))
-	      (beginning-of-line)
-	      (insert (format (format "%%.%dd " line-width) (cl-incf ln)))
-	      (forward-line)))
-	(rename-buffer (concat (buffer-name code-buf) ".html"))
-	(let ((buf (when (fboundp 'htmlize-buffer)
-		     (htmlize-buffer)))
-	      (bname (buffer-name)))
-	  (unwind-protect
-	      (with-current-buffer buf
-		(set-visited-file-name
-		 (dolist (dir jdee-htmlize-code-destinations)
-		   (setq dir (expand-file-name dir))
-		   (if (file-exists-p dir)
-		       (cl-return (expand-file-name bname dir)))))
-		(save-buffer)
-		(if (featurep 'browse-url)
-		    (browse-url (buffer-file-name))))
-	    (if (buffer-live-p buf)
-		(kill-buffer buf))))))))
+        (insert-buffer-substring code-buf)
+        (untabify (point-min) (point-max))
+        (goto-char (point-min))
+        (if (not no-line-numbers-p)
+            (while (not (eobp))
+              (beginning-of-line)
+              (insert (format (format "%%.%dd " line-width) (cl-incf ln)))
+              (forward-line)))
+        (rename-buffer (concat (buffer-name code-buf) ".html"))
+        (let ((buf (when (fboundp 'htmlize-buffer)
+                     (htmlize-buffer)))
+              (bname (buffer-name)))
+          (unwind-protect
+              (with-current-buffer buf
+                (set-visited-file-name
+                 (dolist (dir jdee-htmlize-code-destinations)
+                   (setq dir (expand-file-name dir))
+                   (if (file-exists-p dir)
+                       (cl-return (expand-file-name bname dir)))))
+                (save-buffer)
+                (if (featurep 'browse-url)
+                    (browse-url (buffer-file-name))))
+            (if (buffer-live-p buf)
+                (kill-buffer buf))))))))
 
 (defun jdee-create-default-prompt (prompt default)
   "Format a `PROMPT' with optional `DEFAULT' formatting."
   (format "%s%s"
-	  prompt (if default
-		     (format " (default %s): " default) ": ")))
+          prompt (if default
+                     (format " (default %s): " default) ": ")))
 
 (provide 'jdee-util)
 

--- a/jdee-widgets.el
+++ b/jdee-widgets.el
@@ -70,12 +70,12 @@
 (defun jdee-widget-tree-close-button-callback (widget &optional event)
   ;; Set parent state to closed.
   (let* ((parent (widget-get widget :parent))
-	(entries (widget-get parent :args))
-	(children (widget-get parent :children)))
+        (entries (widget-get parent :args))
+        (children (widget-get parent :children)))
     (while (and entries children)
       (widget-put (car entries) :value (widget-value (car children)))
       (setq entries (cdr entries)
-	    children (cdr children)))
+            children (cdr children)))
     (widget-value-set parent nil)))
 
 (define-widget 'jdee-widget-tree 'default
@@ -92,40 +92,40 @@
 (defun jdee-widget-tree-value-create-callback (widget)
   ;; Insert all values
   (let ((open (widget-value widget))
-	(tag (widget-get widget :tag))
-	(entries (widget-get widget :args))
-	children buttons)
+        (tag (widget-get widget :tag))
+        (entries (widget-get widget :args))
+        children buttons)
     (cond ((null entries)
-	   ;; Empty node.
-	   (insert (widget-get widget :prefix-empty) tag "\n"))
-	  (open
-	   ;; Open node.
-	   (push
-	    (widget-create-child-and-convert widget 'jdee-widget-tree-close-button)
-		buttons)
-	   (insert "-\\ " tag "\n")
-	   (let ((prefix (concat (widget-get widget :prefix)
-				(widget-get widget :prefix-extra)))
-		entry)
-	     (while entries
-	       (setq entry (car entries)
-		     entries (cdr entries))
-	       (insert prefix)
-	       (push (if entries
-			(widget-create-child-and-convert widget entry
-							  :prefix prefix
-							  :prefix-extra " | ")
-		       ;; Last entry uses a different prefix.
-		       (widget-create-child-and-convert
-			widget entry
-			:prefix prefix
-			:prefix-empty " `--- "))
-		     children))))
-	  (t
-	   ;; Closed node.
-	   (push (widget-create-child-and-convert widget 'jdee-widget-tree-open-button)
-		buttons)
-	   (insert "-- " tag "\n")))
+           ;; Empty node.
+           (insert (widget-get widget :prefix-empty) tag "\n"))
+          (open
+           ;; Open node.
+           (push
+            (widget-create-child-and-convert widget 'jdee-widget-tree-close-button)
+                buttons)
+           (insert "-\\ " tag "\n")
+           (let ((prefix (concat (widget-get widget :prefix)
+                                (widget-get widget :prefix-extra)))
+                entry)
+             (while entries
+               (setq entry (car entries)
+                     entries (cdr entries))
+               (insert prefix)
+               (push (if entries
+                        (widget-create-child-and-convert widget entry
+                                                          :prefix prefix
+                                                          :prefix-extra " | ")
+                       ;; Last entry uses a different prefix.
+                       (widget-create-child-and-convert
+                        widget entry
+                        :prefix prefix
+                        :prefix-empty " `--- "))
+                     children))))
+          (t
+           ;; Closed node.
+           (push (widget-create-child-and-convert widget 'jdee-widget-tree-open-button)
+                buttons)
+           (insert "-- " tag "\n")))
     (widget-put widget :children children)
     (widget-put widget :buttons buttons)))
 
@@ -146,33 +146,33 @@
   (widget-insert "Test tree widget. \n\n")
 
 ;   (setq tree (widget-create 'tree
-;			:tag "Foo"
-;			'(tree :tag "First")
-;			'(tree :tag "Second"
-;			       :value nil
-;			       (tree :tag "Nested"))
-;			'(tree :tag "Third")))
+;                        :tag "Foo"
+;                        '(tree :tag "First")
+;                        '(tree :tag "Second"
+;                               :value nil
+;                               (tree :tag "Nested"))
+;                        '(tree :tag "Third")))
 
   (setq tree (widget-create 'jdee-widget-tree
-		  :tag "<test.Foo:139>"
-		  '(jdee-widget-tree :tag "n  int  0")
-		  ;; '(jdee-widget-tree :tag '(jdee-widget-tree :tag "n  int  0"))
-		  '(jdee-widget-tree :tag "a  double 5.5")
-		  '(jdee-widget-tree :tag "s  S      <test.S:145>"
-			 (jdee-widget-tree :tag "b   boolean  true"))))
+                  :tag "<test.Foo:139>"
+                  '(jdee-widget-tree :tag "n  int  0")
+                  ;; '(jdee-widget-tree :tag '(jdee-widget-tree :tag "n  int  0"))
+                  '(jdee-widget-tree :tag "a  double 5.5")
+                  '(jdee-widget-tree :tag "s  S      <test.S:145>"
+                         (jdee-widget-tree :tag "b   boolean  true"))))
 
 ;   (let*  ((threads
-;	  (list
-;	   (list "ThreadGroup" 189 "system"
-;		 (list
-;		  (list "Thread" 190 "Signal dispatcher" "runnable" "suspended by debugger")
-;		  (list "Thread" 191 "Reference Handler" "waiting" "suspended by debugger")
-;		  (list "Thread" 192 "Finalizer" "waiting" "suspended by debugger")))
-;	   (list "ThreadGroup" 193 "main"
-;		 (list
-;		  (list "Thread" 1 "main" "runnable" "suspended at breakpoint"))
-;		 nil)))
-;	 (tree (jdee-dbs-map-threads-to-tree threads)))
+;          (list
+;           (list "ThreadGroup" 189 "system"
+;                 (list
+;                  (list "Thread" 190 "Signal dispatcher" "runnable" "suspended by debugger")
+;                  (list "Thread" 191 "Reference Handler" "waiting" "suspended by debugger")
+;                  (list "Thread" 192 "Finalizer" "waiting" "suspended by debugger")))
+;           (list "ThreadGroup" 193 "main"
+;                 (list
+;                  (list "Thread" 1 "main" "runnable" "suspended at breakpoint"))
+;                 nil)))
+;         (tree (jdee-dbs-map-threads-to-tree threads)))
 
 
 ;  (apply 'widget-create tree))
@@ -208,44 +208,44 @@ tree."
 
 (defun jdee-widget-dtree-create-callback (widget)
   (let ((open (widget-value widget))
-	(tag (widget-get widget :tag))
-	children buttons)
+        (tag (widget-get widget :tag))
+        children buttons)
     (cond
      (open
       (push (widget-create-child-and-convert widget 'jdee-widget-tree-close-button)
-		buttons)
+                buttons)
       (insert "-\\ " tag "\n")
       (let ((prefix (concat (widget-get widget :prefix)
-				(widget-get widget :prefix-extra)))
-	    (nodes (widget-get widget :nodes))
-	    node)
+                                (widget-get widget :prefix-extra)))
+            (nodes (widget-get widget :nodes))
+            node)
 
-	(when (and (widget-get widget :has-nodes)
-		   (not nodes))
-	  (setq nodes
-		(funcall (widget-get widget :node-fcn) widget))
-	  (if nodes
-	      (widget-put widget :nodes nodes)
-	    (widget-put widget :has-nodes nil)))
+        (when (and (widget-get widget :has-nodes)
+                   (not nodes))
+          (setq nodes
+                (funcall (widget-get widget :node-fcn) widget))
+          (if nodes
+              (widget-put widget :nodes nodes)
+            (widget-put widget :has-nodes nil)))
 
-	(while nodes
-	  (setq node (car nodes)
-		nodes (cdr nodes))
-	  (insert prefix)
-	  (push
-	   (if nodes
-	       (widget-create-child-and-convert widget node
-						:prefix prefix
-						:prefix-extra " | ")
-	     (widget-create-child-and-convert
-	      widget node
-	      :prefix prefix
-	      :prefix-empty " `--- "))
-	   children))))
+        (while nodes
+          (setq node (car nodes)
+                nodes (cdr nodes))
+          (insert prefix)
+          (push
+           (if nodes
+               (widget-create-child-and-convert widget node
+                                                :prefix prefix
+                                                :prefix-extra " | ")
+             (widget-create-child-and-convert
+              widget node
+              :prefix prefix
+              :prefix-empty " `--- "))
+           children))))
      (t
       ;; Closed node.
       (push (widget-create-child-and-convert widget 'jdee-widget-tree-open-button)
-	    buttons)
+            buttons)
       (insert "-- " tag "\n")))
     (widget-put widget :children children)
     (widget-put widget :buttons buttons)))
@@ -268,52 +268,52 @@ tree."
 
 (defun jdee-widget-java-var-to-tree (process var)
   (let* ((var-name (oref var name))
-	 (var-type (oref var jtype))
-	 (var-value (oref var value))
-	 (var-tag (format "%s %s" var-type var-name)))
+         (var-type (oref var jtype))
+         (var-value (oref var value))
+         (var-tag (format "%s %s" var-type var-name)))
     (cond
      ((typep var-value 'jdee-dbs-java-udci)
       (setq var-tag (format "%s [id: %d]" var-tag (oref var-value :id)))
       (if (string= (oref var-value :jtype) "java.lang.String")
-	  (let* ((cmd (jdee-dbs-get-string
-		       "get string"
-		       :process process
-		       :object-id (oref var-value id)))
-		 (str-val (jdee-dbs-cmd-exec cmd)))
-	    (list 'tree-widget
-		  :tag var-tag
-		  :node-name var-tag
-		  :open (jdee-dbo-locals-open-p var-tag)
-		  :value t
-		  (list 'tree-widget :tag str-val)))
-	(list 'jdee-widget-java-obj
-	      :tag var-tag
-	      :node-name var-tag
-	      :open (jdee-dbo-locals-open-p var-tag)
-	      :process process
-	      :object-id (oref var-value :id))))
+          (let* ((cmd (jdee-dbs-get-string
+                       "get string"
+                       :process process
+                       :object-id (oref var-value id)))
+                 (str-val (jdee-dbs-cmd-exec cmd)))
+            (list 'tree-widget
+                  :tag var-tag
+                  :node-name var-tag
+                  :open (jdee-dbo-locals-open-p var-tag)
+                  :value t
+                  (list 'tree-widget :tag str-val)))
+        (list 'jdee-widget-java-obj
+              :tag var-tag
+              :node-name var-tag
+              :open (jdee-dbo-locals-open-p var-tag)
+              :process process
+              :object-id (oref var-value :id))))
      ((typep var-value 'jdee-dbs-java-array)
       (setq var-tag (format "%s [id: %d]" var-tag (oref var-value :id)))
       (list 'jdee-widget-java-array
-	    :tag var-tag
-	    :node-name var-tag
-	    :open (jdee-dbo-locals-open-p var-tag)
-	    :process process :object var-value))
+            :tag var-tag
+            :node-name var-tag
+            :open (jdee-dbo-locals-open-p var-tag)
+            :process process :object var-value))
      ((typep var-value 'jdee-dbs-java-primitive)
       (list 'tree-widget
-	    :tag var-tag
-	    :node-name var-tag
-	    :open (jdee-dbo-locals-open-p var-tag)
-	    :value t
-	    (list 'tree-widget
-		  :tag (format "%s" (oref var-value value)))))
+            :tag var-tag
+            :node-name var-tag
+            :open (jdee-dbo-locals-open-p var-tag)
+            :value t
+            (list 'tree-widget
+                  :tag (format "%s" (oref var-value value)))))
      ((typep var-value 'jdee-dbs-java-null)
       (list 'tree-widget
-	    :tag var-tag
-	    :node-name var-tag
-	    :open (jdee-dbo-locals-open-p var-tag)
-	    :value t
-	    (list 'tree-widget :tag "null")))
+            :tag var-tag
+            :node-name var-tag
+            :open (jdee-dbo-locals-open-p var-tag)
+            :value t
+            (list 'tree-widget :tag "null")))
      (t
       (error "Unidentified type of local variable: %s" var-tag)))))
 
@@ -321,23 +321,23 @@ tree."
   (if (widget-get obj-widget :args)
       (widget-get obj-widget :args)
     (let* ((process (widget-get obj-widget :process))
-	   (object-id (widget-get obj-widget :object-id))
-	   (cmd
-	    (jdee-dbs-get-object
-	     (format "get_object %d" object-id)
-	     :process process
-	     :object-id object-id))
-	   (object
-	    (jdee-dbs-cmd-exec cmd))
-	   (fields (oref object fields))
-	   field
-	   nodes)
+           (object-id (widget-get obj-widget :object-id))
+           (cmd
+            (jdee-dbs-get-object
+             (format "get_object %d" object-id)
+             :process process
+             :object-id object-id))
+           (object
+            (jdee-dbs-cmd-exec cmd))
+           (fields (oref object fields))
+           field
+           nodes)
       (while fields
-	(setq field (car fields) fields (cdr fields))
-	(setq field (cdr field))
-	(push
-	 (jdee-widget-java-var-to-tree process field)
-	 nodes))
+        (setq field (car fields) fields (cdr fields))
+        (setq field (cdr field))
+        (push
+         (jdee-widget-java-var-to-tree process field)
+         nodes))
       nodes)))
 
 (define-widget 'jdee-widget-java-obj 'tree-widget
@@ -359,76 +359,76 @@ the object exists, and  ID is the debugger id for the object."
   (cond
      ((typep element 'jdee-dbs-java-udci)
       (if (string= (oref element :jtype) "java.lang.String")
-	  (let* ((cmd (jdee-dbs-get-string
-		       "get string"
-		       :process process
-		       :object-id (oref element id)))
-		 (str-val (jdee-dbs-cmd-exec cmd)))
-	    (list 'tree-widget
-		  :tag (format "[%d] %s" index str-val)
-		  :node-name (format "[%d] %s" index str-val)
-		  :open (jdee-dbo-locals-open-p (format "[%d] %s" index str-val))
-		  ))
-	(list 'jdee-widget-java-obj
-	      :tag (format "[%d] %s" index (oref element jtype))
-	      :node-name (format "[%d] %s" index (oref element jtype))
-	      :open (jdee-dbo-locals-open-p (format "[%d] %s" index (oref element jtype)))
-	      :process process
-	      :object-id (oref element id))))
+          (let* ((cmd (jdee-dbs-get-string
+                       "get string"
+                       :process process
+                       :object-id (oref element id)))
+                 (str-val (jdee-dbs-cmd-exec cmd)))
+            (list 'tree-widget
+                  :tag (format "[%d] %s" index str-val)
+                  :node-name (format "[%d] %s" index str-val)
+                  :open (jdee-dbo-locals-open-p (format "[%d] %s" index str-val))
+                  ))
+        (list 'jdee-widget-java-obj
+              :tag (format "[%d] %s" index (oref element jtype))
+              :node-name (format "[%d] %s" index (oref element jtype))
+              :open (jdee-dbo-locals-open-p (format "[%d] %s" index (oref element jtype)))
+              :process process
+              :object-id (oref element id))))
      ((typep element 'jdee-dbs-java-array)
       (list 'jdee-widget-java-array
-	    :tag (format "[%d] %s" index (oref element jtype))
-	    :node-name (format "[%d] %s" index (oref element jtype))
-	    :open (jdee-dbo-locals-open-p (format "[%d] %s" index (oref element jtype)))
-	    :process process
-	    :object element))
+            :tag (format "[%d] %s" index (oref element jtype))
+            :node-name (format "[%d] %s" index (oref element jtype))
+            :open (jdee-dbo-locals-open-p (format "[%d] %s" index (oref element jtype)))
+            :process process
+            :object element))
      ((typep element 'jdee-dbs-java-primitive)
       (list 'tree-widget :tag (format "[%d] %s"  index (oref element value))))
      ((typep element 'jdee-dbs-java-null)
       (list 'tree-widget :tag (format "[%d] null" index)))
      (t
       (error "Unidentified type of object: <%s|%s>" (oref element jtype)
-	     (oref element id)))))
+             (oref element id)))))
 
 (defun jdee-widget-java-array-get-elements (array-widget)
   (if (widget-get array-widget :args)
       (widget-get array-widget :args)
     (let* ((process (widget-get array-widget :process))
-	   (array (widget-get array-widget :object))
-	   cmd array-length)
+           (array (widget-get array-widget :object))
+           cmd array-length)
 
       (setq cmd
-	    (jdee-dbs-get-array
-	     (format "get_array_length %d" (oref array id))
-	     :process process
-	     :array array))
+            (jdee-dbs-get-array
+             (format "get_array_length %d" (oref array id))
+             :process process
+             :array array))
       (jdee-dbs-cmd-exec cmd)
 
       (setq array-length
-	    (if (slot-boundp array 'length)
-		(oref array length)
-	      0))
+            (if (slot-boundp array 'length)
+                (oref array length)
+              0))
 
       (when (> array-length 0)
-	(setq cmd
-	      (jdee-dbs-get-array
-	       (format "get_array_elements %d" (oref array id))
-	       :process process
-	       :array array
-	       :index 0
-	       :length array-length))
-	(jdee-dbs-cmd-exec cmd)
-	(let ((elements (oref array elements))
-	      element
-	      nodes
-	      (index 0))
-	  (while elements
-	    (setq element (car elements) elements (cdr elements))
-	    (setq nodes
-		  (append nodes
-			  (list (jdee-widget-java-array-element-to-tree process element index))))
-	    (setq index (1+ index)))
-	  nodes)))))
+        (setq cmd
+              (jdee-dbs-get-array
+               (format "get_array_elements %d" (oref array id))
+               :process process
+               :array array
+               :index 0
+               :length array-length))
+        (jdee-dbs-cmd-exec cmd)
+        (let ((elements (oref array elements))
+              element
+              nodes
+              (index 0))
+          (while elements
+            (setq element (car elements) elements (cdr elements))
+            (setq nodes
+                  (append nodes
+                          (list (jdee-widget-java-array-element-to-tree process element index))))
+            (setq index (1+ index)))
+          nodes)))))
 
 (define-widget 'jdee-widget-java-array 'tree-widget
   "A widget that represents a Java array. Clicking on the widget's
@@ -486,9 +486,9 @@ expand button causes the widget to display the values of the array."
 (defun jdee-widget-option-tree-close-button-callback (widget &optional event)
   ;; Set parent state to closed.
   (let* ((parent (widget-get widget :parent))
-	(entries (widget-get parent :args))
-	(group (car (widget-get parent :children)))
-	(children (widget-get group :children)))
+        (entries (widget-get parent :args))
+        (group (car (widget-get parent :children)))
+        (children (widget-get group :children)))
     ;; Get values entered by user from children and
     ;; insert them in the corresponding widget definitions
     ;; so that they appear the next time the user expands
@@ -496,32 +496,32 @@ expand button causes the widget to display the values of the array."
     (while (and entries children)
       (widget-put (car entries) :value (widget-value (car children)))
       (setq entries (cdr entries)
-	    children (cdr children)))
+            children (cdr children)))
     (widget-value-set parent nil)))
 
 (defun jdee-widget-option-tree-value-create-callback (widget)
   (let ((open-widget-p (widget-value widget))
-	(tag (widget-get widget :tag))
-	(entries (widget-get widget :args))
-	entry children buttons)
+        (tag (widget-get widget :tag))
+        (entries (widget-get widget :args))
+        entry children buttons)
     (cond (open-widget-p
-	   ;; Wrap widgets in this tree in a group widget
-	   ;; to ensure proper formatting.
-	   (let ((group-type
-		  (list 'group :args entries))
-		 group-widget)
-	   (push
-	    (widget-create-child-and-convert
-	     widget
-	     'jdee-widget-option-tree-close-button)
-		buttons)
-	   (insert "-\\ " tag "\n")
-	   (push (widget-create-child-and-convert widget group-type) children)))
-	  (t
-	   (push (widget-create 'jdee-widget-option-tree-open-button
-			  :parent widget)
-		 buttons)
-	   (insert "-- " tag "\n")))
+           ;; Wrap widgets in this tree in a group widget
+           ;; to ensure proper formatting.
+           (let ((group-type
+                  (list 'group :args entries))
+                 group-widget)
+           (push
+            (widget-create-child-and-convert
+             widget
+             'jdee-widget-option-tree-close-button)
+                buttons)
+           (insert "-\\ " tag "\n")
+           (push (widget-create-child-and-convert widget group-type) children)))
+          (t
+           (push (widget-create 'jdee-widget-option-tree-open-button
+                          :parent widget)
+                 buttons)
+           (insert "-- " tag "\n")))
     (widget-put widget :children children)
     (widget-put widget :buttons buttons)))
 
@@ -548,31 +548,31 @@ expand button causes the widget to display the values of the array."
   (widget-insert "Test panel widget. \n\n")
 
   (let ((panel (widget-create
-		'jdee-widget-option-tree
-		:tag "Compile Options"
-		'(cons :tag "Debugger Options"
-		   (radio-button-choice :format "%t \n%v"
-					:tag "Debugger "
-					(const "jdb")
-					(const "oldjdb")
-					(const "Other"))
-		   (cons :tag "Other Debugger Info"
-			 (string :tag "Path")
-			 (radio-button-choice :format "%t \n%v"
-					      :tag "Type "
-					      (const "Executable")
-					      (const "Class"))))
-		  '(repeat (string :tag "Path"))
-		  '(editable-field :tag "classpath"
-				  :format "  %t:  %v\n  %h \n\n"
-				  :size 40
-				  :doc "Name of project.")
-		  '(editable-field :tag "compiler"
-				  :format "  %t:  %v\n  %h \n\n"
-				  :size 40
-				  :doc "Name of project.")
-		  '(jdee-widget-option-tree :tag "Debugger Options"
-					   (repeat (string :tag "Path"))))))
+                'jdee-widget-option-tree
+                :tag "Compile Options"
+                '(cons :tag "Debugger Options"
+                   (radio-button-choice :format "%t \n%v"
+                                        :tag "Debugger "
+                                        (const "jdb")
+                                        (const "oldjdb")
+                                        (const "Other"))
+                   (cons :tag "Other Debugger Info"
+                         (string :tag "Path")
+                         (radio-button-choice :format "%t \n%v"
+                                              :tag "Type "
+                                              (const "Executable")
+                                              (const "Class"))))
+                  '(repeat (string :tag "Path"))
+                  '(editable-field :tag "classpath"
+                                  :format "  %t:  %v\n  %h \n\n"
+                                  :size 40
+                                  :doc "Name of project.")
+                  '(editable-field :tag "compiler"
+                                  :format "  %t:  %v\n  %h \n\n"
+                                  :size 40
+                                  :doc "Name of project.")
+                  '(jdee-widget-option-tree :tag "Debugger Options"
+                                           (repeat (string :tag "Path"))))))
     (use-local-map widget-keymap)
     (widget-setup)))
 

--- a/jdee-wiz.el
+++ b/jdee-wiz.el
@@ -53,10 +53,10 @@
     (save-excursion
       (goto-char (point-max))
       (when (re-search-backward package-re (point-min) t)
-	(looking-at package-re)
-	(buffer-substring-no-properties
-	 (match-beginning 1)
-	 (match-end 1))))))
+        (looking-at package-re)
+        (buffer-substring-no-properties
+         (match-beginning 1)
+         (match-end 1))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -73,36 +73,36 @@ extends clause is updated"
   (interactive
    "sEnter interface: ")
   (let (keyword
-	(interface
-	 (jdee-wiz-get-unqualified-name interface-name)))
+        (interface
+         (jdee-wiz-get-unqualified-name interface-name)))
     (if extends
-	(setq keyword "extends")
+        (setq keyword "extends")
       (setq keyword "implements"))
     (save-excursion
       (let* ((class-re "class[ \t]+\\([a-zA-z]+[a-zA-Z0-9._]*\\).*[ \n]*")
-	     (open-brace-pos
-	      (ignore-errors (scan-lists (point) -1 1)))
-	     (class-name-end-pos
-	      (when open-brace-pos
-		(goto-char open-brace-pos)
-		(when (re-search-backward class-re (point-min) t)
-		  (looking-at class-re)
-		  (match-end 1))))
-	     (implements-keyword-end-pos
-	      (when (and open-brace-pos class-name-end-pos)
-		(goto-char open-brace-pos)
-		(if (re-search-backward keyword class-name-end-pos t)
-		    (match-end 0)))))
-	(if implements-keyword-end-pos
-	    (progn
-	      (goto-char implements-keyword-end-pos)
-	      (insert (concat " " interface ",")))
-	  (when class-name-end-pos
-	    (goto-char (- open-brace-pos 1))
-	    (if (looking-at " {")
-		(delete-char 1)  ;; if we don't delete, we end up with 2 spaces
-	      (forward-char))
-	    (insert (concat " " keyword " " interface " "))))))))
+             (open-brace-pos
+              (ignore-errors (scan-lists (point) -1 1)))
+             (class-name-end-pos
+              (when open-brace-pos
+                (goto-char open-brace-pos)
+                (when (re-search-backward class-re (point-min) t)
+                  (looking-at class-re)
+                  (match-end 1))))
+             (implements-keyword-end-pos
+              (when (and open-brace-pos class-name-end-pos)
+                (goto-char open-brace-pos)
+                (if (re-search-backward keyword class-name-end-pos t)
+                    (match-end 0)))))
+        (if implements-keyword-end-pos
+            (progn
+              (goto-char implements-keyword-end-pos)
+              (insert (concat " " interface ",")))
+          (when class-name-end-pos
+            (goto-char (- open-brace-pos 1))
+            (if (looking-at " {")
+                (delete-char 1)  ;; if we don't delete, we end up with 2 spaces
+              (forward-char))
+            (insert (concat " " keyword " " interface " "))))))))
 
 (defun jdee-dollar-name (name)
   "Convert pkg[.Outer].Inner[$Inner] to pkg[.Outer]$Inner[$Inner]"
@@ -115,10 +115,10 @@ extends clause is updated"
           (jdee-backend-make-interface-expr interface-name)))
     (if code
         (let ((required-imports (jdee-backend-get-interface-imports)))
-	  (eval code)			;error may be thrown if bad intf name
-	  (if required-imports
-	      (jdee-import-insert-imports-into-buffer required-imports t))
-	  (jdee-wiz-update-implements-clause interface-name)))))
+          (eval code)                        ;error may be thrown if bad intf name
+          (if required-imports
+              (jdee-import-insert-imports-into-buffer required-imports t))
+          (jdee-wiz-update-implements-clause interface-name)))))
 
 (defun jdee-wiz-gen-implementation-methods (gen-list)
   "Executes the given list of generation statements. Generation statements
@@ -127,12 +127,12 @@ subsequent method(s) or invocations of `jdee-wiz-gen-method'."
   (let ((items gen-list))
     (while (car items)
       (let ((to-end (- (point-max) (point))))
-	(if (stringp (car items))
-	    (progn
-	      (tempo-save-named 'comment-line (car items))
-	      (jdee-gen-section-comment))
-	  (eval (car items)))
-	(goto-char (- (point-max) to-end)))
+        (if (stringp (car items))
+            (progn
+              (tempo-save-named 'comment-line (car items))
+              (jdee-gen-section-comment))
+          (eval (car items)))
+        (goto-char (- (point-max) to-end)))
       (setq items (cdr items)))))
 
 (defun jdee-wiz-implement-interface-internal (interface-name)
@@ -143,15 +143,15 @@ set, otherwise the CLASSPATH environment variable."
    "sInterface name: ")
   (let ((names (jdee-backend-get-qualified-name interface-name)))
     (if names
-	(if (> (length names) 1)
-	    (jdee-wiz-generate-interface
-	     (efc-query-options
-	      names
-	      "Select interface to implement."
-	      "Class Name dialog"))
-	  (jdee-wiz-generate-interface (car names)))
+        (if (> (length names) 1)
+            (jdee-wiz-generate-interface
+             (efc-query-options
+              names
+              "Select interface to implement."
+              "Class Name dialog"))
+          (jdee-wiz-generate-interface (car names)))
       (error "Cannot find interface %s on the current classpath."
-	     interface-name))))
+             interface-name))))
 
 (defun jdee-wiz-implement-interface (interface-name)
   "*Generate a skeleton implementation of a specified interface.
@@ -171,8 +171,8 @@ more information."
    "sInterface name: ")
   (condition-case err
       (let ((pos (point)))
-	(jdee-wiz-implement-interface-internal interface-name)
-	(jdee-wiz-indent pos))
+        (jdee-wiz-implement-interface-internal interface-name)
+        (jdee-wiz-indent pos))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -187,19 +187,19 @@ and fire every method of all listeners registered. It creates a data structure
 to store the listeners too."
   (condition-case err
       (let* ((pos (point))
-	     (code (jdee-backend-make-event-source-expr
+             (code (jdee-backend-make-event-source-expr
                     event-listener-interface-name)))
-	(if code
-	    (let ((required-imports
+        (if code
+            (let ((required-imports
                    (jdee-backend-get-event-source-imports)))
-	      (message "%s" "evaluating")
-	      (eval code)
-	      (message "%s" "eval done")
-	      (jdee-wiz-indent pos)
-	      (if required-imports
-		  (jdee-import-insert-imports-into-buffer required-imports t)
-		(message "%s" "no imports"))
-	      )))
+              (message "%s" "evaluating")
+              (eval code)
+              (message "%s" "eval done")
+              (jdee-wiz-indent pos)
+              (if required-imports
+                  (jdee-import-insert-imports-into-buffer required-imports t)
+                (message "%s" "no imports"))
+              )))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -211,12 +211,12 @@ subsequent method(s) or invocations of `jdee-wiz-gen-listener-registry',
   (let ((items gen-list))
     (while (car items)
       (let ((to-end (- (point-max) (point))))
-	(if (stringp (car items))
-	    (progn
-	      (tempo-save-named 'comment-line (car items))
-	      (jdee-gen-section-comment))
-	  (eval (car items)))
-	(goto-char (- (point-max) to-end)))
+        (if (stringp (car items))
+            (progn
+              (tempo-save-named 'comment-line (car items))
+              (jdee-gen-section-comment))
+          (eval (car items)))
+        (goto-char (- (point-max) to-end)))
       (setq items (cdr items))
       ))
   )
@@ -251,14 +251,14 @@ set, otherwise the CLASSPATH environment variable."
    "sListener Interface name: ")
   (condition-case err
       (let ((names (jdee-backend-get-qualified-name interface-name)))
-	(if names
-	    (if (> (length names) 1)
-		(jdee-wiz-generate-event-source
-		 (efc-query-options names
-				    "Select interface to implement."
-				    "class name dialog"))
-	      (jdee-wiz-generate-event-source (car names)))
-	  (error "Cannot find listener interface %s on the current classpath." interface-name)))
+        (if names
+            (if (> (length names) 1)
+                (jdee-wiz-generate-event-source
+                 (efc-query-options names
+                                    "Select interface to implement."
+                                    "class name dialog"))
+              (jdee-wiz-generate-event-source (car names)))
+          (error "Cannot find listener interface %s on the current classpath." interface-name)))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -308,63 +308,63 @@ NOTE: this command works only if the overriding class
 
   (condition-case err
       (let* ((super-class (jdee-parse-get-super-class-at-point))
-	     (qualified-super-class
-	      (jdee-parse-get-qualified-name super-class t))
-	     (classinfo
-	      (jdee-complete-get-classinfo qualified-super-class jdee-complete-protected))
-	     pair pos class-name qualified-class-name method-name)
-	(setq pair
-	      (assoc
-	       (completing-read "Method to overwrite: " classinfo nil t)
-	       classinfo))
+             (qualified-super-class
+              (jdee-parse-get-qualified-name super-class t))
+             (classinfo
+              (jdee-complete-get-classinfo qualified-super-class jdee-complete-protected))
+             pair pos class-name qualified-class-name method-name)
+        (setq pair
+              (assoc
+               (completing-read "Method to overwrite: " classinfo nil t)
+               classinfo))
 
-	(if (not pair)
-	    (error "No method specified for completion."))
+        (if (not pair)
+            (error "No method specified for completion."))
 
-	(setq pos (string-match " : " (car pair)))
-	(setq method-name
-	      (if pos
-		  (substring (car pair) 0 pos)
-		(cdr pair)))
+        (setq pos (string-match " : " (car pair)))
+        (setq method-name
+              (if pos
+                  (substring (car pair) 0 pos)
+                (cdr pair)))
 
-	(setq class-name
+        (setq class-name
               (jdee-parse-get-super-class-at-point))
-	(setq qualified-class-name
+        (setq qualified-class-name
               (jdee-parse-get-qualified-name class-name t))
-	(setq pos (string-match "(" method-name))
+        (setq pos (string-match "(" method-name))
 
-	(if qualified-super-class
-	    (let ((signatures (jdee-backend-get-candidate-signatures
+        (if qualified-super-class
+            (let ((signatures (jdee-backend-get-candidate-signatures
                                qualified-class-name
                                (substring method-name 0 pos))))
-	      (jdee-wiz-override-method-internal method-name
+              (jdee-wiz-override-method-internal method-name
                                                  signatures))
-	  (error "Cannot find parent class %s" super-class)))
+          (error "Cannot find parent class %s" super-class)))
     (error
      (message "%s" (error-message-string err)))))
 
 
 (defun jdee-wiz-override-method-internal (selected-method methods)
   (let* ((selected-method-args (jdee-wiz-number-of-arguments selected-method))
-	 (pos (point))
-	 (variant 0) skeleton required-imports
-	 (index 0))
+         (pos (point))
+         (variant 0) skeleton required-imports
+         (index 0))
     (while methods
       (if (jdee-wiz-check-signatures selected-method (car methods))
-	  (progn
-	    (setq variant index)
-	    (setq methods nil))
-	(progn
-	  (setq index (+ 1 index))
-	  (setq methods (cdr methods)))))
+          (progn
+            (setq variant index)
+            (setq methods nil))
+        (progn
+          (setq index (+ 1 index))
+          (setq methods (cdr methods)))))
 
     (jdee-backend-make-method-skeleton-expr (int-to-string variant))
     (setq required-imports (jdee-backend-get-method-override-imports))
     (if required-imports
-	(jdee-import-insert-imports-into-buffer required-imports t))))
+        (jdee-import-insert-imports-into-buffer required-imports t))))
 
 (defun jdee-wiz-gen-method (modifiers return-type name parameters exceptions
-				     default-body)
+                                     default-body)
   "Generates a method by setting the tempo named tags and
 invoking `jdee-gen-method'. This method is usually
 called by an expression generated in the beanshell."
@@ -384,12 +384,12 @@ subsequent method(s) or invocations of `jdee-wiz-gen-method'."
   (let ((items gen-list))
     (while (car items)
       (let ((to-end (- (point-max) (point))))
-	(if (stringp (car items))
-	    (progn
-	      (tempo-save-named 'comment-line (car items))
-	      (jdee-gen-section-comment))
-	  (eval (car items)))
-	(goto-char (- (point-max) to-end)))
+        (if (stringp (car items))
+            (progn
+              (tempo-save-named 'comment-line (car items))
+              (jdee-gen-section-comment))
+          (eval (car items)))
+        (goto-char (- (point-max) to-end)))
       (setq items (cdr items))
       ))
   )
@@ -408,16 +408,16 @@ subsequent method(s) or invocations of `jdee-wiz-gen-method'."
   "Returns the number of arguments in this signature"
   (let (pos (number-of-arguments 0))
     (if (string-match "()" signature)
-	number-of-arguments
+        number-of-arguments
       (if (not (string-match "," signature))
-	  (setq number-of-arguments (+ 1 number-of-arguments))
-	(progn
-	  (setq number-of-arguments 1)
-	  (while (string-match "," signature)
-	    (setq pos (string-match "," signature))
-	    (setq number-of-arguments (+ 1 number-of-arguments))
-	    (setq signature (substring signature (+ pos 1)))))))
-	  number-of-arguments))
+          (setq number-of-arguments (+ 1 number-of-arguments))
+        (progn
+          (setq number-of-arguments 1)
+          (while (string-match "," signature)
+            (setq pos (string-match "," signature))
+            (setq number-of-arguments (+ 1 number-of-arguments))
+            (setq signature (substring signature (+ pos 1)))))))
+          number-of-arguments))
 
 (defun jdee-wiz-indent (pos)
   "Indents the just inserted region without moving
@@ -435,8 +435,8 @@ the cursor"
   (let* ((class
           (or class-name
               (read-from-minibuffer "Class: " (thing-at-point 'symbol))))
-	 (fq-class-name
-	  (jdee-parse-select-qualified-class-name class)))
+         (fq-class-name
+          (jdee-parse-select-qualified-class-name class)))
     (if fq-class-name
         (jdee-backend-browse-class fq-class-name))))
 
@@ -464,24 +464,24 @@ function's documentation for more information."
    "sDelegee name: ")
   (condition-case err
       (let* ((pos (point))
-	     (start nil)
-	     (class-name
-	      (or (jdee-parse-get-qualified-name
-		   (car (jdee-parse-declared-type-of delegee)) t)
-		  (read-string (concat "Enter fully qualified class name of "
-				       delegee ": "))))
-	     (code (jdee-backend-make-delegator-methods delegee class-name)))
-	(if code
-	    (let ((required-imports (jdee-backend-get-delegate-imports)))
-	      (font-lock-mode -1)
-	      (setq start (point))
-	      (eval code)
-	      ;;indenting the new code
-	      (jdee-wiz-indent pos)
-	      (if required-imports
-		  (jdee-import-insert-imports-into-buffer required-imports t))
-	      (font-lock-mode)
-	      )))
+             (start nil)
+             (class-name
+              (or (jdee-parse-get-qualified-name
+                   (car (jdee-parse-declared-type-of delegee)) t)
+                  (read-string (concat "Enter fully qualified class name of "
+                                       delegee ": "))))
+             (code (jdee-backend-make-delegator-methods delegee class-name)))
+        (if code
+            (let ((required-imports (jdee-backend-get-delegate-imports)))
+              (font-lock-mode -1)
+              (setq start (point))
+              (eval code)
+              ;;indenting the new code
+              (jdee-wiz-indent pos)
+              (if required-imports
+                  (jdee-import-insert-imports-into-buffer required-imports t))
+              (font-lock-mode)
+              )))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -493,13 +493,13 @@ function's documentation for more information."
   "*Generate a skeleton implementation of a specified abstract class."
   (condition-case err
       (let* ((code (jdee-backend-maket-abstract-class-expr class-name)))
-	(if code
-	    (let ((required-imports
+        (if code
+            (let ((required-imports
                    (jdee-backend-get-abstract-class-imports)))
-	      (eval code)
-	      (if required-imports
-		  (jdee-import-insert-imports-into-buffer required-imports t))
-	      (jdee-wiz-update-implements-clause class-name t))))
+              (eval code)
+              (if required-imports
+                  (jdee-import-insert-imports-into-buffer required-imports t))
+              (jdee-wiz-update-implements-clause class-name t))))
     (message "%s" (error-message-string err))))
 
 (defun jdee-wiz-extend-abstract-class-internal (class-name)
@@ -510,14 +510,14 @@ set, otherwise the CLASSPATH environment variable."
    "sAbstract classname: ")
   (condition-case err
       (let ((names (jdee-backend-get-qualified-name class-name)))
-	(if names
-	    (if (> (length names) 1)
-		(jdee-wiz-generate-abstract-class
-		 (efc-query-options names nil
-				    "class name dialog"))
-	      (jdee-wiz-generate-abstract-class (car names)))
-	  (message "Cannot find abstract class %s on the current classpath."
-		   class-name)))
+        (if names
+            (if (> (length names) 1)
+                (jdee-wiz-generate-abstract-class
+                 (efc-query-options names nil
+                                    "class name dialog"))
+              (jdee-wiz-generate-abstract-class (car names)))
+          (message "Cannot find abstract class %s on the current classpath."
+                   class-name)))
     (message "%s" (error-message-string err))))
 
 (defun jdee-wiz-extend-abstract-class (class-name)
@@ -559,10 +559,10 @@ public String get(String argName)"
 
 (defcustom jdee-wiz-get-javadoc-template
   (list "/**"
-	"* Gets the value of %n"
-	"*"
-	"* @return the value of %n"
-	"*/")
+        "* Gets the value of %n"
+        "*"
+        "* @return the value of %n"
+        "*/")
   "Template used by `jdee-wiz-get-set-method' to add the javadoc
 to a get method. The %n are replaced by the variable name and
 %t by the variable."
@@ -571,10 +571,10 @@ to a get method. The %n are replaced by the variable name and
 
 (defcustom jdee-wiz-set-javadoc-template
   (list "/**"
-	"* Sets the value of %n"
-	"*"
-	"* @param %p Value to assign to this.%n"
-	"*/")
+        "* Sets the value of %n"
+        "*"
+        "* @param %p Value to assign to this.%n"
+        "*/")
   "Template used by `jdee-wiz-get-set-method' to add the javadoc to a
 set method. The %n are replaced by the variable name, %t by the variable
 type and %p for the argument name. In most cases %n and %p are the same
@@ -606,10 +606,10 @@ It will take everything after the first capitalize letter. A nil value will use
 the variable name as it is defined in the buffer."
   :group 'jdee-wiz
   :type '(cons (string :tag "Enter either the prefix or postfix")
-	       (radio-button-choice (const "Prefix")
-				    (const "Postfix")
-				    (const "Everything after the first upcase letter")
-				    (const nil))))
+               (radio-button-choice (const "Prefix")
+                                    (const "Postfix")
+                                    (const "Everything after the first upcase letter")
+                                    (const nil))))
 
 (defcustom jdee-wiz-get-set-methods-include (list "Both")
   "Use this variable to set what methods `jdee-wiz-get-set-methods' will
@@ -617,8 +617,8 @@ insert in the buffer. The options are get methods only, set methods only,
  and both."
   :group 'jdee-wiz
   :type '(list (radio-button-choice (const "Get only")
-				    (const "Set only")
-				    (const "Both"))))
+                                    (const "Set only")
+                                    (const "Both"))))
 
 (defcustom jdee-wiz-get-set-static-members t
   "If on (nonnil), `jdee-wiz-get-set-methods' generates getter/setter methods for
@@ -632,10 +632,10 @@ get and set methods are going to be inserted by
 `jdee-wiz-get-set-methods'"
   :group 'jdee-wiz
   :type '(list (radio-button-choice
-		(const "Get followed by set for each field")
-		(const "Set followed by get for each field")
-		(const "All get methods followed by all set methods")
-		(const "All set methods followed by all get methods"))))
+                (const "Get followed by set for each field")
+                (const "Set followed by get for each field")
+                (const "All get methods followed by all set methods")
+                (const "All set methods followed by all get methods"))))
 
 (defun jdee-wiz-downcase-initials (obj)
   "It downcase the first letter of obj"
@@ -645,15 +645,15 @@ get and set methods are going to be inserted by
   "Recurse through all the tokens in `tokens' looking for
 the tokens of `class-name', returns nil if no token are found"
   (let ((parts (jdee-wiz-get-class-parts-helper class-name tokens))
-	temp-parts inner-classes)
+        temp-parts inner-classes)
     (if (not parts)
-	(while tokens
-	  (setq temp-parts (semantic-tag-type-members (car tokens)))
-	  (setq inner-classes (semantic-brute-find-tag-by-class 'type temp-parts))
-	  (setq parts (jdee-wiz-get-class-parts class-name inner-classes))
-	  (if parts
-	      (setq tokens nil)
-	    (setq tokens (cdr tokens)))))
+        (while tokens
+          (setq temp-parts (semantic-tag-type-members (car tokens)))
+          (setq inner-classes (semantic-brute-find-tag-by-class 'type temp-parts))
+          (setq parts (jdee-wiz-get-class-parts class-name inner-classes))
+          (if parts
+              (setq tokens nil)
+            (setq tokens (cdr tokens)))))
     parts))
 
 (defun jdee-wiz-get-class-parts-helper (class-name tokens)
@@ -664,9 +664,9 @@ return otherwise"
     (while tokens
       (setq current-class (car tokens))
       (if (string= class-name (semantic-tag-name current-class))
-	  (progn
-	    (setq parts (semantic-tag-type-members current-class))
-	    (setq tokens nil)))
+          (progn
+            (setq parts (semantic-tag-type-members current-class))
+            (setq tokens nil)))
       (setq tokens (cdr tokens)))
     parts))
 
@@ -676,12 +676,12 @@ current buffer. Functions are semantic tokens for the functions
 defined in the current buffer."
   (or (member
        (concat
-	"get"
-	(upcase-initials (jdee-wiz-get-name name))) functions)
+        "get"
+        (upcase-initials (jdee-wiz-get-name name))) functions)
       (member
        (concat
-	"is"
-	(upcase-initials (jdee-wiz-get-name name))) functions)))
+        "is"
+        (upcase-initials (jdee-wiz-get-name name))) functions)))
 
 (defun jdee-wiz-set-member-p (name functions)
   "Returns t if the variable name has a set method defined in the current buffer.
@@ -693,28 +693,28 @@ Functions are semantic tokens for the functions defined in the current buffer."
 defined in the current buffer."
   (interactive)
   (let* ((include (car jdee-wiz-get-set-methods-include))
-	 ;;Indicates if both get and set should be inserted
-	 (bothp (string= "Both" include))
-	 ;;only get methods should be inserted
-	 (get-onlyp (string= "Get only" include))
-	 ;;only set methods should be inserted
-	 (set-onlyp (string= "Set only" include))
-	 (order (car jdee-wiz-get-set-methods-order))
-	 (get-firstp
-	  (or (string= "All get methods followed by all set methods" order)
-	      (string= "Get followed by set for each field" order)))
-	 (class (jdee-parse-get-class-at-point));;class name
-	 (classes (split-string class "\\."))
-	 (class-name (nth (- (length classes) 1) classes))
-	 (tokens (semantic-fetch-tags));;buffer tokens
-	 (type (semantic-brute-find-tag-by-class 'type tokens));;class tokens
-	 (parts (jdee-wiz-get-class-parts class-name type))
-	 (variables (semantic-brute-find-tag-by-class 'variable parts));;declared variables
-	 ;;non public variables
-	 (non-public-variables (jdee-wiz-filter-variables-by-typemodifier variables))
-	 (functions (semantic-brute-find-tag-by-class 'function parts));;functions
-	 (set-get-functions (jdee-wiz-get-get-set-methods functions));;get,set,is functions
-	 var name staticp finalp report temp pos)
+         ;;Indicates if both get and set should be inserted
+         (bothp (string= "Both" include))
+         ;;only get methods should be inserted
+         (get-onlyp (string= "Get only" include))
+         ;;only set methods should be inserted
+         (set-onlyp (string= "Set only" include))
+         (order (car jdee-wiz-get-set-methods-order))
+         (get-firstp
+          (or (string= "All get methods followed by all set methods" order)
+              (string= "Get followed by set for each field" order)))
+         (class (jdee-parse-get-class-at-point));;class name
+         (classes (split-string class "\\."))
+         (class-name (nth (- (length classes) 1) classes))
+         (tokens (semantic-fetch-tags));;buffer tokens
+         (type (semantic-brute-find-tag-by-class 'type tokens));;class tokens
+         (parts (jdee-wiz-get-class-parts class-name type))
+         (variables (semantic-brute-find-tag-by-class 'variable parts));;declared variables
+         ;;non public variables
+         (non-public-variables (jdee-wiz-filter-variables-by-typemodifier variables))
+         (functions (semantic-brute-find-tag-by-class 'function parts));;functions
+         (set-get-functions (jdee-wiz-get-get-set-methods functions));;get,set,is functions
+         var name staticp finalp report temp pos)
 
     (setq
      report
@@ -739,129 +739,129 @@ defined in the current buffer."
       (setq
        report
        (concat
-	report
-	(format
-	 "%-60.60s"
-	 (concat
-	  type " " name " "
-	  (and (semantic-tag-modifiers var)
-	       ;; only if some modifiers are present
-	       ;; print them
-	       (format "%s" (semantic-tag-modifiers var)))))))
+        report
+        (format
+         "%-60.60s"
+         (concat
+          type " " name " "
+          (and (semantic-tag-modifiers var)
+               ;; only if some modifiers are present
+               ;; print them
+               (format "%s" (semantic-tag-modifiers var)))))))
 
       (setq report (concat report "\t"))
 
       ;;order in which the methods should be inserted
       (cond ((string= "Get followed by set for each field" order)
-	     ;;get method followed by its set method
-	     ;;getting the get method if it does not exist in the buffer
-	     (if (not (jdee-wiz-get-member-p name set-get-functions))
-		 (if (and (or bothp get-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-get-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (setq report (concat report "[Exists ]")))
+             ;;get method followed by its set method
+             ;;getting the get method if it does not exist in the buffer
+             (if (not (jdee-wiz-get-member-p name set-get-functions))
+                 (if (and (or bothp get-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-get-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (setq report (concat report "[Exists ]")))
 
-	     (setq report (concat report "\t"))
+             (setq report (concat report "\t"))
 
-	     ;;getting the set method if it does not exist in the buffer
-	     (if (and (not finalp);; it is final - can not have a setter
-		      (not (jdee-wiz-set-member-p name set-get-functions)))
-		 (if (and (or bothp set-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-set-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (if (jdee-wiz-set-member-p name set-get-functions)
-		   (setq report (concat report "[Exists ]"))
-		 (if finalp
-		     (setq report (concat report "[N/A    ]"))))))
-	    ;;set method followed by its get method
-	    ((string= "Set followed by get for each field" order)
-	     ;;getting the set method if it does not exist in the buffer
-	     (if (and (not finalp);; it is final - can not have a setter
-		      (not (jdee-wiz-set-member-p name set-get-functions)))
-		 (if (and (or bothp set-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-set-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (if (jdee-wiz-set-member-p name set-get-functions)
-		   (setq report (concat report "[Exists ]"))
-		 (if finalp
-		     (setq report (concat report "[N/A    ]")))))
+             ;;getting the set method if it does not exist in the buffer
+             (if (and (not finalp);; it is final - can not have a setter
+                      (not (jdee-wiz-set-member-p name set-get-functions)))
+                 (if (and (or bothp set-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-set-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (if (jdee-wiz-set-member-p name set-get-functions)
+                   (setq report (concat report "[Exists ]"))
+                 (if finalp
+                     (setq report (concat report "[N/A    ]"))))))
+            ;;set method followed by its get method
+            ((string= "Set followed by get for each field" order)
+             ;;getting the set method if it does not exist in the buffer
+             (if (and (not finalp);; it is final - can not have a setter
+                      (not (jdee-wiz-set-member-p name set-get-functions)))
+                 (if (and (or bothp set-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-set-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (if (jdee-wiz-set-member-p name set-get-functions)
+                   (setq report (concat report "[Exists ]"))
+                 (if finalp
+                     (setq report (concat report "[N/A    ]")))))
 
-	     (setq report (concat report "\t"))
+             (setq report (concat report "\t"))
 
-	     ;;getting the get method if it does not exist in the buffer
-	     (if (not (jdee-wiz-get-member-p name set-get-functions))
-		 (if (and (or bothp get-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-get-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (setq report (concat report "[Exists ]"))))
+             ;;getting the get method if it does not exist in the buffer
+             (if (not (jdee-wiz-get-member-p name set-get-functions))
+                 (if (and (or bothp get-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-get-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (setq report (concat report "[Exists ]"))))
 
-	    ;;all the get method first
-	    ((string= "All get methods followed by all set methods" order)
-	     ;;getting the get method if it does not exist in the buffer
-	     (if (not (jdee-wiz-get-member-p name set-get-functions))
-		 (if (and (or bothp get-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-get-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (setq report (concat report "[Exists ]")))
+            ;;all the get method first
+            ((string= "All get methods followed by all set methods" order)
+             ;;getting the get method if it does not exist in the buffer
+             (if (not (jdee-wiz-get-member-p name set-get-functions))
+                 (if (and (or bothp get-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-get-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (setq report (concat report "[Exists ]")))
 
-	     (setq report (concat report "\t"))
+             (setq report (concat report "\t"))
 
-	     ;;getting the set method if it does not exist in the buffer
-	     (if (and (not finalp);; it is final - can not have a setter
-		      (not (jdee-wiz-set-member-p name set-get-functions)))
-		 (if (and (or bothp set-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (setq temp (concat temp (jdee-wiz-get-set-method type name staticp class)))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (if (jdee-wiz-set-member-p name set-get-functions)
-		   (setq report (concat report "[Exists ]"))
-		 (if finalp
-		     (setq report (concat report "[N/A    ]"))))))
+             ;;getting the set method if it does not exist in the buffer
+             (if (and (not finalp);; it is final - can not have a setter
+                      (not (jdee-wiz-set-member-p name set-get-functions)))
+                 (if (and (or bothp set-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (setq temp (concat temp (jdee-wiz-get-set-method type name staticp class)))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (if (jdee-wiz-set-member-p name set-get-functions)
+                   (setq report (concat report "[Exists ]"))
+                 (if finalp
+                     (setq report (concat report "[N/A    ]"))))))
 
-	    ;;all the set method first
-	    ((string= "All set methods followed by all get methods" order)
-	     ;;getting the set method if it does not exist in the buffer
-	     (if (and (not finalp);; it is final - can not have a setter
-		      (not (jdee-wiz-set-member-p name set-get-functions)))
-		 (if (and (or bothp set-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (insert (jdee-wiz-get-set-method type name staticp class))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (if (jdee-wiz-set-member-p name set-get-functions)
-		   (setq report (concat report "[Exists ]"))
-		 (if finalp
-		     (setq report (concat report "[N/A    ]")))))
+            ;;all the set method first
+            ((string= "All set methods followed by all get methods" order)
+             ;;getting the set method if it does not exist in the buffer
+             (if (and (not finalp);; it is final - can not have a setter
+                      (not (jdee-wiz-set-member-p name set-get-functions)))
+                 (if (and (or bothp set-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (insert (jdee-wiz-get-set-method type name staticp class))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (if (jdee-wiz-set-member-p name set-get-functions)
+                   (setq report (concat report "[Exists ]"))
+                 (if finalp
+                     (setq report (concat report "[N/A    ]")))))
 
-	     (setq report (concat report "\t"))
+             (setq report (concat report "\t"))
 
-	     ;;getting the get method if it does not exist in the buffer
-	     (if (not (jdee-wiz-get-member-p name set-get-functions))
-		 (if (and (or bothp get-onlyp)
-			  (or (not staticp) jdee-wiz-get-set-static-members))
-		     (progn
-		       (setq temp (concat temp (jdee-wiz-get-get-method type name staticp class)))
-		       (setq report (concat report "[Added  ]")))
-		   (setq report (concat report "[Skipped]")))
-	       (setq report (concat report "[Exists ]")))))
+             ;;getting the get method if it does not exist in the buffer
+             (if (not (jdee-wiz-get-member-p name set-get-functions))
+                 (if (and (or bothp get-onlyp)
+                          (or (not staticp) jdee-wiz-get-set-static-members))
+                     (progn
+                       (setq temp (concat temp (jdee-wiz-get-get-method type name staticp class)))
+                       (setq report (concat report "[Added  ]")))
+                   (setq report (concat report "[Skipped]")))
+               (setq report (concat report "[Exists ]")))))
 
       (setq report (concat report "\n"))
 
@@ -870,8 +870,8 @@ defined in the current buffer."
     (setq pos (point))
     (if temp (insert temp))
     (if jdee-wiz-show-report
-	(with-output-to-temp-buffer (concat "*jdee-wiz-get-set-methods report for " class "*")
-	  (princ report)))
+        (with-output-to-temp-buffer (concat "*jdee-wiz-get-set-methods report for " class "*")
+          (princ report)))
     ;;indenting the new code
     (jdee-wiz-indent pos)))
 
@@ -882,9 +882,9 @@ defined in the current buffer."
       (setq token (car tokens))
       (setq name (semantic-tag-name token))
       (if (or (string-match "^get" name)
-	      (string-match "^set" name)
-	      (string-match "^is" name))
-	  (setq filtered-methods (append filtered-methods (list name))))
+              (string-match "^set" name)
+              (string-match "^is" name))
+          (setq filtered-methods (append filtered-methods (list name))))
       (setq tokens (cdr tokens)))
     filtered-methods))
 
@@ -896,7 +896,7 @@ protected modifiers"
       (setq token (car tokens))
       (setq modifiers (semantic-tag-modifiers token))
       (if (not (member "public" modifiers))
-	  (setq filtered-tokens (append filtered-tokens (list token))))
+          (setq filtered-tokens (append filtered-tokens (list token))))
       (setq tokens (cdr tokens)))
     filtered-tokens))
 
@@ -906,36 +906,36 @@ method templates. For Example if the variable is \"_Name\" and the variable
 `jdee-wiz-get-set-variable-convention' is set to prefix _ this method will
 return \"Name\"."
   (let (answer
-	(cfs case-fold-search)
-	(fix (car jdee-wiz-get-set-variable-convention))
-	(convention (cdr jdee-wiz-get-set-variable-convention)))
+        (cfs case-fold-search)
+        (fix (car jdee-wiz-get-set-variable-convention))
+        (convention (cdr jdee-wiz-get-set-variable-convention)))
     (setq case-fold-search nil)
     (cond ((not convention)
-	   (setq answer variable))
-	  ((string= "Prefix" convention)
-	   (progn
-	     (if fix
-		 (let ((pos (string-match (concat "^" fix) variable)))
-		   (if pos
-		       (setq answer (substring variable (+ pos (length fix))))
-		     (setq answer variable)))
-	       (setq answer variable))))
-	  ((string= "Postfix" convention)
-	   (progn
-	     (if fix
-		 (let ((pos (string-match (concat fix "$") variable)))
-		   (if pos
-		       (setq answer (substring variable 0 pos))
-		     (setq answer variable)))
-	       (setq answer variable))))
-	  (t
-	   (let ((pos (string-match "[A-Z]." variable)))
-	     (if pos
-		 (let ((ans (substring variable pos)))
-		   (if ans
-		       (setq answer ans)
-		     (setq answer variable)))
-	       (setq answer variable)))))
+           (setq answer variable))
+          ((string= "Prefix" convention)
+           (progn
+             (if fix
+                 (let ((pos (string-match (concat "^" fix) variable)))
+                   (if pos
+                       (setq answer (substring variable (+ pos (length fix))))
+                     (setq answer variable)))
+               (setq answer variable))))
+          ((string= "Postfix" convention)
+           (progn
+             (if fix
+                 (let ((pos (string-match (concat fix "$") variable)))
+                   (if pos
+                       (setq answer (substring variable 0 pos))
+                     (setq answer variable)))
+               (setq answer variable))))
+          (t
+           (let ((pos (string-match "[A-Z]." variable)))
+             (if pos
+                 (let ((ans (substring variable pos)))
+                   (if ans
+                       (setq answer ans)
+                     (setq answer variable)))
+               (setq answer variable)))))
     (setq case-fold-search cfs)
     answer))
 
@@ -943,32 +943,32 @@ return \"Name\"."
 (defun jdee-wiz-get-get-method(type name &optional staticp class-name)
   "Returns a string representing a get method"
   (let ((filtered-name (jdee-wiz-get-name name))
-	get (javadoc "") temp temp2)
+        get (javadoc "") temp temp2)
     (setq
      get
      (concat
       "\n"
       (if jdee-wiz-include-javadoc
-	  (progn
-	    (setq temp2 jdee-wiz-get-javadoc-template)
-	    (while temp2
-	      (setq temp (car temp2))
-	      (while (string-match "%n" temp)
-		(setq
-		 temp
-		 (replace-match
-		  (jdee-wiz-downcase-initials filtered-name) nil nil temp)))
-	      (while (string-match "%t" temp)
-		(setq temp (replace-match type nil nil temp)))
-	      (setq javadoc (concat javadoc temp "\n"))
-	      (setq temp2 (cdr temp2)))
-	    javadoc))
+          (progn
+            (setq temp2 jdee-wiz-get-javadoc-template)
+            (while temp2
+              (setq temp (car temp2))
+              (while (string-match "%n" temp)
+                (setq
+                 temp
+                 (replace-match
+                  (jdee-wiz-downcase-initials filtered-name) nil nil temp)))
+              (while (string-match "%t" temp)
+                (setq temp (replace-match type nil nil temp)))
+              (setq javadoc (concat javadoc temp "\n"))
+              (setq temp2 (cdr temp2)))
+            javadoc))
       (jdee-gen-method-signature
        (concat "public" (if staticp " static"))
        type
        (concat
-	(if (string= type "boolean") "is" "get")
-	(upcase-initials filtered-name))
+        (if (string= type "boolean") "is" "get")
+        (upcase-initials filtered-name))
        nil)
       (if jdee-gen-k&r "{" "\n{") "\n"
       "return " (if staticp (concat class-name ".") "this.")
@@ -978,12 +978,12 @@ return \"Name\"."
 (defun jdee-wiz-get-set-method(type name &optional staticp class-name)
   "Returns a string representing a set method"
   (let ((filtered-name (jdee-wiz-get-name name))
-	set (javadoc "") arg-name temp temp2)
+        set (javadoc "") arg-name temp temp2)
     (if jdee-wiz-get-set-variable-prefix
-	(setq
-	 arg-name
-	 (jdee-wiz-downcase-initials
-	  (concat jdee-wiz-get-set-variable-prefix (upcase-initials filtered-name))))
+        (setq
+         arg-name
+         (jdee-wiz-downcase-initials
+          (concat jdee-wiz-get-set-variable-prefix (upcase-initials filtered-name))))
       (setq arg-name (jdee-wiz-downcase-initials filtered-name)))
 
     (setq
@@ -991,21 +991,21 @@ return \"Name\"."
      (concat
       "\n"
       (if jdee-wiz-include-javadoc
-	  (progn
-	    (setq temp2 jdee-wiz-set-javadoc-template)
-	    (while temp2
-	      (setq temp (car temp2))
-	      (while (string-match "%n" temp)
-		(setq temp
-		      (replace-match
-		       (jdee-wiz-downcase-initials filtered-name) nil nil temp)))
-	      (while (string-match "%t" temp)
-		(setq temp (replace-match type nil nil temp)))
-	      (while (string-match "%p" temp)
-		(setq temp (replace-match arg-name nil nil temp)))
-	      (setq javadoc (concat javadoc temp "\n"))
-	      (setq temp2 (cdr temp2)))
-	    javadoc))
+          (progn
+            (setq temp2 jdee-wiz-set-javadoc-template)
+            (while temp2
+              (setq temp (car temp2))
+              (while (string-match "%n" temp)
+                (setq temp
+                      (replace-match
+                       (jdee-wiz-downcase-initials filtered-name) nil nil temp)))
+              (while (string-match "%t" temp)
+                (setq temp (replace-match type nil nil temp)))
+              (while (string-match "%p" temp)
+                (setq temp (replace-match arg-name nil nil temp)))
+              (setq javadoc (concat javadoc temp "\n"))
+              (setq temp2 (cdr temp2)))
+            javadoc))
       (jdee-gen-method-signature
        (concat "public" (if staticp " static"))
        "void"
@@ -1083,30 +1083,30 @@ If `jdee-wiz-tostring-prefix' is defined, it is prepended to the string.
 If `jdee-wiz-tostring-postfix' is defined, it is appended to the string. "
  (interactive)
  (let* ((class-name
-	 (jdee-parse-get-unqualified-name
-	  (jdee-parse-get-class-at-point)))
-	(variables
-	 (semantic-brute-find-tag-by-class
-	  'variable
-	  (jdee-wiz-get-class-parts
-	   class-name
-	   (semantic-brute-find-tag-by-class
-	    'type
-	    (semantic-fetch-tags)
-	    ))))
-	(method
-	 (concat
-	  "/**\n"
-	  " * {@inheritDoc}\n"
-	  " */\n"
-	  ;; respect coding style - by yoonforh 2004-05-10 01:34:02
-	  "public String toString()"
-	  (if jdee-gen-k&r " {\n" "\n{\n")
-	  "final int sbSize = " jdee-wiz-tostring-stringbuffer-size  ";\n"
-	  "final String variableSeparator = " jdee-wiz-tostring-variable-separator ";\n"
-	  "final StringBuffer sb = new StringBuffer(sbSize);\n\n"))
-	(prefix jdee-wiz-tostring-prefix)
-	(postfix jdee-wiz-tostring-postfix))
+         (jdee-parse-get-unqualified-name
+          (jdee-parse-get-class-at-point)))
+        (variables
+         (semantic-brute-find-tag-by-class
+          'variable
+          (jdee-wiz-get-class-parts
+           class-name
+           (semantic-brute-find-tag-by-class
+            'type
+            (semantic-fetch-tags)
+            ))))
+        (method
+         (concat
+          "/**\n"
+          " * {@inheritDoc}\n"
+          " */\n"
+          ;; respect coding style - by yoonforh 2004-05-10 01:34:02
+          "public String toString()"
+          (if jdee-gen-k&r " {\n" "\n{\n")
+          "final int sbSize = " jdee-wiz-tostring-stringbuffer-size  ";\n"
+          "final String variableSeparator = " jdee-wiz-tostring-variable-separator ";\n"
+          "final StringBuffer sb = new StringBuffer(sbSize);\n\n"))
+        (prefix jdee-wiz-tostring-prefix)
+        (postfix jdee-wiz-tostring-postfix))
 
    (setq variables (jdee-wiz-filter-variables-by-typemodifier variables))
 
@@ -1120,41 +1120,41 @@ If `jdee-wiz-tostring-postfix' is defined, it is appended to the string. "
       (delq
        nil
        (mapcar
-	(lambda (var)
-	  (let ((staticp
-		 (member
-		  "static"
-		  (semantic-tag-modifiers var))))
-	    (unless staticp var)))
-	variables))))
+        (lambda (var)
+          (let ((staticp
+                 (member
+                  "static"
+                  (semantic-tag-modifiers var))))
+            (unless staticp var)))
+        variables))))
 
    (while prefix
      (setq method (concat method "sb.append(" (car prefix) ");\n")
-	   prefix (cdr prefix)))
+           prefix (cdr prefix)))
 
    (while variables
      (let* ((var (car variables))
-	   (name (semantic-tag-name var))  ;;variable name
-	   (type (semantic-tag-type var))) ;;variable type i.e. boolean
+           (name (semantic-tag-name var))  ;;variable name
+           (type (semantic-tag-type var))) ;;variable type i.e. boolean
 
        (setq
-	method
-	(concat
-	 method
-	 "sb.append(\"" name "=\").append(" name ");\n"))
+        method
+        (concat
+         method
+         "sb.append(\"" name "=\").append(" name ");\n"))
 
        (if (> (length variables) 1)
-	   (setq method (concat method "sb.append(variableSeparator);\n")))
+           (setq method (concat method "sb.append(variableSeparator);\n")))
 
        (setq variables (cdr variables))))
 
    (while postfix
      (setq method (concat method "sb.append(" (car postfix) ");\n")
-	   postfix (cdr postfix)))
+           postfix (cdr postfix)))
 
    (setq method
-	 (concat
-	  method "\nreturn sb.toString();\n}\n"))
+         (concat
+          method "\nreturn sb.toString();\n}\n"))
 
    (insert method))
 

--- a/jdee-xref.el
+++ b/jdee-xref.el
@@ -144,10 +144,10 @@ calling `jdee-xref-unpickle-hash'."
       (erase-buffer)
       (insert "(")
       (maphash (lambda (key val)
-		 (when val
-		   (insert (concat "(" (prin1-to-string key) " . "
-				   (prin1-to-string val) ")\n" ))))
-	       hash)
+                 (when val
+                   (insert (concat "(" (prin1-to-string key) " . "
+                                   (prin1-to-string val) ")\n" ))))
+               hash)
       (insert ")")
       (save-buffer)
       (kill-buffer buf))))
@@ -157,10 +157,10 @@ calling `jdee-xref-unpickle-hash'."
 FILENAME must be created by `jdee-xref-pickle-hash'"
   (unless (file-exists-p filename)
     (error (concat "Cannot unpickle - file " filename " does not exist.  "
-		   "The xref database may need to be recreated.")))
+                   "The xref database may need to be recreated.")))
   (dolist (item (with-temp-buffer
-	  (insert-file-contents-literally filename)
-	  (read (current-buffer))))
+          (insert-file-contents-literally filename)
+          (read (current-buffer))))
     (puthash (car item) (cdr item) hash)))
 
 (defun jdee-xref-get-db-directory ()
@@ -179,35 +179,35 @@ FILENAME must be created by `jdee-xref-pickle-hash'"
   other packages branch out from."
 
   (cl-labels ((get-prefix
-	       (base-path package-path)
-	       ;; if the directory contains just one directory (or two,
-	       ;; one being CVS), then we can recurse down it to build
-	       ;; up a proper prefix before the package tree really
-	       ;; branches out
-	       (let ((files (cl-remove-if-not
-			     (lambda (dir)
-			       (and (file-directory-p
-				     (concat base-path "/" package-path "/" dir))
-				    (not (equal "CVS" dir))))
-			     (directory-files
-			      (concat base-path "/" package-path)
-			      nil "[^.]$"))))
-		 (if (eq (length files) 1)
-		     (get-prefix base-path (concat package-path "/"
-						   (car files)))
-		   (subst-char-in-string ?/ ?. package-path)))))
+               (base-path package-path)
+               ;; if the directory contains just one directory (or two,
+               ;; one being CVS), then we can recurse down it to build
+               ;; up a proper prefix before the package tree really
+               ;; branches out
+               (let ((files (cl-remove-if-not
+                             (lambda (dir)
+                               (and (file-directory-p
+                                     (concat base-path "/" package-path "/" dir))
+                                    (not (equal "CVS" dir))))
+                             (directory-files
+                              (concat base-path "/" package-path)
+                              nil "[^.]$"))))
+                 (if (eq (length files) 1)
+                     (get-prefix base-path (concat package-path "/"
+                                                   (car files)))
+                   (subst-char-in-string ?/ ?. package-path)))))
     (when (and (eq major-mode 'jdee-mode) jdee-sourcepath)
       (let ((first-prefix (car (split-string (jdee-parse-get-package-name)
-					     "\\."))) (prefixes))
-	(dolist (path (cl-remove-if-not
-		       (lambda (path)
-			 (file-exists-p path))
-		       (jdee-expand-wildcards-and-normalize jdee-sourcepath
-													   'jdee-sourcepath))
-				  prefixes)
-	  (when (member first-prefix (directory-files path nil "[^.]$"))
-	    (message (concat "path = " path))
-	    (add-to-list 'prefixes (get-prefix path first-prefix))))))))
+                                             "\\."))) (prefixes))
+        (dolist (path (cl-remove-if-not
+                       (lambda (path)
+                         (file-exists-p path))
+                       (jdee-expand-wildcards-and-normalize jdee-sourcepath
+                                                                                                           'jdee-sourcepath))
+                                  prefixes)
+          (when (member first-prefix (directory-files path nil "[^.]$"))
+            (message (concat "path = " path))
+            (add-to-list 'prefixes (get-prefix path first-prefix))))))))
 
 ;;;###autoload
 (defun jdee-xref-make-xref-db ()
@@ -234,62 +234,62 @@ specified by `jdee-xref-db-base-directory'"
    (lambda (item)
      (string=
       (substring str 0 (min (length item)
-			    (length str)))
+                            (length str)))
       item))
    prefixlist))
 
 (defun jdee-xref-get-package-data ()
   (let ((data (make-hash-table :test 'equal :size 10))
-	(caller-files (directory-files (jdee-xref-get-db-directory)
-				       t "caller$")))
+        (caller-files (directory-files (jdee-xref-get-db-directory)
+                                       t "caller$")))
     (dolist (caller-file caller-files)
       (let* ((package (mapconcat (lambda (x) x)
-				 (butlast
-				  (split-string (car (last
-						      (split-string caller-file
-								    "/")))
-						"-")) "-"))
-	     (package-data (jdee-xref-load-package-hashes package)))
-	(puthash package package-data data)))
+                                 (butlast
+                                  (split-string (car (last
+                                                      (split-string caller-file
+                                                                    "/")))
+                                                "-")) "-"))
+             (package-data (jdee-xref-load-package-hashes package)))
+        (puthash package package-data data)))
     data))
 
 (defun jdee-xref-update-xref-db (&optional only-classes)
   (let ((package-data (if only-classes
-			(jdee-xref-get-package-data)
-			(make-hash-table :test 'equal :size 10)))
-	(subclasses (make-hash-table :test 'equal :size 500)))
+                        (jdee-xref-get-package-data)
+                        (make-hash-table :test 'equal :size 10)))
+        (subclasses (make-hash-table :test 'equal :size 500)))
     ;; Remove all occurances of classes to be updated from the package-data's caller-hashes
     (when only-classes
       (maphash (lambda (package single-package-data)
-		 (maphash (lambda (callee callers)
-			    (puthash callee
-				     (cl-remove-if (lambda (item)
-						  (member (car item)
-							  only-classes))
-						callers)
-				     (nth 0 single-package-data)))
-			  (nth 0 single-package-data)))
-	       package-data))
+                 (maphash (lambda (callee callers)
+                            (puthash callee
+                                     (cl-remove-if (lambda (item)
+                                                  (member (car item)
+                                                          only-classes))
+                                                callers)
+                                     (nth 0 single-package-data)))
+                          (nth 0 single-package-data)))
+               package-data))
     (with-all-class-infos-when (info)
-			       (lambda (class-file)
-				 (or (null only-classes)
-				     (jdee-class-path-in-classes-p
-				      class-file only-classes)))
-			       (jdee-xref-add-class-info-to-db info package-data
-							      subclasses))
+                               (lambda (class-file)
+                                 (or (null only-classes)
+                                     (jdee-class-path-in-classes-p
+                                      class-file only-classes)))
+                               (jdee-xref-add-class-info-to-db info package-data
+                                                              subclasses))
     (setq jdee-xref-parsed-classes nil)
     (jdee-xref-pickle-hash subclasses (jdee-xref-get-subclass-file))
     (setq jdee-xref-subclasses subclasses)
     (maphash (lambda (package data)
-	       (jdee-xref-pickle-hash (nth 0 data)
-				     (jdee-xref-get-caller-file package))
-	       (jdee-xref-pickle-hash (nth 1 data)
-				     (jdee-xref-get-interface-file package))
-	       (jdee-xref-pickle-hash (nth 2 data)
-				     (jdee-xref-get-member-file package))
-	       (jdee-xref-pickle-hash (nth 3 data)
-				     (jdee-xref-get-superclass-file package)))
-	     package-data)
+               (jdee-xref-pickle-hash (nth 0 data)
+                                     (jdee-xref-get-caller-file package))
+               (jdee-xref-pickle-hash (nth 1 data)
+                                     (jdee-xref-get-interface-file package))
+               (jdee-xref-pickle-hash (nth 2 data)
+                                     (jdee-xref-get-member-file package))
+               (jdee-xref-pickle-hash (nth 3 data)
+                                     (jdee-xref-get-superclass-file package)))
+             package-data)
     (setq jdee-xref-cache nil)))
 
 (defun jdee-xref-create-package-hashes (&optional fake)
@@ -299,118 +299,118 @@ member-hash, and the superclass hash.  FAKE determines if we are just
 creating them so that there is something to check against.  In those
 circumstance we just create tiny hashes to conserve memory."
   (list (make-hash-table :test 'equal :size (if fake 1 100))
-	(make-hash-table :test 'equal :size (if fake 1 20))
-	(make-hash-table :test 'equal :size (if fake 1 100))
-	(make-hash-table :test 'equal :size (if fake 1 20))))
+        (make-hash-table :test 'equal :size (if fake 1 20))
+        (make-hash-table :test 'equal :size (if fake 1 100))
+        (make-hash-table :test 'equal :size (if fake 1 20))))
 
 (defun jdee-xref-load-package-hashes (package)
   (let ((data (jdee-xref-create-package-hashes)))
     (jdee-xref-unpickle-hash (nth 0 data)
-			    (jdee-xref-get-caller-file package))
+                            (jdee-xref-get-caller-file package))
     (jdee-xref-unpickle-hash (nth 1 data)
-			    (jdee-xref-get-interface-file package))
+                            (jdee-xref-get-interface-file package))
     (jdee-xref-unpickle-hash (nth 2 data)
-			    (jdee-xref-get-member-file package))
+                            (jdee-xref-get-member-file package))
     (jdee-xref-unpickle-hash (nth 3 data)
-			    (jdee-xref-get-superclass-file package))
+                            (jdee-xref-get-superclass-file package))
     data))
 
 (defun jdee-xref-append-hash (key value hash)
   "Like `puthash' but appends VALUE to the HASH at KEY"
   (puthash key (append (gethash key hash) (if (listp value)
-					    value
-					    (list value))) hash))
+                                            value
+                                            (list value))) hash))
 
 (defun jdee-xref-add-class-info-to-db (info package-data subclasses)
   (message (concat "Parsing class " (jdee-bytecode-extract-classname info)))
   (add-to-list 'jdee-xref-parsed-classes
-	       (jdee-bytecode-extract-classname info))
+               (jdee-bytecode-extract-classname info))
   (let ((package (jdee-parse-get-package-from-name
-		  (jdee-bytecode-extract-classname info))))
+                  (jdee-bytecode-extract-classname info))))
     ;; If there is no existing package data
     (unless (gethash package package-data)
       (puthash package
-	       ;; package-data's values are (caller-hash
-	       ;; interface-hash method-and-field-hash)
-	       (jdee-xref-create-package-hashes)
-	       package-data))
+               ;; package-data's values are (caller-hash
+               ;; interface-hash method-and-field-hash)
+               (jdee-xref-create-package-hashes)
+               package-data))
     (destructuring-bind (caller-hash interface-hash
-				     method-and-field-hash superclass-hash)
-	(gethash package package-data)
+                                     method-and-field-hash superclass-hash)
+        (gethash package package-data)
       (puthash (jdee-bytecode-extract-classname info)
-	       (jdee-bytecode-extract-interfaces info)
-	       interface-hash)
+               (jdee-bytecode-extract-interfaces info)
+               interface-hash)
       (puthash (jdee-bytecode-extract-classname info)
-	       (append (jdee-bytecode-extract-method-signatures info)
-		       (jdee-bytecode-extract-field-signatures info))
-	       method-and-field-hash)
+               (append (jdee-bytecode-extract-method-signatures info)
+                       (jdee-bytecode-extract-field-signatures info))
+               method-and-field-hash)
       (puthash (jdee-bytecode-extract-classname info)
-	       (jdee-bytecode-extract-superclass info)
-	       superclass-hash)
+               (jdee-bytecode-extract-superclass info)
+               superclass-hash)
       (jdee-xref-append-hash
        (jdee-bytecode-extract-superclass info)
        (jdee-bytecode-extract-classname info) subclasses)
       (dolist (call (nreverse
-		     (jdee-bytecode-extract-method-calls info)))
-	(let ((calls (car call))
-	      (called (cadr call)))
-	  (if (or (not jdee-xref-store-prefixes)
-		  (and
-		   (jdee-xref-substring-member (car calls)
+                     (jdee-bytecode-extract-method-calls info)))
+        (let ((calls (car call))
+              (called (cadr call)))
+          (if (or (not jdee-xref-store-prefixes)
+                  (and
+                   (jdee-xref-substring-member (car calls)
                                                jdee-xref-store-prefixes)
-		   (jdee-xref-substring-member (car called)
+                   (jdee-xref-substring-member (car called)
                                                jdee-xref-store-prefixes)))
-	      (let* ((dqcalled (list (car called)
-				     (nth 1 called)
-				     (when (nth 2 called)
-				       (jdee-parse-get-unqualified-name
-					(nth 2 called)))
-				     ;; We don't want to need to
-				     ;; know the constructor args
-				     ;; for anonymous classes
-				     (unless (jdee-xref-is-class-anonymous (car called))
-				       (mapcar 'jdee-parse-get-unqualified-name
-					       (nth 3 called)))))
-		     (called-package (jdee-parse-get-package-from-name
-				      (car dqcalled))))
-		;; Create the package data if needed
-		(unless (gethash called-package package-data)
-		  (puthash called-package (jdee-xref-create-package-hashes)
-			   package-data))
-		(let* ((called-package-hashes
-			(gethash called-package package-data))
-		       (called-package-caller-hash
-			(car called-package-hashes)))
-		  ;; add things to the table - making sure there are no duplicates
-		  (puthash dqcalled
-			   (if (member calls (gethash
-					      dqcalled
-					      called-package-caller-hash))
-			       (gethash dqcalled called-package-caller-hash)
-			     (cons calls
-				   (gethash dqcalled
-					    called-package-caller-hash)))
-			   called-package-caller-hash)))))))))
+              (let* ((dqcalled (list (car called)
+                                     (nth 1 called)
+                                     (when (nth 2 called)
+                                       (jdee-parse-get-unqualified-name
+                                        (nth 2 called)))
+                                     ;; We don't want to need to
+                                     ;; know the constructor args
+                                     ;; for anonymous classes
+                                     (unless (jdee-xref-is-class-anonymous (car called))
+                                       (mapcar 'jdee-parse-get-unqualified-name
+                                               (nth 3 called)))))
+                     (called-package (jdee-parse-get-package-from-name
+                                      (car dqcalled))))
+                ;; Create the package data if needed
+                (unless (gethash called-package package-data)
+                  (puthash called-package (jdee-xref-create-package-hashes)
+                           package-data))
+                (let* ((called-package-hashes
+                        (gethash called-package package-data))
+                       (called-package-caller-hash
+                        (car called-package-hashes)))
+                  ;; add things to the table - making sure there are no duplicates
+                  (puthash dqcalled
+                           (if (member calls (gethash
+                                              dqcalled
+                                              called-package-caller-hash))
+                               (gethash dqcalled called-package-caller-hash)
+                             (cons calls
+                                   (gethash dqcalled
+                                            called-package-caller-hash)))
+                           called-package-caller-hash)))))))))
 
 (defun jdee-xref-class-and-token-to-signature (class token)
   (let ((ttype  (semantic-tag-type token))
-	(tclass (semantic-tag-class token))
-	(tname  (semantic-tag-name token)))
+        (tclass (semantic-tag-class token))
+        (tname  (semantic-tag-name token)))
     (list tclass
-	  class
-	  (if (equal tname (jdee-parse-get-unqualified-name class))
-	      "<init>"
-	    tname)
-	  (when (eq tclass 'function)
-	    (if (or (not ttype) (equal ttype "void"))
-		nil
-	      (jdee-parse-get-unqualified-name ttype)))
-	  (if (eq tclass 'function)
-	      (mapcar (lambda (arg)
-			(jdee-parse-get-unqualified-name
-			 (semantic-tag-type arg)))
-		      (semantic-tag-function-arguments token))
-	    (list (jdee-parse-get-unqualified-name ttype))))))
+          class
+          (if (equal tname (jdee-parse-get-unqualified-name class))
+              "<init>"
+            tname)
+          (when (eq tclass 'function)
+            (if (or (not ttype) (equal ttype "void"))
+                nil
+              (jdee-parse-get-unqualified-name ttype)))
+          (if (eq tclass 'function)
+              (mapcar (lambda (arg)
+                        (jdee-parse-get-unqualified-name
+                         (semantic-tag-type arg)))
+                      (semantic-tag-function-arguments token))
+            (list (jdee-parse-get-unqualified-name ttype))))))
 
 (defun jdee-xref-get-current-class ()
   (let ((package-name (jdee-parse-get-package-name)))
@@ -418,8 +418,8 @@ circumstance we just create tiny hashes to conserve memory."
 
 (defun jdee-xref-get-current-signature ()
   (unless (member
-	   (semantic-tag-class (semantic-current-tag))
-		'(function variable))
+           (semantic-tag-class (semantic-current-tag))
+                '(function variable))
     (error "The cursor must be in a function or class variable to get the callers"))
   (jdee-xref-class-and-token-to-signature
    (jdee-xref-get-current-class)
@@ -437,11 +437,11 @@ the requested function are considered."
   (interactive "P")
   (jdee-xref-load-subclasses-table-if-necessary)
   (setq jdee-xref-stack (jdee-xref-get-callers
-			    (jdee-xref-get-current-signature) strict))
+                            (jdee-xref-get-current-signature) strict))
   (if jdee-xref-stack
       (progn
-	(ring-insert find-tag-marker-ring (point-marker))
-	(jdee-xref-next-caller))
+        (ring-insert find-tag-marker-ring (point-marker))
+        (jdee-xref-next-caller))
     (message "No calls")))
 
 (defun jdee-xref-goto-caller (caller)
@@ -465,19 +465,19 @@ and show it"
   (unless jdee-xref-subclasses
     (setq jdee-xref-subclasses (make-hash-table :test 'equal :size 500))
     (jdee-xref-unpickle-hash jdee-xref-subclasses
-			    (jdee-xref-get-subclass-file))
+                            (jdee-xref-get-subclass-file))
     ;; if subclasses were empty, then it's the first time this is run,
     ;; so do our one-time initializations
     (add-hook 'after-save-hook 'jdee-xref-file-saved)))
 
 (defun jdee-xref-signature-to-string (sig)
   (concat (or (nth 3 sig) "void") " " (cadr sig) "."
-	  (if (equal (nth 2 sig) "<init>")
-	    (jdee-parse-get-unqualified-name (cadr sig))
-	    (nth 2 sig))
-	  (when (eq (car sig) 'function)
-	    (concat "("
-		    (mapconcat (lambda (x) x) (nth 4 sig) ",") ")"))))
+          (if (equal (nth 2 sig) "<init>")
+            (jdee-parse-get-unqualified-name (cadr sig))
+            (nth 2 sig))
+          (when (eq (car sig) 'function)
+            (concat "("
+                    (mapconcat (lambda (x) x) (nth 4 sig) ",") ")"))))
 
 (defun jdee-xref-find-package-in-cache (package cache)
   (when cache
@@ -505,14 +505,14 @@ and show it"
     (error "The variable `jdee-xref-db-base-directory' must be specified to load the xref db"))
   (if (file-exists-p (jdee-xref-get-caller-file package))
     (or (jdee-xref-find-package-in-cache package jdee-xref-cache)
-	;; Or we need to get the new package and put it in the cache
-	(let ((data (jdee-xref-load-package-hashes package)))
-	(setq jdee-xref-cache (cons (cons package data)
-				   (if (> (length jdee-xref-cache)
-					  jdee-xref-cache-size)
-				       (cdr jdee-xref-cache)
-				     jdee-xref-cache)))
-	data))
+        ;; Or we need to get the new package and put it in the cache
+        (let ((data (jdee-xref-load-package-hashes package)))
+        (setq jdee-xref-cache (cons (cons package data)
+                                   (if (> (length jdee-xref-cache)
+                                          jdee-xref-cache-size)
+                                       (cdr jdee-xref-cache)
+                                     jdee-xref-cache)))
+        data))
     (jdee-xref-create-package-hashes t)))
 
 (defun jdee-xref-get-caller-hash (package)
@@ -529,15 +529,15 @@ and show it"
 
 (defun jdee-xref-get-basic-caller (sig)
   (gethash (cdr sig) (jdee-xref-get-caller-hash (jdee-parse-get-package-from-name
-						(nth 1 sig)))))
+                                                (nth 1 sig)))))
 
 (defun jdee-xref-get-members (class)
   (gethash class (jdee-xref-get-member-hash (jdee-parse-get-package-from-name
-					    class))))
+                                            class))))
 
 (defun jdee-xref-get-superclass (class)
   (gethash class (jdee-xref-get-superclass-hash (jdee-parse-get-package-from-name
-						class))))
+                                                class))))
 
 (defun jdee-xref-is-class-anonymous (class)
   (string-match "\\$[0-9]+$" class))
@@ -560,32 +560,32 @@ and show it"
      (jdee-xref-get-basic-caller sig)
      (unless strict
        (apply 'append
-	  (mapcar
-	   (lambda (classname)
-	 (let* ((sig `(,typesig ,classname ,@(cddr sig)))
-	    (callers-for-classname (jdee-xref-get-basic-caller sig)))
-	   (when callers-for-classname
-	     (cons classname callers-for-classname)))) ;; include classname in the usage list
-	   (jdee-xref-get-subs classname sig (jdee-xref-get-supers classname nil))))))))
+          (mapcar
+           (lambda (classname)
+         (let* ((sig `(,typesig ,classname ,@(cddr sig)))
+            (callers-for-classname (jdee-xref-get-basic-caller sig)))
+           (when callers-for-classname
+             (cons classname callers-for-classname)))) ;; include classname in the usage list
+           (jdee-xref-get-subs classname sig (jdee-xref-get-supers classname nil))))))))
 
 
 (defun jdee-xref-get-supers (classname collect)
   (mapc (lambda (super)
       (unless (member super collect)
-	(setq collect (jdee-xref-get-supers super (cons super collect)))))
+        (setq collect (jdee-xref-get-supers super (cons super collect)))))
     (let* ((package (jdee-parse-get-package-from-name classname))
-	   (superclass (jdee-xref-get-superclass classname))
-	   (superinterfaces (gethash classname (jdee-xref-get-interface-hash package))))
+           (superclass (jdee-xref-get-superclass classname))
+           (superinterfaces (gethash classname (jdee-xref-get-interface-hash package))))
       (if superclass
-	  (cons superclass superinterfaces)
-	superinterfaces)))
+          (cons superclass superinterfaces)
+        superinterfaces)))
   collect)
 
 
 (defun jdee-xref-get-subs (classname sig collect)
   (mapc (lambda (subclass)
-	(unless (or (member subclass collect) (member (cddr sig) (jdee-xref-get-members subclass)))
-	  (setq collect (jdee-xref-get-subs subclass sig (cons subclass collect)))))
+        (unless (or (member subclass collect) (member (cddr sig) (jdee-xref-get-members subclass)))
+          (setq collect (jdee-xref-get-subs subclass sig (cons subclass collect)))))
       (gethash classname jdee-xref-subclasses))
   collect)
 
@@ -595,7 +595,7 @@ and show it"
 
 (defun jdee-xref-caller-to-sig (caller)
   (list 'function (nth 0 caller) (nth 1 caller) (when (nth 2 caller) (jdee-parse-get-unqualified-name (nth 2 caller)))
-	(mapcar 'jdee-parse-get-unqualified-name (nth 3 caller))))
+        (mapcar 'jdee-parse-get-unqualified-name (nth 3 caller))))
 
 (defun jdee-xref-tree-get-children (sig)
   (when sig
@@ -603,18 +603,18 @@ and show it"
      (lambda (caller)
        (if (listp caller)
        (let  ((caller-sig (jdee-xref-caller-to-sig caller)))
-	 (list
-	  'tree-widget
-	  :node `(push-button
-	      :tag ,(jdee-xref-signature-to-string caller-sig)
-	      :format "%[%t%]\n"
-	      :sig ,caller-sig
-	      :caller ,caller
-	      :notify jdee-xref-notify)
-	  :dynargs 'jdee-xref-tree-get-children-from-tree
-	  :expander 'jdee-xref-tree-get-children-from-tree
-	  :sig caller-sig
-	  :has-children t))
+         (list
+          'tree-widget
+          :node `(push-button
+              :tag ,(jdee-xref-signature-to-string caller-sig)
+              :format "%[%t%]\n"
+              :sig ,caller-sig
+              :caller ,caller
+              :notify jdee-xref-notify)
+          :dynargs 'jdee-xref-tree-get-children-from-tree
+          :expander 'jdee-xref-tree-get-children-from-tree
+          :sig caller-sig
+          :has-children t))
      (list 'tree-widget :tag caller))) ;; class for next set of usages
        (jdee-xref-get-callers sig))))
 
@@ -632,25 +632,25 @@ and show it"
   (interactive "P")
   (jdee-xref-load-subclasses-table-if-necessary)
   (let* ((sig (jdee-xref-get-current-signature))
-	 (buf (get-buffer-create (concat "JDE call graph for "
-					 (jdee-xref-signature-to-string
-					  sig)))))
+         (buf (get-buffer-create (concat "JDE call graph for "
+                                         (jdee-xref-signature-to-string
+                                          sig)))))
     (switch-to-buffer buf)
     (erase-buffer)
     (widget-create 'tree-widget
-		   :tag (jdee-xref-signature-to-string sig)
-		   :dynargs 'jdee-xref-tree-get-children-from-tree
-		   :expander 'jdee-xref-tree-get-children-from-tree
-		   :has-children t
-		   :sig sig)
+                   :tag (jdee-xref-signature-to-string sig)
+                   :dynargs 'jdee-xref-tree-get-children-from-tree
+                   :expander 'jdee-xref-tree-get-children-from-tree
+                   :has-children t
+                   :sig sig)
     (use-local-map widget-keymap)
     (widget-setup)))
 
 (defun jdee-xref-get-class-variables (class-token)
   (cl-mapcan (lambda (token)
-	       (when (eq (semantic-tag-class token) 'variable)
-		 (list token)))
-	     (semantic-tag-children-compatibility class-token)))
+               (when (eq (semantic-tag-class token) 'variable)
+                 (list token)))
+             (semantic-tag-children-compatibility class-token)))
 
 ;;;###autoload
 (defun jdee-xref-list-uncalled-functions (strict)
@@ -669,14 +669,14 @@ while. If it does, you might want to consider increasing
   (jdee-xref-load-subclasses-table-if-necessary)
   (save-excursion
     (cl-flet ((get-unused-string
-	       (token)
-	       (goto-char (semantic-tag-start token))
-	       (unless (jdee-xref-get-callers
-			(jdee-xref-class-and-token-to-signature
-			 (jdee-xref-get-current-class) token) strict)
-		 (list (jdee-xref-signature-to-string
-			(jdee-xref-class-and-token-to-signature
-			 (jdee-xref-get-current-class) token))))))
+               (token)
+               (goto-char (semantic-tag-start token))
+               (unless (jdee-xref-get-callers
+                        (jdee-xref-class-and-token-to-signature
+                         (jdee-xref-get-current-class) token) strict)
+                 (list (jdee-xref-signature-to-string
+                        (jdee-xref-class-and-token-to-signature
+                         (jdee-xref-get-current-class) token))))))
       (let ((uncalled-methods
              (cl-mapcan #'get-unused-string
                         (semantic-brute-find-tag-by-class 'function
@@ -712,11 +712,11 @@ while. If it does, you might want to consider increasing
 
 (defun jdee-xref-remove-classes-from-subclasses-table (classes)
   (maphash (lambda (key value)
-	     (puthash key
-		      (cl-remove-if (lambda (item)
-				   (member item classes)) value)
-		      jdee-xref-subclasses))
-	   jdee-xref-subclasses))
+             (puthash key
+                      (cl-remove-if (lambda (item)
+                                   (member item classes)) value)
+                      jdee-xref-subclasses))
+           jdee-xref-subclasses))
 
 ;;;###autoload
 (defun jdee-xref-update (&rest ignored)
@@ -735,13 +735,13 @@ call list of all files modified in emacs"
 (defun jdee-xref-file-saved ()
   (when (eq major-mode 'jdee-mode)
     (setq jdee-xref-modified-classes
-	  (append jdee-xref-modified-classes
-		  (mapcar (lambda (class-token)
-			    (concat (jdee-parse-get-package-name)
-				    (when (jdee-parse-get-package-name) ".")
-				    (semantic-tag-name class-token)))
-			  (semantic-brute-find-tag-by-type
-			   "class" (current-buffer) t))))))
+          (append jdee-xref-modified-classes
+                  (mapcar (lambda (class-token)
+                            (concat (jdee-parse-get-package-name)
+                                    (when (jdee-parse-get-package-name) ".")
+                                    (semantic-tag-name class-token)))
+                          (semantic-brute-find-tag-by-type
+                           "class" (current-buffer) t))))))
 
 ;;;###autoload
 (defun jdee-xref-customize ()

--- a/jdee.el
+++ b/jdee.el
@@ -119,10 +119,10 @@ be an interactive function that can be called by
   :group 'jdee-project
   :safe (lambda (val) (member val '(jdee-make jdee-ant-build jdee-maven-build)))
   :type '(radio
-	  (const :tag "Make" jdee-make)
-	  (const :tag "Ant" jdee-ant-build)
-	  (const :tag "Maven" jdee-maven-build)
-	  (function :tag "Custom function" identity)))
+          (const :tag "Make" jdee-make)
+          (const :tag "Ant" jdee-ant-build)
+          (const :tag "Maven" jdee-maven-build)
+          (function :tag "Custom function" identity)))
 
 ;;(makunbound 'jdee-debugger)
 (defcustom jdee-debugger (list "jdb")
@@ -133,23 +133,23 @@ are using JDK 1.2.2 or later and want to use the the old (e.g., pre-JPDA)
 version of jdb instead of the new (JPDA-based) version of jdb."
   :group 'jdee-project
   :type '(list
-	  (radio-button-choice
+          (radio-button-choice
            (item "jdb")
            (item "old jdb")))
   :set '(lambda (sym val)
-	  (mapc
-	   (lambda (buff)
-	     (save-excursion
-	       (set-buffer buff)
-	       (if (string= (car val) "JDEbug")
-		   (progn
-		     (jdee-jdb-minor-mode -1)
-		     (jdee-bug-minor-mode 1))
-		 (progn
-		   (jdee-jdb-minor-mode 1)
-		   (jdee-bug-minor-mode -1)))))
-	   (jdee-get-java-source-buffers))
-	  (set-default sym val)))
+          (mapc
+           (lambda (buff)
+             (save-excursion
+               (set-buffer buff)
+               (if (string= (car val) "JDEbug")
+                   (progn
+                     (jdee-jdb-minor-mode -1)
+                     (jdee-bug-minor-mode 1))
+                 (progn
+                   (jdee-jdb-minor-mode 1)
+                   (jdee-bug-minor-mode -1)))))
+           (jdee-get-java-source-buffers))
+          (set-default sym val)))
 
 (defun jdee-show-run-options ()
   "Show the JDEE Run Options panel."
@@ -200,83 +200,83 @@ This command invokes the function defined by `jdee-build-function'."
   (interactive)
   (condition-case err
       (progn
-	(jdee-check-versions)
+        (jdee-check-versions)
         (require 'jdee-plugins)
 
-	(add-to-list 'semantic-new-buffer-setup-functions
-		     '(jdee-mode . jdee-parse-semantic-default-setup))
+        (add-to-list 'semantic-new-buffer-setup-functions
+                     '(jdee-mode . jdee-parse-semantic-default-setup))
 
-	(java-mode)
-	(if (get 'java-mode 'special)
-	    (put 'jdee-mode 'special t))
-	(setq major-mode 'jdee-mode)
-	(setq mode-name "JDEE")
-	(derived-mode-set-keymap 'jdee-mode)
-	(derived-mode-set-syntax-table 'jdee-mode)
-	(derived-mode-set-abbrev-table 'jdee-mode)
+        (java-mode)
+        (if (get 'java-mode 'special)
+            (put 'jdee-mode 'special t))
+        (setq major-mode 'jdee-mode)
+        (setq mode-name "JDEE")
+        (derived-mode-set-keymap 'jdee-mode)
+        (derived-mode-set-syntax-table 'jdee-mode)
+        (derived-mode-set-abbrev-table 'jdee-mode)
 
-	;; Define buffer-local variables.
-	(make-local-variable 'jdee-project-name)
-	(make-local-variable 'jdee-run-applet-document)
+        ;; Define buffer-local variables.
+        (make-local-variable 'jdee-project-name)
+        (make-local-variable 'jdee-run-applet-document)
 
-	(setq jdee-current-project
-	      (or (jdee-find-project-file default-directory)
-		  "")) ;; Avoid setting startup values twice!
+        (setq jdee-current-project
+              (or (jdee-find-project-file default-directory)
+                  "")) ;; Avoid setting startup values twice!
 
-	(setq jdee-buffer-project-file jdee-current-project)
+        (setq jdee-buffer-project-file jdee-current-project)
 
-	;; Load the project file for this buffer. The project file
-	;; defines JDEE options for a project.
-	(if (and (not (jdee-debugger-running-p)) jdee-project-context-switching-enabled-p)
-	    (jdee-load-project-file))
+        ;; Load the project file for this buffer. The project file
+        ;; defines JDEE options for a project.
+        (if (and (not (jdee-debugger-running-p)) jdee-project-context-switching-enabled-p)
+            (jdee-load-project-file))
 
         (jdee-activator-init)
 
         ;; Define underscore as a word constituent. This is needed
-	;; to support coding styles the begin fields with an underscore.
-	(modify-syntax-entry ?_ "w")
+        ;; to support coding styles the begin fields with an underscore.
+        (modify-syntax-entry ?_ "w")
 
-	(when jdee-enable-abbrev-mode
-	  ;; Define abbreviations.
-	  (jdee-init-abbrev-table)
-	  (abbrev-mode 1))
+        (when jdee-enable-abbrev-mode
+          ;; Define abbreviations.
+          (jdee-init-abbrev-table)
+          (abbrev-mode 1))
 
-	;; Reset the key bindings in case jdee-mode-keymap
-	;; was not bound at startup.
-	(custom-initialize-reset 'jdee-key-bindings nil)
+        ;; Reset the key bindings in case jdee-mode-keymap
+        ;; was not bound at startup.
+        (custom-initialize-reset 'jdee-key-bindings nil)
 
-	(make-local-variable 'mode-line-format)
-	(setq mode-line-format jdee-mode-line-format)
+        (make-local-variable 'mode-line-format)
+        (setq mode-line-format jdee-mode-line-format)
 
-	;; When looking for a tag that has multiple matches
-	;; in the TAGS file, prefer (find first) the
-	;; occurrence in the _current_ buffer.
-	;; Contributed by Charles Rich, Mitsubishi Electric Research Laboratories,
-	;; Cambridge, MA>
-	(when (boundp 'tags-table-format-functions)
-	  (make-local-variable 'tags-table-format-functions)
-	  (add-hook 'tags-table-format-functions 'jdee-etags-recognize-tags-table nil t))
+        ;; When looking for a tag that has multiple matches
+        ;; in the TAGS file, prefer (find first) the
+        ;; occurrence in the _current_ buffer.
+        ;; Contributed by Charles Rich, Mitsubishi Electric Research Laboratories,
+        ;; Cambridge, MA>
+        (when (boundp 'tags-table-format-functions)
+          (make-local-variable 'tags-table-format-functions)
+          (add-hook 'tags-table-format-functions 'jdee-etags-recognize-tags-table nil t))
 
-	(when (not jdee-launch-beanshell-on-demand-p)
+        (when (not jdee-launch-beanshell-on-demand-p)
           (jdee-backend-launch))
 
-	(jdee-project-update-backend)
+        (jdee-project-update-backend)
 
-	(wisent-java-default-setup)
-	(semantic-mode 1)
+        (wisent-java-default-setup)
+        (semantic-mode 1)
 
-	;; Install debug menu.
-	(if (string= (car jdee-debugger) "JDEbug")
-	    (jdee-bug-minor-mode 1)
-	  (jdee-jdb-minor-mode 1))
+        ;; Install debug menu.
+        (if (string= (car jdee-debugger) "JDEbug")
+            (jdee-bug-minor-mode 1)
+          (jdee-jdb-minor-mode 1))
 
-	(when (boundp 'jdee-mode-map)
-	  (let ((key (car (read-from-string "[return]"))))
+        (when (boundp 'jdee-mode-map)
+          (let ((key (car (read-from-string "[return]"))))
             (if jdee-electric-return-mode
                 (define-key (current-local-map) key 'jdee-electric-return))))
 
-	;; Set up indentation of Java annotations.
-	(jdee-annotations-setup)
+        ;; Set up indentation of Java annotations.
+        (jdee-annotations-setup)
 
         ;; Setup flycheck mode
         (when (and (featurep 'flycheck)
@@ -284,9 +284,9 @@ This command invokes the function defined by `jdee-build-function'."
           (require 'jdee-flycheck)
           (jdee-flycheck-mode))
 
-	;; The next form must be the last executed
-	;; by jdee-mode.
-	(derived-mode-run-hooks 'jdee-mode))
+        ;; The next form must be the last executed
+        ;; by jdee-mode.
+        (derived-mode-run-hooks 'jdee-mode))
     (error
      (message "%s" (error-message-string err)))))
 
@@ -298,23 +298,23 @@ This command invokes the function defined by `jdee-build-function'."
 
 (defcustom jdee-menu-definition
   (list "JDEE"
-	["Compile"           jdee-compile t]
-	;; ["Run App"           jdee-run (not (jdee-run-application-running-p))]
-	["Run App"           jdee-run t]
-	["Run Unit Test"     jdee-test-unittest t]
-	["Debug App"         jdee-debug t]
-	"-"
-	;;["-"                 ignore nil]
-	["Run Applet"        jdee-run-menu-run-applet t]
-	["Debug Applet"      jdee-debug-applet t]
-	"-"
-	["Build"             jdee-build t]
-	(list "Find"
-	      ["Expression"    jdee-find
+        ["Compile"           jdee-compile t]
+        ;; ["Run App"           jdee-run (not (jdee-run-application-running-p))]
+        ["Run App"           jdee-run t]
+        ["Run Unit Test"     jdee-test-unittest t]
+        ["Debug App"         jdee-debug t]
+        "-"
+        ;;["-"                 ignore nil]
+        ["Run Applet"        jdee-run-menu-run-applet t]
+        ["Debug Applet"      jdee-debug-applet t]
+        "-"
+        ["Build"             jdee-build t]
+        (list "Find"
+              ["Expression"    jdee-find
                (and
                 (jdee-find-get-find-exec)
                 (jdee-find-get-grep-exec))]
-	      ["Expression..."  jdee-find-dlg
+              ["Expression..."  jdee-find-dlg
                (and
                 (jdee-find-get-find-exec)
                 (jdee-find-get-grep-exec))]
@@ -322,134 +322,134 @@ This command invokes the function defined by `jdee-build-function'."
               ["Class"  jdee-show-class-source t]
               ["Super Class"  jdee-show-superclass-source t]
               ["Interface"  jdee-show-interface-source t]
-	      )
-	(list "Interpreter"
-	      ["Start"         jdee-backend-run t]
-	      ["Exit"          jdee-backend-exit t]
-	      "-"
-	      ["Help"          jdee-help-beanshell t]
               )
-	(list "Documentation"
-	      ["Add"             jdee-javadoc-autodoc-at-line (jdee-javadoc-enable-menu-p)]
-	      ["Remove"          jdee-javadoc-remdoc-at-line (jdee-javadoc-enable-menu-p)]
-	      ["Check This"      jdee-javadoc-checkdoc-at-line (jdee-javadoc-enable-menu-p)]
-	      ["Check All"           jdee-javadoc-checkdoc t]
-	      ["Generate All"        jdee-javadoc-make t]
-	      ["Generate Buffer"     jdee-javadoc-make-buffer t]
-	      "-"
-	      ["Javadoc Reference"     jdee-javadoc-browse-tool-doc t]
-	      "-"
-	      [ "Create HTML"    jdee-htmlize-code t]
+        (list "Interpreter"
+              ["Start"         jdee-backend-run t]
+              ["Exit"          jdee-backend-exit t]
+              "-"
+              ["Help"          jdee-help-beanshell t]
               )
-	"-"
-	(list "Code Generation"
-	      (list "Templates"
-		    ["Get/Set Pair..."  jdee-gen-get-set t]
-		    ["Println..."       jdee-gen-println t]
-		    (list "Listener"
-			  ["Action"          jdee-gen-action-listener t]
-			  ["Change"          jdee-gen-change-listener t]
-			  ["Window"          jdee-gen-window-listener t]
-			  ["Mouse"           jdee-gen-mouse-listener t]
-			  )
-		    ["Other..."        jdee-gen-code t]
-		    )
-	      (list "Import"
-		    ["Class..."                jdee-import-find-and-import t]
-		    ["All"                     jdee-import-all t]
-		    ["All Unique"              jdee-import-all-unique t]
-		    "-"
-		    ["Expand Package Imports"  jdee-import-expand-imports t]
-		    ["Collapse Class Imports"  jdee-import-collapse-imports t]
-		    ["Delete Unneeded"         jdee-import-kill-extra-imports t]
-		    ["Organize Imports"        jdee-import-organize t]
-		    ["Show Unimported Classes" jdee-import-all-show t]
-		    )
-	      (list "Wizards"
-		    ["Override Method"             jdee-wiz-override-method t]
-		    ["Implement Interface..."      jdee-wiz-implement-interface t]
-		    ["Generate Get/Set Methods"    jdee-wiz-get-set-methods t]
-		    ["Generate toString Method"    jdee-wiz-tostring t]
-		    ["Update Package Statement"    jdee-package-update t]
-		    ["Implement Event Source..."   jdee-wiz-implement-event-source t]
-		    ["Extend Abstract Class..."    jdee-wiz-extend-abstract-class t]
-		    ["Delegate Methods..."         jdee-wiz-delegate t]
-		    "-"
-		    ["Update Class List"   jdee-project-update-class-list t]
-		    )
-	      (list "Modes"
-		    (vector "Abbrev"
-			    'jdee-abbrev-mode
-			    :enable t
-			    :style 'toggle
-			    :selected 'jdee-enable-abbrev-mode)
-		    (vector "Electric Return"
-			    'jdee-electric-return-mode
-			    :enable t
-			    :style 'toggle
-			    :selected 'jdee-electric-return-mode)
+        (list "Documentation"
+              ["Add"             jdee-javadoc-autodoc-at-line (jdee-javadoc-enable-menu-p)]
+              ["Remove"          jdee-javadoc-remdoc-at-line (jdee-javadoc-enable-menu-p)]
+              ["Check This"      jdee-javadoc-checkdoc-at-line (jdee-javadoc-enable-menu-p)]
+              ["Check All"           jdee-javadoc-checkdoc t]
+              ["Generate All"        jdee-javadoc-make t]
+              ["Generate Buffer"     jdee-javadoc-make-buffer t]
+              "-"
+              ["Javadoc Reference"     jdee-javadoc-browse-tool-doc t]
+              "-"
+              [ "Create HTML"    jdee-htmlize-code t]
+              )
+        "-"
+        (list "Code Generation"
+              (list "Templates"
+                    ["Get/Set Pair..."  jdee-gen-get-set t]
+                    ["Println..."       jdee-gen-println t]
+                    (list "Listener"
+                          ["Action"          jdee-gen-action-listener t]
+                          ["Change"          jdee-gen-change-listener t]
+                          ["Window"          jdee-gen-window-listener t]
+                          ["Mouse"           jdee-gen-mouse-listener t]
+                          )
+                    ["Other..."        jdee-gen-code t]
+                    )
+              (list "Import"
+                    ["Class..."                jdee-import-find-and-import t]
+                    ["All"                     jdee-import-all t]
+                    ["All Unique"              jdee-import-all-unique t]
+                    "-"
+                    ["Expand Package Imports"  jdee-import-expand-imports t]
+                    ["Collapse Class Imports"  jdee-import-collapse-imports t]
+                    ["Delete Unneeded"         jdee-import-kill-extra-imports t]
+                    ["Organize Imports"        jdee-import-organize t]
+                    ["Show Unimported Classes" jdee-import-all-show t]
+                    )
+              (list "Wizards"
+                    ["Override Method"             jdee-wiz-override-method t]
+                    ["Implement Interface..."      jdee-wiz-implement-interface t]
+                    ["Generate Get/Set Methods"    jdee-wiz-get-set-methods t]
+                    ["Generate toString Method"    jdee-wiz-tostring t]
+                    ["Update Package Statement"    jdee-package-update t]
+                    ["Implement Event Source..."   jdee-wiz-implement-event-source t]
+                    ["Extend Abstract Class..."    jdee-wiz-extend-abstract-class t]
+                    ["Delegate Methods..."         jdee-wiz-delegate t]
+                    "-"
+                    ["Update Class List"   jdee-project-update-class-list t]
+                    )
+              (list "Modes"
+                    (vector "Abbrev"
+                            'jdee-abbrev-mode
+                            :enable t
+                            :style 'toggle
+                            :selected 'jdee-enable-abbrev-mode)
+                    (vector "Electric Return"
+                            'jdee-electric-return-mode
+                            :enable t
+                            :style 'toggle
+                            :selected 'jdee-electric-return-mode)
                     ))
-	(list "Browse"
-	      ["Source Files"          jdee-show-speedbar t]
-	      ["Class at Point"        jdee-browse-class-at-point t]
-	      ["Copy Fully Qualified Class Name"        jdee-parse-fqn-to-kill-ring t]
+        (list "Browse"
+              ["Source Files"          jdee-show-speedbar t]
+              ["Class at Point"        jdee-browse-class-at-point t]
+              ["Copy Fully Qualified Class Name"        jdee-parse-fqn-to-kill-ring t]
               ["Stack Trace Buffer"        jdee-stacktrace-buffer t]
               ["Location of Class"         jdee-archive-which t]
               )
-	["Check Style"  jdee-checkstyle]
-	(list "Project"
-	      (vector "Auto Switch"
-		      'jdee-toggle-project-switching
-		      :enable t
-		      :style 'toggle
-		      :selected 'jdee-project-context-switching-enabled-p)
-	      (list "Options"
-		    ["General"         jdee-show-project-options t]
-		    ["Compile"         jdee-compile-show-options-buffer t]
-		    ["Run"             jdee-show-run-options t]
-		    ["Debug"           jdee-show-debug-options t]
-		    ["Goto Exception"  jdee-exception-goto t]
-		    ["Autocode"        jdee-show-autocode-options t]
-		    ["Javadoc"         jdee-javadoc-customize t]
-		    ["Make"            jdee-make-show-options t]
-		    ["Ant"             jdee-ant-show-options t]
-		    ["Complete"        jdee-show-complete-options t]
-		    ["JUnit"           jdee-junit-show-options t]
-		    ["Wiz"             jdee-show-wiz-options t]
-		    )
-	      (list "Project File"
-		    ["Create New" jdee-create-new-project t]
-		    ["Save"     jdee-save-project t]
-		    ["Load"     jdee-load-project-file t]
-		    ["Load All" jdee-load-all-project-files t]
-		    ;; FIXME: need edit, show
-		    )
-	      )
-	(list "Refactor"
-	      [ "Rename Class" jdee-rename-class t]
-	      [ "Fully Qualify Class" jdee-replace-fully-qualified-class-at-point t]
-	      )
-	(list "Help"
-	      ["JDEE Users Guide"      jdee-help-show-jdee-doc t]
-	      ["JDK"                   jdee-help-browse-jdk-doc t]
-	      ["JDEE Key Bindings"     jdee-keys t]
-	      "-"
-	      ["Class..."              jdee-help-class t]
-	      ["Class Member..."       jdee-help-class-member t]
-	      ["Symbol at Point"       jdee-help-symbol t]
-	      "-"
-	      ["Submit problem report" jdee-submit-problem-report t]
-	      "-"
-	      (concat "JDEE " jdee-version)
-	      )
-	)
+        ["Check Style"  jdee-checkstyle]
+        (list "Project"
+              (vector "Auto Switch"
+                      'jdee-toggle-project-switching
+                      :enable t
+                      :style 'toggle
+                      :selected 'jdee-project-context-switching-enabled-p)
+              (list "Options"
+                    ["General"         jdee-show-project-options t]
+                    ["Compile"         jdee-compile-show-options-buffer t]
+                    ["Run"             jdee-show-run-options t]
+                    ["Debug"           jdee-show-debug-options t]
+                    ["Goto Exception"  jdee-exception-goto t]
+                    ["Autocode"        jdee-show-autocode-options t]
+                    ["Javadoc"         jdee-javadoc-customize t]
+                    ["Make"            jdee-make-show-options t]
+                    ["Ant"             jdee-ant-show-options t]
+                    ["Complete"        jdee-show-complete-options t]
+                    ["JUnit"           jdee-junit-show-options t]
+                    ["Wiz"             jdee-show-wiz-options t]
+                    )
+              (list "Project File"
+                    ["Create New" jdee-create-new-project t]
+                    ["Save"     jdee-save-project t]
+                    ["Load"     jdee-load-project-file t]
+                    ["Load All" jdee-load-all-project-files t]
+                    ;; FIXME: need edit, show
+                    )
+              )
+        (list "Refactor"
+              [ "Rename Class" jdee-rename-class t]
+              [ "Fully Qualify Class" jdee-replace-fully-qualified-class-at-point t]
+              )
+        (list "Help"
+              ["JDEE Users Guide"      jdee-help-show-jdee-doc t]
+              ["JDK"                   jdee-help-browse-jdk-doc t]
+              ["JDEE Key Bindings"     jdee-keys t]
+              "-"
+              ["Class..."              jdee-help-class t]
+              ["Class Member..."       jdee-help-class-member t]
+              ["Symbol at Point"       jdee-help-symbol t]
+              "-"
+              ["Submit problem report" jdee-submit-problem-report t]
+              "-"
+              (concat "JDEE " jdee-version)
+              )
+        )
   "The JDEE main menu."
   :group 'jdee-project
   :type 'sexp
   :set '(lambda (sym val)
-	  (set-default sym val)
+          (set-default sym val)
           ;; Define JDEE menu for FSF Emacs.
-	  (easy-menu-define jdee-menu
+          (easy-menu-define jdee-menu
             jdee-mode-map
             "Menu for JDEE."
             val)))
@@ -476,8 +476,8 @@ This command invokes the function defined by `jdee-build-function'."
   :group 'jdee-project
   :type 'sexp
   :set '(lambda (sym val)
-	  (set-default sym val)
-	  (let* ((menu (if (fboundp 'easy-menu-create-menu)
+          (set-default sym val)
+          (let* ((menu (if (fboundp 'easy-menu-create-menu)
                            (easy-menu-create-menu
                             (car val) (cdr val))))
                  (menu-name (car val)))


### PR DESCRIPTION
According to `.dir-locals.el` and commit edcc103, `indent-tab-mode`
should be `nil` when developing for this project, which means there
shouldn't be any tab in the source code.  But for old code, this was
not true.  Untabify those files to make it true.

Simplify `.dir-locals.el` to make it more human readable.  And add
`(lisp-indent-function . lisp-indent-function)` to it.  However, you
may also need to add this to your `safe-local-variable-values`.  This
is definitely safe, since this is actually the default value for
Emacs.  Many Lisp programmers like to set the indent function to
something else like `common-lisp-indent-function`.  This way, they
don't have to change this variable back and forth when switching
projects and it's likely for this project to get a consistent
indentation.